### PR TITLE
Add React TypeScript demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # Codex-test
 A temporary repo for testing codex
+
+## React + TypeScript Demo
+
+The `react-demo` directory contains a minimal React application written in TypeScript and configured with [Vite](https://vitejs.dev/).
+
+### Getting Started
+
+Install dependencies and run the development server:
+
+```bash
+cd react-demo
+npm install
+npm run dev
+```
+
+Then open `http://localhost:5173` in your browser to see the app.

--- a/react-demo/index.html
+++ b/react-demo/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>React TypeScript Demo</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "react-ts-demo",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.10",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/react-demo/src/App.tsx
+++ b/react-demo/src/App.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const App: React.FC = () => {
+  const [count, setCount] = React.useState(0);
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center', marginTop: '2rem' }}>
+      <h1>Hello, React + TypeScript!</h1>
+      <p>You clicked {count} times.</p>
+      <button onClick={() => setCount(count + 1)}>Click me</button>
+    </div>
+  );
+};
+
+export default App;

--- a/react-demo/src/main.tsx
+++ b/react-demo/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const rootElement = document.getElementById('root') as HTMLElement;
+const root = ReactDOM.createRoot(rootElement);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/react-demo/tsconfig.json
+++ b/react-demo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/react-demo/vite.config.ts
+++ b/react-demo/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- create a simple React + TypeScript demo under `react-demo`
- document how to run the demo in the README

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_683f85ebdcdc8324bf4d26d362df7205