### PR TITLE
Replace deep clone with structuredClone helper

### DIFF
--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { GameStateStack, FullGameState, AIMapUpdatePayload, Item, Character, MapData, ThemeHistoryState } from '../types';
+import { structuredCloneGameState } from '../utils/cloneUtils';
 import { DebugPacket } from '../hooks/useGameLogic';
 
 interface DebugViewProps {
@@ -31,7 +32,7 @@ const DebugView: React.FC<DebugViewProps> = ({ isVisible, onClose, debugPacket, 
       displayContent = content;
     } else if (isJson) {
       try {
-        let contentForDisplay: any = JSON.parse(JSON.stringify(content));
+        let contentForDisplay: any = structuredCloneGameState(content);
         
         if (title.startsWith("Current Game State") || title.startsWith("Previous Game State")) {
             if ('lastDebugPacket' in contentForDisplay) delete contentForDisplay.lastDebugPacket;

--- a/hooks/useDialogueFlow.ts
+++ b/hooks/useDialogueFlow.ts
@@ -28,6 +28,7 @@ import {
 } from '../services/dialogueService';
 import { MAX_LOG_MESSAGES, MAX_DIALOGUE_SUMMARIES_PER_CHARACTER } from '../constants';
 import { addLogMessageToList } from '../utils/gameLogicUtils';
+import { structuredCloneGameState } from '../utils/cloneUtils';
 
 const DIALOGUE_EXIT_READ_DELAY_MS = 5000;
 
@@ -84,7 +85,7 @@ export const useDialogueFlow = (props: UseDialogueFlowProps) => {
     setDialogueUiCloseDelayTargetMs(Date.now() + DIALOGUE_EXIT_READ_DELAY_MS);
     setError(null);
 
-    let workingGameState = JSON.parse(JSON.stringify(stateAtDialogueConclusionStart)) as FullGameState;
+    let workingGameState = structuredCloneGameState(stateAtDialogueConclusionStart);
 
     setLoadingReason('dialogue_memory_creation');
     const memorySummaryContext: DialogueMemorySummaryContext = {

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -65,6 +65,7 @@ import {
 } from '../utils/mapLayoutUtils';
 import { selectBestMatchingMapNode, attemptMatchAndSetNode } from '../utils/mapNodeMatcher';
 import { handleMapUpdates } from '../utils/mapUpdateHandlers';
+import { structuredCloneGameState } from '../utils/cloneUtils';
 
 
 const OBJECTIVE_ANIMATION_DURATION = 5000;
@@ -356,7 +357,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     setParseErrorCounter(0);
     setFreeFormActionText("");
 
-    const baseStateSnapshot = JSON.parse(JSON.stringify(currentFullState)) as FullGameState;
+    const baseStateSnapshot = structuredCloneGameState(currentFullState);
     let scoreChangeFromAction = isFreeForm ? -FREE_FORM_ACTION_COST : 0;
 
     const currentThemeObj = currentFullState.currentThemeObject; 
@@ -380,7 +381,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
         playerGenderProp, currentFullState.themeHistory, currentMapNodeDetails, currentFullState.mapData
     );
 
-    let draftState = JSON.parse(JSON.stringify(currentFullState)) as FullGameState;
+    let draftState = structuredCloneGameState(currentFullState);
     draftState.lastDebugPacket = { prompt, rawResponseText: null, parsedResponse: null, timestamp: new Date().toISOString() };
     if (isFreeForm) draftState.score -= FREE_FORM_ACTION_COST;
 
@@ -543,7 +544,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
       draftState.inventory = [];
     }
 
-    const baseStateSnapshotForInitialTurn = JSON.parse(JSON.stringify(draftState)) as FullGameState;
+    const baseStateSnapshotForInitialTurn = structuredCloneGameState(draftState);
     let prompt = "";
     if (isTransitioningFromShift && draftState.themeHistory[themeObjToLoad.name]) {
       const currentThemeMainMapNodes = draftState.mapData.nodes.filter(n => n.themeName === themeObjToLoad.name && !n.data.isLeaf);
@@ -671,7 +672,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     const itemToDiscard = currentFullState.inventory.find(item => item.name === itemName);
     if (!itemToDiscard || !itemToDiscard.isJunk) return;
 
-    let draftState = JSON.parse(JSON.stringify(currentFullState)) as FullGameState;
+    let draftState = structuredCloneGameState(currentFullState);
     draftState.inventory = draftState.inventory.filter(item => item.name !== itemName);
     const itemChangeRecord: ItemChangeRecord = { type: 'loss', lostItem: { ...itemToDiscard } };
     const turnChangesForDiscard: TurnChanges = {
@@ -735,12 +736,12 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     setIsLoading,
     setLoadingReason,
     onDialogueConcluded: (summaryPayload, preparedGameState) => {
-      let draftState = JSON.parse(JSON.stringify(preparedGameState)) as FullGameState;
+      let draftState = structuredCloneGameState(preparedGameState);
       processAiResponse(
         summaryPayload,
         preparedGameState.currentThemeObject, 
         draftState,
-        { baseStateSnapshot: JSON.parse(JSON.stringify(preparedGameState)) as FullGameState, isFromDialogueSummary: true }
+        { baseStateSnapshot: structuredCloneGameState(preparedGameState), isFromDialogueSummary: true }
       ).then(() => {
         commitGameState(draftState);
         setIsLoading(false); setLoadingReason(null);

--- a/services/mapCorrectionService.ts
+++ b/services/mapCorrectionService.ts
@@ -12,6 +12,7 @@ import { MAP_CHAIN_CORRECTION_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
 import { ai as geminiAIInstance } from './geminiClient';
 import { VALID_NODE_STATUS_VALUES, VALID_EDGE_TYPE_VALUES, VALID_EDGE_STATUS_VALUES } from '../utils/mapUpdateValidationUtils';
 import { pruneAndRefineMapConnections } from '../utils/mapPruningUtils'; // Import pruning utility
+import { structuredCloneGameState } from '../utils/cloneUtils';
 
 
 /**
@@ -263,7 +264,7 @@ function applyChainRefinementPayloadToMapData(
   chains: MapChainToRefine[],
   refinementPayload: AIMapUpdatePayload
 ): { updatedMapData: MapData; changesMade: boolean } {
-  const workingMapData: MapData = JSON.parse(JSON.stringify(currentMapData));
+  const workingMapData: MapData = structuredCloneGameState(currentMapData);
   let changesMadeOverall = false;
 
   chains.forEach(chain => {

--- a/services/mapUpdateService.ts
+++ b/services/mapUpdateService.ts
@@ -11,6 +11,7 @@ import { MAP_UPDATE_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
 import { ai } from './geminiClient';
 import { formatKnownPlacesForPrompt } from '../utils/promptFormatters';
 import { isValidAIMapUpdatePayload } from '../utils/mapUpdateValidationUtils';
+import { structuredCloneGameState } from '../utils/cloneUtils';
 
 // Local type definition for Place, matching what useGameLogic might prepare
 interface Place {
@@ -184,7 +185,7 @@ Key points:
   }
 
   // Proceed with map data processing using validParsedPayload
-  const newMapData: MapData = JSON.parse(JSON.stringify(currentMapData));
+  const newMapData: MapData = structuredCloneGameState(currentMapData);
   const newNodesInBatchIdNameMap: Record<string, { id: string; name: string }> = {};
 
   // Annihilation Step (remains the same)

--- a/utils/cloneUtils.ts
+++ b/utils/cloneUtils.ts
@@ -1,0 +1,48 @@
+/**
+ * @file cloneUtils.ts
+ * @description Utility for deep cloning game state objects using `structuredClone`
+ *              when available, with a fallback custom deep copy implementation.
+ */
+
+/**
+ * Performs a deep clone of the provided object.
+ * Uses the built-in `structuredClone` if available; otherwise falls back to a
+ * recursive cloning function.
+ *
+ * @param state - The object to clone.
+ * @returns A deep copy of the input object.
+ */
+export function structuredCloneGameState<T>(state: T): T {
+  if (typeof (globalThis as any).structuredClone === 'function') {
+    return (globalThis as any).structuredClone(state);
+  }
+  return deepCopy(state);
+}
+
+/**
+ * Recursively clones a value. Handles arrays, plain objects and Date instances.
+ *
+ * @param value - The value to clone.
+ * @returns A deeply cloned copy of `value`.
+ */
+function deepCopy<T>(value: T): T {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as any;
+  }
+
+  if (Array.isArray(value)) {
+    return (value.map(v => deepCopy(v)) as unknown) as T;
+  }
+
+  const clonedObj: Record<string, any> = {};
+  for (const key in value as Record<string, any>) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      clonedObj[key] = deepCopy((value as Record<string, any>)[key]);
+    }
+  }
+  return clonedObj as T;
+}

--- a/utils/mapLayoutUtils.ts
+++ b/utils/mapLayoutUtils.ts
@@ -1,5 +1,11 @@
 
+/**
+ * @file mapLayoutUtils.ts
+ * @description Utilities for performing force-directed layout of game maps.
+ */
+
 import { MapNode, MapEdge } from '../types';
+import { structuredCloneGameState } from './cloneUtils';
 
 export const DEFAULT_K_REPULSION = 20000; 
 export const DEFAULT_K_SPRING = 0.25;     
@@ -145,7 +151,7 @@ export const applyBasicLayoutAlgorithm = (
 ): MapNode[] => {
   if (initialNodes.length === 0) return [];
 
-  let nodes = JSON.parse(JSON.stringify(initialNodes)) as MapNode[];
+  let nodes = structuredCloneGameState(initialNodes);
   const nodeMap = new Map(nodes.map(node => [node.id, node]));
 
   const {

--- a/utils/mapPruningUtils.ts
+++ b/utils/mapPruningUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import { MapData, MapNode, MapEdge, MapChainToRefine, MapChainLeafInfo } from '../types';
+import { structuredCloneGameState } from './cloneUtils';
 
 /**
  * Generates a unique ID string.
@@ -34,7 +35,7 @@ export const pruneAndRefineMapConnections = (
   originalMapData: MapData,
   currentThemeName: string
 ): { updatedMapData: MapData; chainsToRefine: MapChainToRefine[] } => {
-  const workingMapData: MapData = JSON.parse(JSON.stringify(originalMapData));
+  const workingMapData: MapData = structuredCloneGameState(originalMapData);
   const chainsToRefine: MapChainToRefine[] = [];
   const edgesToRemoveIds = new Set<string>();
 


### PR DESCRIPTION
## Summary
- add `structuredCloneGameState` utility for deep cloning
- replace JSON clone calls across the app
- use helper in DebugView, game hooks, map utilities, and services

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684040b9d6c08324a24aeab24ea33819