### PR TITLE
Refactor save utilities

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,12 +29,12 @@ import CustomGameSetupScreen from './components/CustomGameSetupScreen';
 
 import {
   saveGameStateToFile,
-  loadGameStateFromFile,
+  loadGameStateFromFile
+} from "./services/saveLoadService";
+import {
   saveGameStateToLocalStorage,
   loadGameStateFromLocalStorage
-} from './services/saveLoadService';
-import { DEFAULT_PLAYER_GENDER, DEVELOPER, DEFAULT_ENABLED_THEME_PACKS, DEFAULT_STABILITY_LEVEL, DEFAULT_CHAOS_LEVEL, CURRENT_SAVE_GAME_VERSION, FREE_FORM_ACTION_COST, FREE_FORM_ACTION_MAX_LENGTH } from './constants';
-import { getThemesFromPacks, ALL_THEME_PACK_NAMES } from './themes'; 
+} from "./services/storage";
 
 
 const AUTOSAVE_DEBOUNCE_TIME = 1500;

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -13,7 +13,7 @@ import { executeAIMainTurn } from '../services/gameAIService';
 import { parseAIResponse } from '../services/aiResponseParser';
 import { getThemesFromPacks } from '../themes';
 import { CURRENT_SAVE_GAME_VERSION } from '../constants';
-import { findThemeByName } from '../services/saveLoadService';
+import { findThemeByName } from '../services/themeUtils';
 import {
   formatNewGameFirstTurnPrompt,
   formatNewThemePostShiftPrompt,

--- a/services/saveConverters/index.ts
+++ b/services/saveConverters/index.ts
@@ -1,0 +1,434 @@
+/**
+ * @file services/saveConverters/index.ts
+ * @description Conversion utilities for migrating saved game data between versions.
+ */
+
+import {
+  FullGameState,
+  SavedGameDataShape,
+  Item,
+  ThemeHistoryState,
+  AdventureTheme,
+  Character,
+  ItemType,
+  ThemePackName,
+  KnownUse as V2KnownUse,
+  MapData,
+  MapNode,
+  MapEdge,
+  MapLayoutConfig,
+  MapNodeData,
+  DialogueSummaryRecord
+} from '../../types';
+import {
+  CURRENT_SAVE_GAME_VERSION,
+  DEFAULT_STABILITY_LEVEL,
+  DEFAULT_CHAOS_LEVEL,
+  VALID_ITEM_TYPES,
+  DEFAULT_ENABLED_THEME_PACKS,
+  DEFAULT_PLAYER_GENDER
+} from '../../constants';
+import { fetchCorrectedCharacterDetails_Service, fetchCorrectedLocalPlace_Service } from '../correctionService';
+import {
+  DEFAULT_K_REPULSION,
+  DEFAULT_K_SPRING,
+  DEFAULT_IDEAL_EDGE_LENGTH,
+  DEFAULT_K_CENTERING,
+  DEFAULT_K_UNTANGLE,
+  DEFAULT_K_EDGE_NODE_REPULSION,
+  DEFAULT_DAMPING_FACTOR,
+  DEFAULT_MAX_DISPLACEMENT,
+  DEFAULT_LAYOUT_ITERATIONS,
+} from '../../utils/mapLayoutUtils';
+import { findThemeByName } from '../themeUtils';
+
+/** V1 KnownUse structure for conversion. */
+export interface V1KnownUse {
+  actionName: string;
+  promptEffect: string;
+  description?: string;
+}
+
+/** V1 Item structure for conversion. */
+export interface V1Item {
+  name: string;
+  type: string;
+  description: string;
+  isActive?: boolean;
+  isJunk?: boolean;
+  knownUses?: V1KnownUse[];
+}
+
+/** V1 Place representation for conversion. */
+export interface V1Place {
+  themeName: string;
+  name: string;
+  description: string;
+  aliases?: string[];
+}
+
+/** V1 Character representation for conversion. */
+export interface V1Character {
+  themeName: string;
+  name: string;
+  description: string;
+  aliases?: string[];
+}
+
+/** V1 theme memory structure. */
+export interface V1ThemeMemory {
+  summary: string;
+  overarchingQuest: string;
+  currentObjective: string;
+  placeNames: string[];
+  characterNames: string[];
+}
+
+/** Map of theme memories in V1 saves. */
+export interface V1ThemeHistoryState {
+  [themeName: string]: V1ThemeMemory;
+}
+
+/** Top level V1 save shape. */
+export interface V1SavedGameState {
+  saveGameVersion: '1.0.0';
+  currentThemeName: string | null;
+  currentScene: string;
+  actionOptions: string[];
+  overarchingQuest: string | null;
+  currentObjective: string | null;
+  inventory: V1Item[];
+  gameLog: string[];
+  lastActionLog: string | null;
+  themeHistory: V1ThemeHistoryState;
+  pendingNewThemeNameAfterShift: string | null;
+  allPlaces: V1Place[];
+  allCharacters: V1Character[];
+  score: number;
+  stabilityLevel: number;
+  chaosLevel: number;
+  enabledThemePacks: ThemePackName[];
+  playerGender: string;
+  localTime: string | null;
+  localEnvironment: string | null;
+  localPlace: string | null;
+}
+
+/** Intermediate V2 structure produced when converting from V1. */
+export interface V2IntermediateSavedGameState {
+  saveGameVersion: '2';
+  currentThemeName: string | null;
+  currentThemeObject: AdventureTheme | null;
+  currentScene: string;
+  actionOptions: string[];
+  mainQuest: string | null;
+  currentObjective: string | null;
+  inventory: Item[];
+  gameLog: string[];
+  lastActionLog: string | null;
+  themeHistory: ThemeHistoryState;
+  pendingNewThemeNameAfterShift: string | null;
+  allCharacters: Character[];
+  score: number;
+  localTime: string | null;
+  localEnvironment: string | null;
+  localPlace: string | null;
+  turnsSinceLastShift: number;
+  globalTurnNumber: number;
+  playerGender: string;
+  enabledThemePacks: ThemePackName[];
+  stabilityLevel: number;
+  chaosLevel: number;
+  mapData: MapData;
+  currentMapNodeId: string | null;
+  mapLayoutConfig: MapLayoutConfig;
+  isCustomGameMode: boolean;
+}
+
+/** Returns default map layout configuration. */
+export const getDefaultMapLayoutConfig = (): MapLayoutConfig => ({
+  K_REPULSION: DEFAULT_K_REPULSION,
+  K_SPRING: DEFAULT_K_SPRING,
+  IDEAL_EDGE_LENGTH: DEFAULT_IDEAL_EDGE_LENGTH,
+  K_CENTERING: DEFAULT_K_CENTERING,
+  K_UNTANGLE: DEFAULT_K_UNTANGLE,
+  K_EDGE_NODE_REPULSION: DEFAULT_K_EDGE_NODE_REPULSION,
+  DAMPING_FACTOR: DEFAULT_DAMPING_FACTOR,
+  MAX_DISPLACEMENT: DEFAULT_MAX_DISPLACEMENT,
+  iterations: DEFAULT_LAYOUT_ITERATIONS,
+});
+
+/**
+ * Converts a V1 save into an intermediate V2 structure.
+ * @param v1Data Data parsed from an old V1 save file.
+ */
+export async function convertV1toV2Intermediate(v1Data: V1SavedGameState): Promise<V2IntermediateSavedGameState> {
+  const v2Inventory: Item[] = v1Data.inventory.map((v1Item: V1Item) => ({
+    name: v1Item.name,
+    type: v1Item.type as ItemType,
+    description: v1Item.description,
+    activeDescription: undefined,
+    isActive: v1Item.isActive ?? false,
+    knownUses: (v1Item.knownUses || []).map((ku: V1KnownUse) => ({
+      ...ku,
+      appliesWhenActive: undefined,
+      appliesWhenInactive: undefined,
+    } as V2KnownUse)),
+    isJunk: v1Item.isJunk ?? false,
+  }));
+
+  const v2ThemeHistory: ThemeHistoryState = {};
+  for (const themeName in v1Data.themeHistory) {
+    if (Object.prototype.hasOwnProperty.call(v1Data.themeHistory, themeName)) {
+      const v1Memory = v1Data.themeHistory[themeName];
+      v2ThemeHistory[themeName] = {
+        summary: v1Memory.summary,
+        mainQuest: v1Memory.overarchingQuest,
+        currentObjective: v1Memory.currentObjective,
+        placeNames: v1Memory.placeNames,
+        characterNames: v1Memory.characterNames,
+      };
+    }
+  }
+
+  const v1ConvertedMapNodes: MapNode[] = v1Data.allPlaces.map((v1Place, index) => {
+    const baseNameForId = v1Place.name.replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
+    const nodeId = `${v1Place.themeName}_${baseNameForId}_v1main_${index}`;
+    return {
+      id: nodeId,
+      themeName: v1Place.themeName,
+      placeName: v1Place.name,
+      position: { x: Math.random() * 200 - 100, y: Math.random() * 200 - 100 },
+      data: {
+        description: v1Place.description || 'Description missing from V1 save',
+        aliases: v1Place.aliases || [],
+        status: 'discovered',
+        isLeaf: false,
+        visited: true,
+      },
+    };
+  });
+
+  const v1MapData: MapData = { nodes: v1ConvertedMapNodes, edges: [] };
+
+  let v2LocalPlace = v1Data.localPlace;
+  const currentThemeObjFromV1 = findThemeByName(v1Data.currentThemeName);
+  if ((!v2LocalPlace || v2LocalPlace === 'Unknown' || v2LocalPlace === 'Undetermined Location') && currentThemeObjFromV1 && v1Data.currentScene) {
+    try {
+      const inferredPlace = await fetchCorrectedLocalPlace_Service(
+        v1Data.currentScene,
+        currentThemeObjFromV1,
+        v1ConvertedMapNodes,
+        v1Data.localTime,
+        v1Data.localEnvironment
+      );
+      if (inferredPlace) v2LocalPlace = inferredPlace;
+    } catch (e) { console.error('V1 conversion: Error inferring localPlace:', e); }
+  }
+
+  const v2AllCharactersPromises = v1Data.allCharacters.map(async (v1Char: V1Character) => {
+    let charThemeObj = findThemeByName(v1Char.themeName);
+    let presenceStatus: Character['presenceStatus'] = 'unknown';
+    let lastKnownLocation: string | null = null;
+    let preciseLocation: string | null = null;
+
+    if (charThemeObj && process.env.API_KEY) {
+      const relevantMapNodesForCharThemeContext = v1ConvertedMapNodes.filter(node => node.themeName === charThemeObj!.name);
+      const sceneContextForChar = (v1Data.currentThemeName === v1Char.themeName) ? v1Data.currentScene : undefined;
+      const logContextForChar = (v1Data.currentThemeName === v1Char.themeName) ? v1Data.lastActionLog : undefined;
+      try {
+        const correctedDetails = await fetchCorrectedCharacterDetails_Service(
+          v1Char.name,
+          logContextForChar || undefined,
+          sceneContextForChar || undefined,
+          charThemeObj,
+          relevantMapNodesForCharThemeContext
+        );
+        if (correctedDetails) {
+          presenceStatus = correctedDetails.presenceStatus;
+          lastKnownLocation = correctedDetails.lastKnownLocation;
+          preciseLocation = correctedDetails.preciseLocation;
+        }
+      } catch (e) { console.error(`V1 conversion: Error inferring details for ${v1Char.name}:`, e); }
+    }
+    return {
+      themeName: v1Char.themeName,
+      name: v1Char.name,
+      description: v1Char.description,
+      aliases: v1Char.aliases || [],
+      presenceStatus,
+      lastKnownLocation,
+      preciseLocation,
+      dialogueSummaries: [],
+    };
+  });
+  const v2AllCharacters: Character[] = await Promise.all(v2AllCharactersPromises);
+
+  return {
+    saveGameVersion: '2',
+    currentThemeName: v1Data.currentThemeName,
+    currentThemeObject: currentThemeObjFromV1,
+    currentScene: v1Data.currentScene,
+    actionOptions: v1Data.actionOptions,
+    mainQuest: v1Data.overarchingQuest,
+    currentObjective: v1Data.currentObjective,
+    inventory: v2Inventory,
+    gameLog: v1Data.gameLog,
+    lastActionLog: v1Data.lastActionLog,
+    themeHistory: v2ThemeHistory,
+    pendingNewThemeNameAfterShift: v1Data.pendingNewThemeNameAfterShift,
+    allCharacters: v2AllCharacters,
+    score: v1Data.score,
+    localTime: v1Data.localTime,
+    localEnvironment: v1Data.localEnvironment,
+    localPlace: v2LocalPlace || 'Undetermined Location',
+    turnsSinceLastShift: 0,
+    globalTurnNumber: 0,
+    playerGender: v1Data.playerGender || DEFAULT_PLAYER_GENDER,
+    enabledThemePacks: v1Data.enabledThemePacks || [...DEFAULT_ENABLED_THEME_PACKS],
+    stabilityLevel: v1Data.stabilityLevel ?? DEFAULT_STABILITY_LEVEL,
+    chaosLevel: v1Data.chaosLevel ?? DEFAULT_CHAOS_LEVEL,
+    mapData: v1MapData,
+    currentMapNodeId: null,
+    mapLayoutConfig: getDefaultMapLayoutConfig(),
+    isCustomGameMode: false,
+  };
+}
+
+/**
+ * Converts a V2 intermediate save into the current save shape.
+ * @param v2Data Data produced by the V1 to V2 converter or loaded from a V2 save.
+ */
+export function convertV2toV3Shape(v2Data: V2IntermediateSavedGameState): SavedGameDataShape {
+  const { ...v3RelevantData } = v2Data;
+
+  let finalMapData: MapData;
+  if (v2Data.mapData && Array.isArray(v2Data.mapData.nodes) && Array.isArray(v2Data.mapData.edges)) {
+    finalMapData = {
+      nodes: v2Data.mapData.nodes.map(node => ({
+        ...node,
+        data: {
+          description: node.data.description || 'Description missing from V2 save',
+          aliases: node.data.aliases || [],
+          status: node.data.status || 'discovered',
+          isLeaf: node.data.isLeaf ?? false,
+          visited: node.data.visited ?? false,
+          parentNodeId: node.data.parentNodeId,
+          ...Object.fromEntries(Object.entries(node.data).filter(([key]) => !['description', 'aliases', 'status', 'isLeaf', 'visited', 'parentNodeId'].includes(key)))
+        }
+      })),
+      edges: v2Data.mapData.edges,
+    };
+  } else {
+    finalMapData = { nodes: [], edges: [] };
+  }
+
+  let finalMapLayoutConfig: MapLayoutConfig;
+  if (v2Data.mapLayoutConfig && isValidMapLayoutConfig(v2Data.mapLayoutConfig)) {
+    finalMapLayoutConfig = v2Data.mapLayoutConfig;
+  } else {
+    const defaultConfig = getDefaultMapLayoutConfig();
+    if (v2Data.mapLayoutConfig && typeof v2Data.mapLayoutConfig === 'object') {
+      const loadedConfig = v2Data.mapLayoutConfig;
+      const patchedConfig: Partial<MapLayoutConfig> = {};
+      for (const key of Object.keys(defaultConfig) as Array<keyof MapLayoutConfig>) {
+        if (Object.prototype.hasOwnProperty.call(loadedConfig, key) && typeof (loadedConfig as any)[key] === 'number') {
+          patchedConfig[key] = (loadedConfig as any)[key];
+        } else {
+          patchedConfig[key] = defaultConfig[key];
+        }
+      }
+      finalMapLayoutConfig = patchedConfig as MapLayoutConfig;
+    } else {
+      finalMapLayoutConfig = defaultConfig;
+    }
+  }
+
+  const finalCurrentMapNodeId = v2Data.currentMapNodeId === undefined ? null : v2Data.currentMapNodeId;
+
+  const finalAllCharacters = v2Data.allCharacters.map(char => ({
+    ...char,
+    dialogueSummaries: char.dialogueSummaries || [],
+  }));
+
+  const finalCurrentThemeObject = v2Data.currentThemeObject || findThemeByName(v2Data.currentThemeName);
+
+  return {
+    ...v3RelevantData,
+    currentThemeObject: finalCurrentThemeObject,
+    allCharacters: finalAllCharacters,
+    saveGameVersion: CURRENT_SAVE_GAME_VERSION,
+    mapData: finalMapData,
+    currentMapNodeId: finalCurrentMapNodeId,
+    mapLayoutConfig: finalMapLayoutConfig,
+    isCustomGameMode: v2Data.isCustomGameMode ?? false,
+    globalTurnNumber: v2Data.globalTurnNumber ?? 0,
+  };
+}
+
+/** Validates dialogue summary records used during conversion. */
+function isValidDialogueSummaryRecord(record: any): record is DialogueSummaryRecord {
+  return record &&
+    typeof record.summaryText === 'string' &&
+    Array.isArray(record.participants) && record.participants.every((p: any) => typeof p === 'string') &&
+    typeof record.timestamp === 'string' &&
+    typeof record.location === 'string';
+}
+
+/** Validates items when converting older saves. */
+function isValidItemForSave(item: any): item is Item {
+  return item &&
+    typeof item.name === 'string' &&
+    typeof item.type === 'string' && (VALID_ITEM_TYPES as readonly string[]).includes(item.type) &&
+    typeof item.description === 'string' &&
+    (item.activeDescription === undefined || typeof item.activeDescription === 'string') &&
+    (item.isActive === undefined || typeof item.isActive === 'boolean') &&
+    (item.isJunk === undefined || typeof item.isJunk === 'boolean') &&
+    (item.knownUses === undefined || (Array.isArray(item.knownUses) && item.knownUses.every((ku: V2KnownUse) =>
+      ku && typeof ku.actionName === 'string' && typeof ku.promptEffect === 'string' &&
+      (ku.description === undefined || typeof ku.description === 'string') &&
+      (ku.appliesWhenActive === undefined || typeof ku.appliesWhenActive === 'boolean') &&
+      (ku.appliesWhenInactive === undefined || typeof ku.appliesWhenInactive === 'boolean')
+    )));
+}
+
+/** Validates the theme history object during conversion. */
+function isValidThemeHistory(history: any): history is ThemeHistoryState {
+  if (typeof history !== 'object' || history === null) return false;
+  for (const key in history) {
+    if (Object.prototype.hasOwnProperty.call(history, key)) {
+      const entry = history[key];
+      if (!entry || typeof entry.summary !== 'string' || typeof entry.mainQuest !== 'string' ||
+        typeof entry.currentObjective !== 'string' ||
+        !Array.isArray(entry.placeNames) || !entry.placeNames.every((name: any) => typeof name === 'string') ||
+        !Array.isArray(entry.characterNames) || !entry.characterNames.every((name: any) => typeof name === 'string')
+      ) return false;
+    }
+  }
+  return true;
+}
+
+/** Validates a character record for the current save format. */
+function isValidCharacterForSave(character: any): character is Character {
+  return character && typeof character.themeName === 'string' && typeof character.name === 'string' && character.name.trim() !== '' &&
+    typeof character.description === 'string' && character.description.trim() !== '' &&
+    (character.aliases === undefined || (Array.isArray(character.aliases) && character.aliases.every((alias: any) => typeof alias === 'string'))) &&
+    (character.presenceStatus === undefined || ['distant', 'nearby', 'companion', 'unknown'].includes(character.presenceStatus)) &&
+    (character.lastKnownLocation === undefined || character.lastKnownLocation === null || typeof character.lastKnownLocation === 'string') &&
+    (character.preciseLocation === undefined || character.preciseLocation === null || typeof character.preciseLocation === 'string') &&
+    (character.dialogueSummaries === undefined || (Array.isArray(character.dialogueSummaries) && character.dialogueSummaries.every(isValidDialogueSummaryRecord)));
+}
+
+
+/** Validates a map layout configuration during conversion. */
+function isValidMapLayoutConfig(config: any): config is MapLayoutConfig {
+  if (!config || typeof config !== 'object') return false;
+  const defaultConfigKeys = Object.keys(getDefaultMapLayoutConfig()) as Array<keyof MapLayoutConfig>;
+  for (const key of defaultConfigKeys) {
+    if (typeof config[key] !== 'number') {
+      console.warn(`isValidMapLayoutConfig: Key '${key}' is missing or not a number. Value: ${config[key]}`);
+      return false;
+    }
+  }
+  return true;
+}

--- a/services/saveLoadService.ts
+++ b/services/saveLoadService.ts
@@ -4,8 +4,8 @@
  * @description Functions for saving and loading game state across versions.
  */
 import { FullGameState, SavedGameDataShape, Item, ThemeHistoryState, AdventureTheme, Character, ItemType, ThemePackName, KnownUse as V2KnownUse, DialogueHistoryEntry, DialogueData, MapData, MapNode, MapEdge, MapLayoutConfig, MapNodeData, DialogueSummaryRecord } from '../types';
-import { CURRENT_SAVE_GAME_VERSION, LOCAL_STORAGE_SAVE_KEY, DEFAULT_STABILITY_LEVEL, DEFAULT_CHAOS_LEVEL, VALID_ITEM_TYPES, DEFAULT_ENABLED_THEME_PACKS, DEFAULT_PLAYER_GENDER } from '../constants';
-import { THEME_PACKS, ALL_THEME_PACK_NAMES } from '../themes';
+import { CURRENT_SAVE_GAME_VERSION, DEFAULT_STABILITY_LEVEL, DEFAULT_CHAOS_LEVEL, VALID_ITEM_TYPES, DEFAULT_ENABLED_THEME_PACKS, DEFAULT_PLAYER_GENDER } from '../constants';
+import { ALL_THEME_PACK_NAMES } from '../themes';
 import { fetchCorrectedCharacterDetails_Service, fetchCorrectedLocalPlace_Service } from './correctionService';
 import {
     DEFAULT_K_REPULSION, DEFAULT_K_SPRING, DEFAULT_IDEAL_EDGE_LENGTH,
@@ -14,329 +14,8 @@ import {
 } from '../utils/mapLayoutUtils';
 import { formatKnownPlacesForPrompt } from '../utils/promptFormatters';
 
-// --- V1 Save Game Interfaces (for conversion) ---
-interface V1KnownUse {
-  actionName: string;
-  promptEffect: string;
-  description?: string;
-}
-
-interface V1Item {
-  name: string;
-  type: string;
-  description: string;
-  isActive?: boolean;
-  isJunk?: boolean;
-  knownUses?: V1KnownUse[];
-}
-
-interface V1Place { // This interface represents the old Place structure for V1
-  themeName: string;
-  name: string;
-  description: string;
-  aliases?: string[];
-}
-
-interface V1Character {
-  themeName: string;
-  name: string;
-  description: string;
-  aliases?: string[];
-}
-
-interface V1ThemeMemory {
-  summary: string;
-  overarchingQuest: string;
-  currentObjective: string;
-  placeNames: string[];
-  characterNames: string[];
-}
-
-interface V1ThemeHistoryState {
-  [themeName: string]: V1ThemeMemory;
-}
-
-interface V1SavedGameState {
-  saveGameVersion: "1.0.0";
-  currentThemeName: string | null;
-  currentScene: string;
-  actionOptions: string[];
-  overarchingQuest: string | null;
-  currentObjective: string | null;
-  inventory: V1Item[];
-  gameLog: string[];
-  lastActionLog: string | null;
-  themeHistory: V1ThemeHistoryState;
-  // isPostRealityShiftDisorientation: boolean; // Removed for V3
-  pendingNewThemeNameAfterShift: string | null;
-  allPlaces: V1Place[];
-  allCharacters: V1Character[];
-  score: number;
-  stabilityLevel: number;
-  chaosLevel: number;
-  enabledThemePacks: ThemePackName[];
-  playerGender: string;
-  localTime: string | null;
-  localEnvironment: string | null;
-  localPlace: string | null;
-}
-
-// V2-like structure that convertV1toV2 outputs.
-interface V2IntermediateSavedGameState {
-  saveGameVersion: "2"; // Target version after V1 conversion step
-  currentThemeName: string | null;
-  currentThemeObject: AdventureTheme | null; // Added
-  currentScene: string;
-  actionOptions: string[];
-  mainQuest: string | null;
-  currentObjective: string | null;
-  inventory: Item[];
-  gameLog: string[];
-  lastActionLog: string | null;
-  themeHistory: ThemeHistoryState;
-  // isPostRealityShiftDisorientation: boolean; // Removed for V3
-  pendingNewThemeNameAfterShift: string | null;
-  allCharacters: Character[]; // V2 Characters do not have dialogueSummaries yet
-  score: number;
-  localTime: string | null;
-  localEnvironment: string | null;
-  localPlace: string | null;
-  turnsSinceLastShift: number;
-  globalTurnNumber: number; // Added for V3, initialize in conversion
-  playerGender: string;
-  enabledThemePacks: ThemePackName[];
-  stabilityLevel: number;
-  chaosLevel: number;
-  mapData: MapData; // Introduced in this intermediate step
-  currentMapNodeId: string | null;
-  mapLayoutConfig: MapLayoutConfig;
-  isCustomGameMode: boolean; // Added for V3, initialize as false for V2
-  // dialogueState?: DialogueData | null; // V2 might not have had this formalized
-}
-
-const getDefaultMapLayoutConfig = (): MapLayoutConfig => ({
-    K_REPULSION: DEFAULT_K_REPULSION,
-    K_SPRING: DEFAULT_K_SPRING,
-    IDEAL_EDGE_LENGTH: DEFAULT_IDEAL_EDGE_LENGTH,
-    K_CENTERING: DEFAULT_K_CENTERING,
-    K_UNTANGLE: DEFAULT_K_UNTANGLE,
-    K_EDGE_NODE_REPULSION: DEFAULT_K_EDGE_NODE_REPULSION, // Added
-    DAMPING_FACTOR: DEFAULT_DAMPING_FACTOR,
-    MAX_DISPLACEMENT: DEFAULT_MAX_DISPLACEMENT,
-    iterations: DEFAULT_LAYOUT_ITERATIONS,
-});
-
-
-export const findThemeByName = (themeName: string | null): AdventureTheme | null => {
-    if (!themeName) return null;
-    for (const packKey in THEME_PACKS) {
-        const pack = THEME_PACKS[packKey as ThemePackName];
-        const foundTheme = pack.find(theme => theme.name === themeName);
-        if (foundTheme) {
-            return foundTheme;
-        }
-    }
-    return null;
-};
-
-async function convertV1toV2Intermediate(v1Data: V1SavedGameState): Promise<V2IntermediateSavedGameState> {
-  const v2Inventory: Item[] = v1Data.inventory.map((v1Item: V1Item) => ({
-    name: v1Item.name,
-    type: v1Item.type as ItemType,
-    description: v1Item.description,
-    activeDescription: undefined,
-    isActive: v1Item.isActive ?? false,
-    knownUses: (v1Item.knownUses || []).map((ku: V1KnownUse) => ({
-      ...ku,
-      appliesWhenActive: undefined,
-      appliesWhenInactive: undefined,
-    } as V2KnownUse)),
-    isJunk: v1Item.isJunk ?? false,
-  }));
-
-  const v2ThemeHistory: ThemeHistoryState = {};
-  for (const themeName in v1Data.themeHistory) {
-    if (Object.prototype.hasOwnProperty.call(v1Data.themeHistory, themeName)) {
-      const v1Memory = v1Data.themeHistory[themeName];
-      v2ThemeHistory[themeName] = {
-        summary: v1Memory.summary,
-        mainQuest: v1Memory.overarchingQuest,
-        currentObjective: v1Memory.currentObjective,
-        placeNames: v1Memory.placeNames, // These will now refer to MapNode.placeName of main map nodes
-        characterNames: v1Memory.characterNames,
-      };
-    }
-  }
-
-  // Convert V1Places to MapNodes (main nodes)
-  const v1ConvertedMapNodes: MapNode[] = v1Data.allPlaces.map((v1Place, index) => {
-    const baseNameForId = v1Place.name.replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
-    const nodeId = `${v1Place.themeName}_${baseNameForId}_v1main_${index}`;
-    return {
-      id: nodeId,
-      themeName: v1Place.themeName,
-      placeName: v1Place.name,
-      position: { x: Math.random() * 200 - 100, y: Math.random() * 200 - 100 }, // Initial random position
-      data: {
-        description: v1Place.description || "Description missing from V1 save",
-        aliases: v1Place.aliases || [],
-        status: 'discovered',
-        isLeaf: false,
-        visited: true,
-      },
-    };
-  });
-
-  const v1MapData: MapData = { nodes: v1ConvertedMapNodes, edges: [] };
-
-  let v2LocalPlace = v1Data.localPlace;
-  const currentThemeObjFromV1 = findThemeByName(v1Data.currentThemeName);
-  if ((!v2LocalPlace || v2LocalPlace === "Unknown" || v2LocalPlace === "Undetermined Location") && currentThemeObjFromV1 && v1Data.currentScene) {
-      try {
-        const inferredPlace = await fetchCorrectedLocalPlace_Service(
-          v1Data.currentScene,
-          currentThemeObjFromV1, // Pass AdventureTheme object
-          v1ConvertedMapNodes,
-          v1Data.localTime,
-          v1Data.localEnvironment
-        );
-        if (inferredPlace) v2LocalPlace = inferredPlace;
-      } catch (e) { console.error("V1 conversion: Error inferring localPlace:", e); }
-  }
-
-  const v2AllCharactersPromises = v1Data.allCharacters.map(async (v1Char: V1Character) => {
-    let charThemeObj = findThemeByName(v1Char.themeName);
-    let presenceStatus: Character['presenceStatus'] = 'unknown';
-    let lastKnownLocation: string | null = null;
-    let preciseLocation: string | null = null;
-
-    if (charThemeObj && process.env.API_KEY) {
-      const relevantMapNodesForCharThemeContext = v1ConvertedMapNodes.filter(node => node.themeName === charThemeObj!.name);
-      const sceneContextForChar = (v1Data.currentThemeName === v1Char.themeName) ? v1Data.currentScene : undefined;
-      const logContextForChar = (v1Data.currentThemeName === v1Char.themeName) ? v1Data.lastActionLog : undefined;
-      try {
-        const correctedDetails = await fetchCorrectedCharacterDetails_Service(
-          v1Char.name,
-          logContextForChar || undefined,
-          sceneContextForChar || undefined,
-          charThemeObj, // Pass AdventureTheme object
-          relevantMapNodesForCharThemeContext
-        );
-        if (correctedDetails) {
-          presenceStatus = correctedDetails.presenceStatus;
-          lastKnownLocation = correctedDetails.lastKnownLocation;
-          preciseLocation = correctedDetails.preciseLocation;
-        }
-      } catch (e) { console.error(`V1 conversion: Error inferring details for ${v1Char.name}:`, e); }
-    }
-    return {
-      themeName: v1Char.themeName, name: v1Char.name, description: v1Char.description,
-      aliases: v1Char.aliases || [], presenceStatus, lastKnownLocation, preciseLocation,
-      dialogueSummaries: [], // Initialize for V2 intermediate
-    };
-  });
-  const v2AllCharacters: Character[] = await Promise.all(v2AllCharactersPromises);
-
-  return {
-    saveGameVersion: "2",
-    currentThemeName: v1Data.currentThemeName,
-    currentThemeObject: currentThemeObjFromV1, // Populate currentThemeObject
-    currentScene: v1Data.currentScene,
-    actionOptions: v1Data.actionOptions,
-    mainQuest: v1Data.overarchingQuest,
-    currentObjective: v1Data.currentObjective,
-    inventory: v2Inventory,
-    gameLog: v1Data.gameLog,
-    lastActionLog: v1Data.lastActionLog,
-    themeHistory: v2ThemeHistory,
-    // isPostRealityShiftDisorientation: (v1Data as any).isPostRealityShiftDisorientation ?? false, // Handle potential absence in older V1
-    pendingNewThemeNameAfterShift: v1Data.pendingNewThemeNameAfterShift,
-    allCharacters: v2AllCharacters,
-    score: v1Data.score,
-    localTime: v1Data.localTime,
-    localEnvironment: v1Data.localEnvironment,
-    localPlace: v2LocalPlace || "Undetermined Location",
-    turnsSinceLastShift: 0, // Initialize for V2
-    globalTurnNumber: 0, // Initialize for V2 (will become part of V3)
-    playerGender: v1Data.playerGender || DEFAULT_PLAYER_GENDER,
-    enabledThemePacks: v1Data.enabledThemePacks || [...DEFAULT_ENABLED_THEME_PACKS],
-    stabilityLevel: v1Data.stabilityLevel ?? DEFAULT_STABILITY_LEVEL,
-    chaosLevel: v1Data.chaosLevel ?? DEFAULT_CHAOS_LEVEL,
-    mapData: v1MapData,
-    currentMapNodeId: null,
-    mapLayoutConfig: getDefaultMapLayoutConfig(),
-    isCustomGameMode: false, // Default for V2
-  };
-}
-
-function convertV2toV3Shape(v2Data: V2IntermediateSavedGameState): SavedGameDataShape {
-  const { ...v3RelevantData } = v2Data;
-
-  let finalMapData: MapData;
-  if (v2Data.mapData && Array.isArray(v2Data.mapData.nodes) && Array.isArray(v2Data.mapData.edges)) {
-    finalMapData = {
-        nodes: v2Data.mapData.nodes.map(node => ({
-            ...node,
-            data: {
-                description: node.data.description || "Description missing from V2 save",
-                aliases: node.data.aliases || [],
-                status: node.data.status || 'discovered',
-                isLeaf: node.data.isLeaf ?? false,
-                visited: node.data.visited ?? false,
-                parentNodeId: node.data.parentNodeId,
-                ...Object.fromEntries(Object.entries(node.data).filter(([key]) => !['description', 'aliases', 'status', 'isLeaf', 'visited', 'parentNodeId'].includes(key)))
-            }
-        })),
-        edges: v2Data.mapData.edges,
-    };
-  } else {
-    finalMapData = { nodes: [], edges: [] };
-  }
-
-  let finalMapLayoutConfig: MapLayoutConfig;
-  if (v2Data.mapLayoutConfig && isValidMapLayoutConfig(v2Data.mapLayoutConfig)) {
-    finalMapLayoutConfig = v2Data.mapLayoutConfig;
-  } else {
-    const defaultConfig = getDefaultMapLayoutConfig();
-    if (v2Data.mapLayoutConfig && typeof v2Data.mapLayoutConfig === 'object') {
-        const loadedConfig = v2Data.mapLayoutConfig;
-        const patchedConfig: Partial<MapLayoutConfig> = {};
-        for (const key of Object.keys(defaultConfig) as Array<keyof MapLayoutConfig>) {
-            if (Object.prototype.hasOwnProperty.call(loadedConfig, key) && typeof (loadedConfig as any)[key] === 'number') {
-                patchedConfig[key] = (loadedConfig as any)[key];
-            } else {
-                patchedConfig[key] = defaultConfig[key];
-            }
-        }
-        finalMapLayoutConfig = patchedConfig as MapLayoutConfig;
-    } else {
-        finalMapLayoutConfig = defaultConfig;
-    }
-  }
-
-
-  const finalCurrentMapNodeId = v2Data.currentMapNodeId === undefined ? null : v2Data.currentMapNodeId;
-  
-  const finalAllCharacters = v2Data.allCharacters.map(char => ({
-    ...char,
-    dialogueSummaries: char.dialogueSummaries || [], // Ensure dialogueSummaries is initialized
-  }));
-
-  const finalCurrentThemeObject = v2Data.currentThemeObject || findThemeByName(v2Data.currentThemeName);
-
-
-  return {
-    ...v3RelevantData,
-    currentThemeObject: finalCurrentThemeObject, // Ensure currentThemeObject is set
-    allCharacters: finalAllCharacters, // Use characters with initialized dialogueSummaries
-    saveGameVersion: CURRENT_SAVE_GAME_VERSION, // Target V3
-    mapData: finalMapData,
-    currentMapNodeId: finalCurrentMapNodeId,
-    mapLayoutConfig: finalMapLayoutConfig,
-    isCustomGameMode: v2Data.isCustomGameMode ?? false, // Carry over or default
-    globalTurnNumber: v2Data.globalTurnNumber ?? 0, // Carry over or default
-  };
-}
+import { convertV1toV2Intermediate, convertV2toV3Shape, V1SavedGameState, V2IntermediateSavedGameState, getDefaultMapLayoutConfig } from "./saveConverters";
+import { findThemeByName } from "./themeUtils";
 
 
 // --- Validation Helpers for SavedGameDataShape (V3) ---
@@ -449,7 +128,7 @@ function isValidAdventureThemeObject(obj: any): obj is AdventureTheme {
 }
 
 
-function validateSavedGameState(data: any): data is SavedGameDataShape {
+export function validateSavedGameState(data: any): data is SavedGameDataShape {
   if (!data || typeof data !== 'object') { console.warn("Invalid save data: Not an object."); return false; }
   if (data.saveGameVersion !== CURRENT_SAVE_GAME_VERSION) {
     console.warn(`Save data version mismatch. Expected ${CURRENT_SAVE_GAME_VERSION}, got ${data.saveGameVersion}. Attempting to load anyway if structure is V3-compatible.`);
@@ -516,7 +195,7 @@ function validateSavedGameState(data: any): data is SavedGameDataShape {
  * Modifies the object in place.
  * @param configHolder An object that is expected to have a mapLayoutConfig property.
  */
-function ensureCompleteMapLayoutConfig(configHolder: { mapLayoutConfig?: Partial<MapLayoutConfig> | MapLayoutConfig }): void {
+export function ensureCompleteMapLayoutConfig(configHolder: { mapLayoutConfig?: Partial<MapLayoutConfig> | MapLayoutConfig }): void {
     const defaultConfig = getDefaultMapLayoutConfig();
     if (configHolder.mapLayoutConfig && typeof configHolder.mapLayoutConfig === 'object') {
         const loadedConfig = configHolder.mapLayoutConfig as Partial<MapLayoutConfig>; // Cast to allow partial
@@ -539,7 +218,7 @@ function ensureCompleteMapLayoutConfig(configHolder: { mapLayoutConfig?: Partial
  * and other optional fields if they are missing. Modifies mapData in place.
  * @param mapData The MapData object to process.
  */
-function ensureCompleteMapNodeDataDefaults(mapData: MapData | undefined): void {
+export function ensureCompleteMapNodeDataDefaults(mapData: MapData | undefined): void {
     if (!mapData || !Array.isArray(mapData.nodes)) {
         return;
     }
@@ -569,7 +248,7 @@ function ensureCompleteMapNodeDataDefaults(mapData: MapData | undefined): void {
 }
 
 
-const prepareGameStateForSaving = (gameState: FullGameState): SavedGameDataShape => {
+export const prepareGameStateForSaving = (gameState: FullGameState): SavedGameDataShape => {
   const {
     dialogueState,
     objectiveAnimationType,
@@ -626,7 +305,7 @@ const prepareGameStateForSaving = (gameState: FullGameState): SavedGameDataShape
   return savedData;
 };
 
-const expandSavedDataToFullState = (savedData: SavedGameDataShape): FullGameState => {
+export const expandSavedDataToFullState = (savedData: SavedGameDataShape): FullGameState => {
   const mapDataFromLoad: MapData = {
     nodes: (savedData.mapData?.nodes || []).map(node => ({
         ...node,
@@ -668,114 +347,6 @@ const expandSavedDataToFullState = (savedData: SavedGameDataShape): FullGameStat
   };
 };
 
-// --- LocalStorage Operations ---
-export const saveGameStateToLocalStorage = (gameState: FullGameState): boolean => {
-  try {
-    const dataToSave = prepareGameStateForSaving(gameState);
-    localStorage.setItem(LOCAL_STORAGE_SAVE_KEY, JSON.stringify(dataToSave));
-    return true;
-  } catch (error) {
-    console.error("Error saving game state to localStorage:", error);
-    if (error instanceof DOMException && (error.name === 'QuotaExceededError' || error.code === 22)) {
-      alert("Could not save game: Browser storage is full. Please clear some space or try saving to a file.");
-    } else {
-      alert("An unexpected error occurred while trying to automatically save your game.");
-    }
-    return false;
-  }
-};
-
-/**
- * Loads the latest saved game from localStorage if available.
- * Converts older save versions to the current structure and validates the result.
- */
-export const loadGameStateFromLocalStorage = async (): Promise<FullGameState | null> => {
-  try {
-    const savedDataString = localStorage.getItem(LOCAL_STORAGE_SAVE_KEY);
-    if (!savedDataString) return null;
-
-    let parsedData = JSON.parse(savedDataString);
-    let dataToValidateAndExpand: SavedGameDataShape | null = null;
-
-    if (parsedData && parsedData.saveGameVersion === "1.0.0") {
-      console.log("V1 save data detected from localStorage. Attempting conversion to V3...");
-      const v2Intermediate = await convertV1toV2Intermediate(parsedData as V1SavedGameState);
-      dataToValidateAndExpand = convertV2toV3Shape(v2Intermediate);
-    } else if (parsedData && parsedData.saveGameVersion === "2") {
-      console.log("V2 save data detected from localStorage. Attempting conversion to V3...");
-      dataToValidateAndExpand = convertV2toV3Shape(parsedData as V2IntermediateSavedGameState);
-    } else if (parsedData && (parsedData.saveGameVersion === CURRENT_SAVE_GAME_VERSION || (typeof parsedData.saveGameVersion === 'string' && parsedData.saveGameVersion.startsWith(CURRENT_SAVE_GAME_VERSION.split('.')[0])))) {
-       if (parsedData.saveGameVersion !== CURRENT_SAVE_GAME_VERSION) {
-          console.warn(`Potentially compatible future V${CURRENT_SAVE_GAME_VERSION.split('.')[0]}.x save version '${parsedData.saveGameVersion}' from localStorage. Attempting to treat as current version (V3) for validation.`);
-       }
-       dataToValidateAndExpand = parsedData as SavedGameDataShape;
-       ensureCompleteMapLayoutConfig(dataToValidateAndExpand);
-       ensureCompleteMapNodeDataDefaults(dataToValidateAndExpand.mapData);
-   } else if (parsedData) {
-      console.warn(`Unknown save version '${parsedData.saveGameVersion}' from localStorage. This might fail validation.`);
-      dataToValidateAndExpand = parsedData as SavedGameDataShape;
-      if (dataToValidateAndExpand) {
-        ensureCompleteMapLayoutConfig(dataToValidateAndExpand);
-        ensureCompleteMapNodeDataDefaults(dataToValidateAndExpand.mapData);
-      }
-   }
-
-    if (dataToValidateAndExpand && !dataToValidateAndExpand.currentThemeObject && dataToValidateAndExpand.currentThemeName) {
-      dataToValidateAndExpand.currentThemeObject = findThemeByName(dataToValidateAndExpand.currentThemeName);
-      if (!dataToValidateAndExpand.currentThemeObject) {
-        console.warn(`Failed to find theme "${dataToValidateAndExpand.currentThemeName}" during localStorage load. Game state might be incomplete.`);
-      }
-    }
-
-    if (dataToValidateAndExpand) {
-      const gt = (dataToValidateAndExpand as any).globalTurnNumber;
-      if (typeof gt === 'string') {
-        const parsed = parseInt(gt, 10);
-        dataToValidateAndExpand.globalTurnNumber = isNaN(parsed) ? 0 : parsed;
-      } else if (gt === undefined || gt === null) {
-        dataToValidateAndExpand.globalTurnNumber = 0;
-      }
-    }
-
-    if (dataToValidateAndExpand && validateSavedGameState(dataToValidateAndExpand)) {
-      dataToValidateAndExpand.inventory = dataToValidateAndExpand.inventory.map((item: Item) => ({ ...item, isJunk: item.isJunk ?? false }));
-      dataToValidateAndExpand.score = dataToValidateAndExpand.score ?? 0;
-      dataToValidateAndExpand.stabilityLevel = dataToValidateAndExpand.stabilityLevel ?? DEFAULT_STABILITY_LEVEL;
-      dataToValidateAndExpand.chaosLevel = dataToValidateAndExpand.chaosLevel ?? DEFAULT_CHAOS_LEVEL;
-      dataToValidateAndExpand.localTime = dataToValidateAndExpand.localTime ?? null;
-      dataToValidateAndExpand.localEnvironment = dataToValidateAndExpand.localEnvironment ?? null;
-      dataToValidateAndExpand.localPlace = dataToValidateAndExpand.localPlace ?? null;
-      dataToValidateAndExpand.allCharacters = dataToValidateAndExpand.allCharacters.map((c: any) => ({
-        ...c, 
-        aliases: c.aliases || [], 
-        presenceStatus: c.presenceStatus || 'unknown',
-        lastKnownLocation: c.lastKnownLocation ?? null,
-        preciseLocation: c.preciseLocation || null,
-        dialogueSummaries: c.dialogueSummaries || [], 
-      }));
-      dataToValidateAndExpand.enabledThemePacks = dataToValidateAndExpand.enabledThemePacks ?? [...DEFAULT_ENABLED_THEME_PACKS];
-      dataToValidateAndExpand.playerGender = dataToValidateAndExpand.playerGender ?? DEFAULT_PLAYER_GENDER;
-      dataToValidateAndExpand.turnsSinceLastShift = dataToValidateAndExpand.turnsSinceLastShift ?? 0;
-      dataToValidateAndExpand.globalTurnNumber = dataToValidateAndExpand.globalTurnNumber ?? 0; 
-      dataToValidateAndExpand.mainQuest = dataToValidateAndExpand.mainQuest ?? null;
-      dataToValidateAndExpand.isCustomGameMode = dataToValidateAndExpand.isCustomGameMode ?? false; 
-      
-      return expandSavedDataToFullState(dataToValidateAndExpand);
-    }
-    console.warn("Local save data is invalid or version mismatch for V3. Starting new game.");
-    localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);
-    return null;
-  } catch (error) {
-    console.error("Error loading game state from localStorage:", error);
-    localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);
-    return null;
-  }
-};
-
-export const clearGameStateFromLocalStorage = (): void => {
-  try { localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY); }
-  catch (error) { console.error("Error clearing game state from localStorage:", error); }
-};
 
 // --- File Operations ---
 const triggerDownload = (data: string, filename: string, type: string): void => {

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -1,0 +1,128 @@
+/**
+ * @file services/storage.ts
+ * @description Helper functions for persisting game state to browser localStorage.
+ */
+
+import { FullGameState, SavedGameDataShape, Item } from '../types';
+import {
+  CURRENT_SAVE_GAME_VERSION,
+  LOCAL_STORAGE_SAVE_KEY,
+  DEFAULT_STABILITY_LEVEL,
+  DEFAULT_CHAOS_LEVEL,
+  DEFAULT_ENABLED_THEME_PACKS,
+  DEFAULT_PLAYER_GENDER
+} from '../constants';
+import { prepareGameStateForSaving, expandSavedDataToFullState, validateSavedGameState } from './saveLoadService';
+import { convertV1toV2Intermediate, convertV2toV3Shape, V1SavedGameState, V2IntermediateSavedGameState } from './saveConverters';
+import { ensureCompleteMapLayoutConfig, ensureCompleteMapNodeDataDefaults } from './saveLoadService';
+import { findThemeByName } from './themeUtils';
+
+/** Saves the current game state to localStorage. */
+export const saveGameStateToLocalStorage = (gameState: FullGameState): boolean => {
+  try {
+    const dataToSave = prepareGameStateForSaving(gameState);
+    localStorage.setItem(LOCAL_STORAGE_SAVE_KEY, JSON.stringify(dataToSave));
+    return true;
+  } catch (error) {
+    console.error('Error saving game state to localStorage:', error);
+    if (error instanceof DOMException && (error.name === 'QuotaExceededError' || (error as any).code === 22)) {
+      alert('Could not save game: Browser storage is full. Please clear some space or try saving to a file.');
+    } else {
+      alert('An unexpected error occurred while trying to automatically save your game.');
+    }
+    return false;
+  }
+};
+
+/**
+ * Loads the latest saved game from localStorage if available.
+ * Handles version conversion and validation steps.
+ */
+export const loadGameStateFromLocalStorage = async (): Promise<FullGameState | null> => {
+  try {
+    const savedDataString = localStorage.getItem(LOCAL_STORAGE_SAVE_KEY);
+    if (!savedDataString) return null;
+
+    let parsedData = JSON.parse(savedDataString);
+    let dataToValidateAndExpand: SavedGameDataShape | null = null;
+
+    if (parsedData && parsedData.saveGameVersion === '1.0.0') {
+      console.log('V1 save data detected from localStorage. Attempting conversion to V3...');
+      const v2Intermediate = await convertV1toV2Intermediate(parsedData as V1SavedGameState);
+      dataToValidateAndExpand = convertV2toV3Shape(v2Intermediate);
+    } else if (parsedData && parsedData.saveGameVersion === '2') {
+      console.log('V2 save data detected from localStorage. Attempting conversion to V3...');
+      dataToValidateAndExpand = convertV2toV3Shape(parsedData as V2IntermediateSavedGameState);
+    } else if (parsedData && (parsedData.saveGameVersion === CURRENT_SAVE_GAME_VERSION || (typeof parsedData.saveGameVersion === 'string' && parsedData.saveGameVersion.startsWith(CURRENT_SAVE_GAME_VERSION.split('.')[0])))) {
+      if (parsedData.saveGameVersion !== CURRENT_SAVE_GAME_VERSION) {
+        console.warn(`Potentially compatible future V${CURRENT_SAVE_GAME_VERSION.split('.')[0]}.x save version '${parsedData.saveGameVersion}' from localStorage. Attempting to treat as current version (V3) for validation.`);
+      }
+      dataToValidateAndExpand = parsedData as SavedGameDataShape;
+      ensureCompleteMapLayoutConfig(dataToValidateAndExpand);
+      ensureCompleteMapNodeDataDefaults(dataToValidateAndExpand.mapData);
+    } else if (parsedData) {
+      console.warn(`Unknown save version '${parsedData.saveGameVersion}' from localStorage. This might fail validation.`);
+      dataToValidateAndExpand = parsedData as SavedGameDataShape;
+      if (dataToValidateAndExpand) {
+        ensureCompleteMapLayoutConfig(dataToValidateAndExpand);
+        ensureCompleteMapNodeDataDefaults(dataToValidateAndExpand.mapData);
+      }
+    }
+
+    if (dataToValidateAndExpand && !dataToValidateAndExpand.currentThemeObject && dataToValidateAndExpand.currentThemeName) {
+      dataToValidateAndExpand.currentThemeObject = findThemeByName(dataToValidateAndExpand.currentThemeName);
+      if (!dataToValidateAndExpand.currentThemeObject) {
+        console.warn(`Failed to find theme "${dataToValidateAndExpand.currentThemeName}" during localStorage load. Game state might be incomplete.`);
+      }
+    }
+
+    if (dataToValidateAndExpand) {
+      const gt = (dataToValidateAndExpand as any).globalTurnNumber;
+      if (typeof gt === 'string') {
+        const parsed = parseInt(gt, 10);
+        dataToValidateAndExpand.globalTurnNumber = isNaN(parsed) ? 0 : parsed;
+      } else if (gt === undefined || gt === null) {
+        dataToValidateAndExpand.globalTurnNumber = 0;
+      }
+    }
+
+    if (dataToValidateAndExpand && validateSavedGameState(dataToValidateAndExpand)) {
+      dataToValidateAndExpand.inventory = dataToValidateAndExpand.inventory.map((item: Item) => ({ ...item, isJunk: item.isJunk ?? false }));
+      dataToValidateAndExpand.score = dataToValidateAndExpand.score ?? 0;
+      dataToValidateAndExpand.stabilityLevel = dataToValidateAndExpand.stabilityLevel ?? DEFAULT_STABILITY_LEVEL;
+      dataToValidateAndExpand.chaosLevel = dataToValidateAndExpand.chaosLevel ?? DEFAULT_CHAOS_LEVEL;
+      dataToValidateAndExpand.localTime = dataToValidateAndExpand.localTime ?? null;
+      dataToValidateAndExpand.localEnvironment = dataToValidateAndExpand.localEnvironment ?? null;
+      dataToValidateAndExpand.localPlace = dataToValidateAndExpand.localPlace ?? null;
+      dataToValidateAndExpand.allCharacters = dataToValidateAndExpand.allCharacters.map((c: any) => ({
+        ...c,
+        aliases: c.aliases || [],
+        presenceStatus: c.presenceStatus || 'unknown',
+        lastKnownLocation: c.lastKnownLocation ?? null,
+        preciseLocation: c.preciseLocation || null,
+        dialogueSummaries: c.dialogueSummaries || [],
+      }));
+      dataToValidateAndExpand.enabledThemePacks = dataToValidateAndExpand.enabledThemePacks ?? [...DEFAULT_ENABLED_THEME_PACKS];
+      dataToValidateAndExpand.playerGender = dataToValidateAndExpand.playerGender ?? DEFAULT_PLAYER_GENDER;
+      dataToValidateAndExpand.turnsSinceLastShift = dataToValidateAndExpand.turnsSinceLastShift ?? 0;
+      dataToValidateAndExpand.globalTurnNumber = dataToValidateAndExpand.globalTurnNumber ?? 0;
+      dataToValidateAndExpand.mainQuest = dataToValidateAndExpand.mainQuest ?? null;
+      dataToValidateAndExpand.isCustomGameMode = dataToValidateAndExpand.isCustomGameMode ?? false;
+
+      return expandSavedDataToFullState(dataToValidateAndExpand);
+    }
+    console.warn('Local save data is invalid or version mismatch for V3. Starting new game.');
+    localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);
+    return null;
+  } catch (error) {
+    console.error('Error loading game state from localStorage:', error);
+    localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);
+    return null;
+  }
+};
+
+/** Clears any saved game data from localStorage. */
+export const clearGameStateFromLocalStorage = (): void => {
+  try { localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY); }
+  catch (error) { console.error('Error clearing game state from localStorage:', error); }
+};

--- a/services/themeUtils.ts
+++ b/services/themeUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * @file services/themeUtils.ts
+ * @description Helper functions related to theme lookups.
+ */
+
+import { AdventureTheme, ThemePackName } from '../types';
+import { THEME_PACKS } from '../themes';
+
+/**
+ * Finds and returns the AdventureTheme object for a given theme name.
+ * @param themeName Name of the theme to search for.
+ */
+export const findThemeByName = (themeName: string | null): AdventureTheme | null => {
+  if (!themeName) return null;
+  for (const packKey in THEME_PACKS) {
+    const pack = THEME_PACKS[packKey as ThemePackName];
+    const foundTheme = pack.find(theme => theme.name === themeName);
+    if (foundTheme) {
+      return foundTheme;
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- extract save game conversion logic into `services/saveConverters`
- create `services/storage.ts` with local storage helpers
- move theme lookup helper to `services/themeUtils.ts`
- simplify `saveLoadService` to orchestrate modules
- update imports across project

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684051ceabc88324874157338f7cb3b4