### PR TITLE
Refactor AI parsing helpers

### DIFF
--- a/services/aiResponseParser.ts
+++ b/services/aiResponseParser.ts
@@ -10,7 +10,7 @@ import {
     isValidCharacterUpdate,
     isValidNewCharacterPayload,
     isDialogueSetupPayloadStructurallyValid
-} from './validationUtils';
+} from './parsers/validation';
 import {
     fetchCorrectedItemAction_Service,
     fetchCorrectedItemPayload_Service,
@@ -21,6 +21,7 @@ import {
 } from './corrections';
 
 
+import { sanitizeJsonString } from './parsers/jsonSanitizer';
 /**
  * Parses the AI's JSON response, validates its structure against GameStateFromAI,
  * and attempts to correct malformed sections using correction services.
@@ -46,12 +47,7 @@ export async function parseAIResponse(
     currentThemeMapData: MapData = { nodes: [], edges: [] },
     currentInventoryForCorrection: Item[] = []
 ): Promise<GameStateFromAI | null> {
-  let jsonStr = responseText.trim();
-  const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
-  const fenceMatch = jsonStr.match(fenceRegex);
-  if (fenceMatch && fenceMatch[1]) {
-    jsonStr = fenceMatch[1].trim();
-  }
+  const jsonStr = sanitizeJsonString(responseText);
 
   // Derive known main map nodes from map data for correction context
   const allRelevantMainMapNodesForCorrection: MapNode[] = currentThemeMapData.nodes

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -5,7 +5,7 @@
 import { AdventureTheme, Character, MapNode, Item, DialogueSetupPayload } from '../../types';
 import { MAX_RETRIES } from '../../constants';
 import { formatKnownPlacesForPrompt, formatKnownCharactersForPrompt } from '../../utils/promptFormatters';
-import { isDialogueSetupPayloadStructurallyValid } from '../validationUtils';
+import { isDialogueSetupPayloadStructurallyValid } from '../parsers/validation';
 import { callCorrectionAI } from './base';
 
 /**

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -4,7 +4,7 @@
  */
 import { Item, AdventureTheme, ItemChange } from '../../types';
 import { MAX_RETRIES, VALID_ITEM_TYPES_STRING } from '../../constants';
-import { isValidItem } from '../validationUtils';
+import { isValidItem } from '../parsers/validation';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters';
 import { callCorrectionAI, callMinimalCorrectionAI } from './base';
 

--- a/services/parsers/jsonSanitizer.ts
+++ b/services/parsers/jsonSanitizer.ts
@@ -1,0 +1,20 @@
+/**
+ * @file jsonSanitizer.ts
+ * @description Helper for cleaning raw AI responses into valid JSON strings.
+ */
+
+/**
+ * Strips Markdown fences and trims whitespace from a potential JSON string.
+ *
+ * @param rawText - The raw string returned from the AI model.
+ * @returns The cleaned JSON string ready for parsing.
+ */
+export function sanitizeJsonString(rawText: string): string {
+  let jsonStr = rawText.trim();
+  const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
+  const fenceMatch = jsonStr.match(fenceRegex);
+  if (fenceMatch && fenceMatch[1]) {
+    jsonStr = fenceMatch[1].trim();
+  }
+  return jsonStr;
+}

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -1,10 +1,9 @@
-
 /**
- * @file validationUtils.ts
+ * @file validation.ts
  * @description Shared validation helpers for AI payloads.
  */
-import { Item, KnownUse, ItemType, Character, DialogueTurnResponsePart, ValidCharacterUpdatePayload, ValidNewCharacterPayload, DialogueSetupPayload } from '../types';
-import { VALID_ITEM_TYPES } from '../constants';
+import { Item, KnownUse, ItemType, Character, DialogueTurnResponsePart, ValidCharacterUpdatePayload, ValidNewCharacterPayload, DialogueSetupPayload } from '../../types';
+import { VALID_ITEM_TYPES } from '../../constants';
 
 export function isValidKnownUse(ku: any): ku is KnownUse {
   return ku &&


### PR DESCRIPTION
## Summary
- move validation utilities into `services/parsers`
- add `jsonSanitizer` utility for cleaning raw responses
- import new helpers in `aiResponseParser`
- update correction helpers to use moved validation module

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684059d543048324b5414f705dd11e14