### PR TITLE
Centralize Gemini client configuration

### DIFF
--- a/components/ImageVisualizer.tsx
+++ b/components/ImageVisualizer.tsx
@@ -1,16 +1,12 @@
 
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { GoogleGenAI } from "@google/genai";
+import { geminiClient as ai, isApiConfigured } from '../services/apiClient';
 import { AdventureTheme, Character, MapNode } from '../types'; 
 import LoadingSpinner from './LoadingSpinner';
 
-const API_KEY = process.env.API_KEY;
-let ai: GoogleGenAI | null = null;
-if (API_KEY) {
-  ai = new GoogleGenAI({ apiKey: API_KEY });
-} else {
-  console.error("API_KEY for GoogleGenAI is not set. Image visualization will not work.");
+if (!isApiConfigured()) {
+  console.error("GEMINI_API_KEY for GoogleGenAI is not set. Image visualization will not work.");
 }
 
 interface ImageVisualizerProps {

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -1,0 +1,23 @@
+/**
+ * @file services/apiClient.ts
+ * @description Centralized Gemini API key handling and client exposure.
+ */
+import { GoogleGenAI } from '@google/genai';
+
+/** Cached API key read from environment variables. */
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || process.env.API_KEY;
+
+if (!GEMINI_API_KEY) {
+  console.error('GEMINI_API_KEY environment variable is not set. Gemini services will be unavailable.');
+}
+
+/** Shared GoogleGenAI client instance, or null if API key is missing. */
+export const geminiClient: GoogleGenAI | null = GEMINI_API_KEY
+  ? new GoogleGenAI({ apiKey: GEMINI_API_KEY })
+  : null;
+
+/** Returns whether the Gemini API key is configured. */
+export const isApiConfigured = (): boolean => !!GEMINI_API_KEY;
+
+/** Returns the configured API key, or null when absent. */
+export const getApiKey = (): string | null => GEMINI_API_KEY || null;

--- a/services/corrections/base.ts
+++ b/services/corrections/base.ts
@@ -4,6 +4,7 @@
  */
 import { AUXILIARY_MODEL_NAME, MINIMAL_MODEL_NAME } from '../../constants';
 import { ai } from '../geminiClient';
+import { isApiConfigured } from '../apiClient';
 
 /** Temperature used for all correction related AI calls. */
 export const CORRECTION_TEMPERATURE = 0.75;
@@ -47,7 +48,7 @@ export const callMinimalCorrectionAI = async (
   prompt: string,
   systemInstruction: string
 ): Promise<string | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error('callMinimalCorrectionAI: API Key not configured.');
     return null;
   }

--- a/services/corrections/character.ts
+++ b/services/corrections/character.ts
@@ -6,6 +6,7 @@ import { AdventureTheme, Character, MapNode } from '../../types';
 import { MAX_RETRIES } from '../../constants';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
 import { callCorrectionAI, callMinimalCorrectionAI } from './base';
+import { isApiConfigured } from '../apiClient';
 
 /** Structure returned when correcting character details. */
 export interface CorrectedCharacterDetails {
@@ -26,7 +27,7 @@ export const fetchCorrectedCharacterDetails_Service = async (
   currentTheme: AdventureTheme,
   allRelevantMapNodes: MapNode[]
 ): Promise<CorrectedCharacterDetails | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error(`fetchCorrectedCharacterDetails_Service: API Key not configured. Cannot fetch details for "${characterName}".`);
     return null;
   }
@@ -96,7 +97,7 @@ export const fetchCorrectedCompanionOrNPCLocation_Service = async (
   invalidPreciseLocationPayload: string,
   currentTheme: AdventureTheme
 ): Promise<string | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error(`fetchCorrectedCompanionOrNPCLocation_Service: API Key not configured. Cannot correct location for "${characterName}".`);
     return null;
   }

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -8,6 +8,7 @@ import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
 import { formatKnownCharactersForPrompt } from '../../utils/promptFormatters/dialogue';
 import { isDialogueSetupPayloadStructurallyValid } from '../parsers/validation';
 import { callCorrectionAI } from './base';
+import { isApiConfigured } from '../apiClient';
 
 /**
  * Attempts to correct a malformed DialogueSetupPayload.
@@ -22,7 +23,7 @@ export const fetchCorrectedDialogueSetup_Service = async (
   playerGender: string,
   malformedDialogueSetup: Partial<DialogueSetupPayload> | any
 ): Promise<DialogueSetupPayload | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error('fetchCorrectedDialogueSetup_Service: API Key not configured.');
     return null;
   }

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -7,6 +7,7 @@ import { MAX_RETRIES, VALID_ITEM_TYPES_STRING } from '../../constants';
 import { isValidItem } from '../parsers/validation';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
 import { callCorrectionAI, callMinimalCorrectionAI } from './base';
+import { isApiConfigured } from '../apiClient';
 
 /**
  * Fetches a corrected item payload from the AI when an itemChange object is malformed.
@@ -18,7 +19,7 @@ export const fetchCorrectedItemPayload_Service = async (
   malformedPayloadString: string,
   currentTheme: AdventureTheme
 ): Promise<Item | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error(`fetchCorrectedItemPayload_Service: API Key not configured. Cannot correct item payload for action "${actionType}".`);
     return null;
   }
@@ -134,7 +135,7 @@ export const fetchCorrectedItemAction_Service = async (
   malformedItemChangeString: string,
   currentTheme: AdventureTheme
 ): Promise<ItemChange['action'] | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error('fetchCorrectedItemAction_Service: API Key not configured. Cannot correct item action.');
     return null;
   }

--- a/services/corrections/map.ts
+++ b/services/corrections/map.ts
@@ -6,6 +6,7 @@ import { AdventureTheme, MapNode } from '../../types';
 import { MAX_RETRIES } from '../../constants';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
 import { callCorrectionAI, callMinimalCorrectionAI } from './base';
+import { isApiConfigured } from '../apiClient';
 
 /**
  * Infers or corrects the player's current local place string.
@@ -17,7 +18,7 @@ export const fetchCorrectedLocalPlace_Service = async (
   localTime: string | null,
   localEnvironment: string | null
 ): Promise<string | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error('fetchCorrectedLocalPlace_Service: API Key not configured.');
     return null;
   }
@@ -68,7 +69,7 @@ export const fetchCorrectedPlaceDetails_Service = async (
   sceneDescriptionContext: string | undefined,
   currentTheme: AdventureTheme
 ): Promise<{ name: string; description: string; aliases?: string[] } | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error('fetchCorrectedPlaceDetails_Service: API Key not configured.');
     return null;
   }
@@ -137,7 +138,7 @@ export const fetchFullPlaceDetailsForNewMapNode_Service = async (
   sceneDescriptionContext: string | undefined,
   currentTheme: AdventureTheme
 ): Promise<{ name: string; description: string; aliases?: string[] } | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error('fetchFullPlaceDetailsForNewMapNode_Service: API Key not configured.');
     return null;
   }

--- a/services/corrections/name.ts
+++ b/services/corrections/name.ts
@@ -5,6 +5,7 @@
 import { AdventureTheme } from '../../types';
 import { MAX_RETRIES } from '../../constants';
 import { callMinimalCorrectionAI } from './base';
+import { isApiConfigured } from '../apiClient';
 
 /**
  * Attempts to match a malformed name against a list of valid names.
@@ -17,7 +18,7 @@ export const fetchCorrectedName_Service = async (
   validNamesList: string[],
   currentTheme: AdventureTheme
 ): Promise<string | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error(`fetchCorrectedName_Service: API Key not configured. Cannot correct ${entityTypeToCorrect} name.`);
     return null;
   }

--- a/services/dialogueService.ts
+++ b/services/dialogueService.ts
@@ -14,6 +14,7 @@ import {
     DIALOGUE_SUMMARY_SYSTEM_INSTRUCTION
 } from '../prompts/dialoguePrompts';
 import { ai } from './geminiClient';
+import { isApiConfigured } from './apiClient';
 import { formatKnownPlacesForPrompt } from '../utils/promptFormatters/map';
 
 const callDialogueGeminiAPI = async (
@@ -102,7 +103,7 @@ export const fetchDialogueTurn = async (
   playerLastUtterance: string,
   dialogueParticipants: string[]
 ): Promise<DialogueAIResponse | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error("API Key not configured for Dialogue Service.");
     return Promise.reject(new Error("API Key not configured."));
   }
@@ -189,9 +190,9 @@ Provide new dialogue options, ensuring the last one is a way to end the dialogue
 
 
 export const summarizeDialogueForUpdates = async (
-  summaryContext: DialogueSummaryContext 
+  summaryContext: DialogueSummaryContext
 ): Promise<DialogueSummaryResponse | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error("API Key not configured for Dialogue Summary Service.");
     return Promise.reject(new Error("API Key not configured."));
   }
@@ -268,9 +269,9 @@ If the dialogue revealed new map information (new locations, changed accessibili
  * @returns A promise that resolves to the summary string (500-1000 chars) or null.
  */
 export const summarizeDialogueForMemory = async (
-  context: DialogueMemorySummaryContext 
+  context: DialogueMemorySummaryContext
 ): Promise<string | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error("API Key not configured for Dialogue Memory Summary Service.");
     return null;
   }

--- a/services/gameAIService.ts
+++ b/services/gameAIService.ts
@@ -8,13 +8,14 @@ import { GameStateFromAI, Item, ItemChange, AdventureTheme, Character, MapNode }
 import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES, DEFAULT_PLAYER_GENDER } from '../constants';
 import { SYSTEM_INSTRUCTION } from '../prompts/mainPrompts';
 import { ai } from './geminiClient';
+import { isApiConfigured } from './apiClient';
 
 // This function is now the primary way gameAIService interacts with Gemini for main game turns. It takes a fully constructed prompt.
 export const executeAIMainTurn = async (
     fullPrompt: string,
     themeSystemInstructionModifier: string | undefined // Retain as string for direct use
 ): Promise<GenerateContentResponse> => {
-    if (!process.env.API_KEY) {
+    if (!isApiConfigured()) {
       console.error("API Key not configured for Gemini Service.");
       return Promise.reject(new Error("API Key not configured."));
     }
@@ -66,7 +67,7 @@ export const summarizeThemeAdventure_Service = async (
   lastSceneDescription: string,
   actionLog: string[]
 ): Promise<string | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error("API Key not configured for Gemini Service. Cannot summarize.");
     return null;
   }

--- a/services/geminiClient.ts
+++ b/services/geminiClient.ts
@@ -1,12 +1,13 @@
-
+/**
+ * @file services/geminiClient.ts
+ * @description Provides a shared GoogleGenAI client instance.
+ */
 import { GoogleGenAI } from "@google/genai";
+import { geminiClient, isApiConfigured, getApiKey } from "./apiClient";
 
-if (!process.env.API_KEY) {
-  console.error("API_KEY environment variable is not set. The application will not be able to connect to the Gemini API.");
-  // Potentially throw an error or have a fallback if critical for app initialization
+if (!isApiConfigured()) {
+  console.error("GEMINI_API_KEY environment variable is not set. The application will not be able to connect to the Gemini API.");
 }
 
-// Initialize the GoogleGenAI client
-// The exclamation mark asserts that API_KEY is non-null, 
-// assuming process.env.API_KEY is properly configured in the environment.
-export const ai = new GoogleGenAI({ apiKey: process.env.API_KEY! });
+/** Shared Gemini client used across services. */
+export const ai: GoogleGenAI | null = geminiClient;

--- a/services/mapCorrectionService.ts
+++ b/services/mapCorrectionService.ts
@@ -10,6 +10,7 @@ import { AIMapUpdatePayload, MapChainToRefine, MapData, MapNode, MapEdge, Advent
 import { AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
 import { MAP_CHAIN_CORRECTION_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
 import { ai as geminiAIInstance } from './geminiClient';
+import { isApiConfigured } from './apiClient';
 import { VALID_NODE_STATUS_VALUES, VALID_EDGE_TYPE_VALUES, VALID_EDGE_STATUS_VALUES } from '../utils/mapUpdateValidationUtils';
 import { pruneAndRefineMapConnections } from '../utils/mapPruningUtils'; // Import pruning utility
 import { structuredCloneGameState } from '../utils/cloneUtils';
@@ -22,7 +23,7 @@ import { structuredCloneGameState } from '../utils/cloneUtils';
  * @returns A promise that resolves to the AI's response or null on error.
  */
 const callCorrectionAI = async (prompt: string, systemInstruction: string): Promise<GenerateContentResponse | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error("callCorrectionAI (mapCorrectionService): API Key not configured.");
     return null;
   }

--- a/services/mapUpdateService.ts
+++ b/services/mapUpdateService.ts
@@ -9,6 +9,7 @@ import { GameStateFromAI, AdventureTheme, MapData, MapNode, MapEdge, DialogueSum
 import { AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
 import { MAP_UPDATE_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
 import { ai } from './geminiClient';
+import { isApiConfigured } from './apiClient';
 import { formatKnownPlacesForPrompt } from '../utils/promptFormatters/map';
 import { isValidAIMapUpdatePayload } from '../utils/mapUpdateValidationUtils';
 import { structuredCloneGameState } from '../utils/cloneUtils';
@@ -83,7 +84,7 @@ export const updateMapFromAIData_Service = async (
   allKnownMainMapNodesForTheme: MapNode[],
   previousMapNodeId: string | null
 ): Promise<MapUpdateServiceResult | null> => {
-  if (!process.env.API_KEY) {
+  if (!isApiConfigured()) {
     console.error("API Key not configured for Map Update Service.");
     return null;
   }

--- a/services/saveConverters/index.ts
+++ b/services/saveConverters/index.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_PLAYER_GENDER
 } from '../../constants';
 import { fetchCorrectedCharacterDetails_Service, fetchCorrectedLocalPlace_Service } from '../corrections';
+import { isApiConfigured } from '../apiClient';
 import {
   DEFAULT_K_REPULSION,
   DEFAULT_K_SPRING,
@@ -232,7 +233,7 @@ export async function convertV1toV2Intermediate(v1Data: V1SavedGameState): Promi
     let lastKnownLocation: string | null = null;
     let preciseLocation: string | null = null;
 
-    if (charThemeObj && process.env.API_KEY) {
+    if (charThemeObj && isApiConfigured()) {
       const relevantMapNodesForCharThemeContext = v1ConvertedMapNodes.filter(node => node.themeName === charThemeObj!.name);
       const sceneContextForChar = (v1Data.currentThemeName === v1Char.themeName) ? v1Data.currentScene : undefined;
       const logContextForChar = (v1Data.currentThemeName === v1Char.themeName) ? v1Data.lastActionLog : undefined;


### PR DESCRIPTION
## Summary
- create `apiClient` to manage Gemini API key
- expose configured client through `geminiClient`
- update services and components to use new API key helper

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68406843658c8324b9d03c89b141db49