### PR TITLE
Add JSDoc summaries for exported components

### DIFF
--- a/components/ConfirmationDialog.tsx
+++ b/components/ConfirmationDialog.tsx
@@ -14,10 +14,13 @@ interface ConfirmationDialogProps {
   onCancel: () => void;
   confirmText?: string;
   cancelText?: string;
-  confirmButtonClass?: string; 
+  confirmButtonClass?: string;
   isCustomModeShift?: boolean; // New prop
 }
 
+/**
+ * Modal dialog prompting the user to confirm or cancel an action.
+ */
 const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   isOpen,
   title,

--- a/components/CustomGameSetupScreen.tsx
+++ b/components/CustomGameSetupScreen.tsx
@@ -17,6 +17,9 @@ interface CustomGameSetupScreenProps {
   descriptionText?: string; // Optional: Custom description text
 }
 
+/**
+ * Lets the player pick starting themes for a custom game.
+ */
 const CustomGameSetupScreen: React.FC<CustomGameSetupScreenProps> = ({
   isVisible,
   onClose,

--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -18,6 +18,9 @@ interface DebugViewProps {
 
 type DebugTab = "GameState" | "MainAI" | "MapLocationAI" | "Inventory" | "Characters" | "MapDataFull" | "ThemeHistory" | "GameLog" | "MiscState";
 
+/**
+ * Developer-only panel for inspecting and manipulating game state.
+ */
 const DebugView: React.FC<DebugViewProps> = ({ isVisible, onClose, debugPacket, gameStateStack, onUndoTurn }) => {
   const [activeTab, setActiveTab] = useState<DebugTab>("GameState");
   const [showMainAIRaw, setShowMainAIRaw] = useState<boolean>(true);

--- a/components/DialogueDisplay.tsx
+++ b/components/DialogueDisplay.tsx
@@ -23,6 +23,9 @@ interface DialogueDisplayProps {
   loadingReason: LoadingReason | null; // Added prop
 }
 
+/**
+ * Renders dialogue history and available dialogue options.
+ */
 const DialogueDisplay: React.FC<DialogueDisplayProps> = ({
   isVisible,
   onClose,

--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -10,6 +10,9 @@ interface ErrorDisplayProps {
   onRetry?: () => void;
 }
 
+/**
+ * Renders a flashing error message with an optional retry button.
+ */
 const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ message, onRetry }) => (
   <div className="bg-red-800 border border-red-600 text-red-100 p-6 rounded-lg shadow-xl my-4 animate-pulse">
     <div className="flex items-center mb-2">

--- a/components/GameLogDisplay.tsx
+++ b/components/GameLogDisplay.tsx
@@ -10,6 +10,9 @@ interface GameLogDisplayProps {
   messages: string[];
 }
 
+/**
+ * Shows a scrollable log of important game events.
+ */
 const GameLogDisplay: React.FC<GameLogDisplayProps> = ({ messages }) => {
   const logEndRef = useRef<null | HTMLDivElement>(null);
   return (

--- a/components/ImageVisualizer.tsx
+++ b/components/ImageVisualizer.tsx
@@ -28,6 +28,9 @@ interface ImageVisualizerProps {
   cachedImageScene: string | null;
 }
 
+/**
+ * Requests and displays AI-generated imagery for the current scene.
+ */
 const ImageVisualizer: React.FC<ImageVisualizerProps> = ({
   currentSceneDescription,
   currentTheme, // This is now AdventureTheme | null

--- a/components/InfoDisplay.tsx
+++ b/components/InfoDisplay.tsx
@@ -11,6 +11,9 @@ interface InfoDisplayProps {
   onClose: () => void;
 }
 
+/**
+ * Shows build and version information in a modal window.
+ */
 const InfoDisplay: React.FC<InfoDisplayProps> = ({ isVisible, onClose }) => {
   const textModel = GEMINI_MODEL_NAME; // from constants.ts
   const imageModel = "imagen-3.0-generate-002"; // from ImageVisualizer.tsx

--- a/components/InventoryDisplay.tsx
+++ b/components/InventoryDisplay.tsx
@@ -16,6 +16,9 @@ interface InventoryDisplayProps {
 
 type SortOrder = 'default' | 'name' | 'type';
 
+/**
+ * Displays the item type label with theme-based coloring.
+ */
 export const ItemTypeDisplay: React.FC<{ type: Item['type'] }> = ({ type }) => {
   let color = 'text-slate-400'; // Default
   if (type === 'single-use') color = 'text-red-400';
@@ -27,10 +30,13 @@ export const ItemTypeDisplay: React.FC<{ type: Item['type'] }> = ({ type }) => {
   else if (type === 'vehicle') color = 'text-indigo-400';
   else if (type === 'knowledge') color = 'text-purple-400';
   else if (type === 'status effect') color = 'text-pink-400';
-  
+
   return <span className={`text-xs italic ${color}`}>{type}</span>;
 };
 
+/**
+ * Shows the player's inventory and handles item interactions.
+ */
 const InventoryDisplay: React.FC<InventoryDisplayProps> = ({ items, onItemInteract, onDiscardJunkItem, disabled }) => {
   const [newlyAddedItemNames, setNewlyAddedItemNames] = useState<Set<string>>(new Set());
   const prevItemsRef = useRef<Item[]>(items);

--- a/components/ItemChangeAnimator.tsx
+++ b/components/ItemChangeAnimator.tsx
@@ -70,7 +70,9 @@ const areItemsEffectivelyIdentical = (item1?: Item, item2?: Item): boolean => {
   return areKnownUsesEffectivelyIdentical(item1.knownUses, item2.knownUses);
 };
 
-
+/**
+ * Animates item gains, losses, and transformations over time.
+ */
 const ItemChangeAnimator: React.FC<ItemChangeAnimatorProps> = ({
   lastTurnChanges,
   isGameBusy,

--- a/components/KnowledgeBase.tsx
+++ b/components/KnowledgeBase.tsx
@@ -20,6 +20,9 @@ interface GroupedEntities {
   };
 }
 
+/**
+ * Lists discovered characters grouped by their associated theme.
+ */
 const KnowledgeBase: React.FC<KnowledgeBaseProps> = ({
   allCharacters,
   currentTheme, // This is now AdventureTheme | null

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -7,9 +7,12 @@ import React from 'react';
 import { LoadingReason } from '../types'; // Import LoadingReason
 
 interface LoadingSpinnerProps {
-  loadingReason?: LoadingReason; 
+  loadingReason?: LoadingReason;
 }
 
+/**
+ * Displays a spinner with a reason message while the game is busy.
+ */
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ loadingReason }) => {
   const spinnerBaseClass = "rounded-full h-16 w-16 border-t-4 border-b-4";
   const spinnerClass = `${spinnerBaseClass} animate-spin border-sky-600`;

--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -24,6 +24,9 @@ interface MainToolbarProps {
   turnsSinceLastShift: number;
 }
 
+/**
+ * Provides quick-access buttons for common game actions.
+ */
 const MainToolbar: React.FC<MainToolbarProps> = ({
   score,
   isLoading,

--- a/components/MapDisplay.tsx
+++ b/components/MapDisplay.tsx
@@ -32,6 +32,9 @@ interface MapDisplayProps {
   onClose: () => void;
 }
 
+/**
+ * Renders the interactive map with controls for layout tweaking.
+ */
 const MapDisplay: React.FC<MapDisplayProps> = ({
   mapData,
   currentThemeName,

--- a/components/SceneDisplay.tsx
+++ b/components/SceneDisplay.tsx
@@ -19,10 +19,13 @@ interface SceneDisplayProps {
   currentThemeName: string | null;
   objectiveAnimationType?: 'success' | 'neutral' | null; 
   localTime?: string | null; 
-  localEnvironment?: string | null; 
+  localEnvironment?: string | null;
   localPlace?: string | null;
 }
 
+/**
+ * Displays the current scene description and quest objectives.
+ */
 const SceneDisplay: React.FC<SceneDisplayProps> = ({
   description,
   mainQuest,

--- a/components/SettingsDisplay.tsx
+++ b/components/SettingsDisplay.tsx
@@ -21,6 +21,9 @@ interface SettingsDisplayProps {
   isCustomGameMode: boolean;
 }
 
+/**
+ * Screen for tweaking player and gameplay settings.
+ */
 const SettingsDisplay: React.FC<SettingsDisplayProps> = ({
   isVisible,
   onClose,

--- a/components/ThemeMemoryDisplay.tsx
+++ b/components/ThemeMemoryDisplay.tsx
@@ -15,7 +15,10 @@ interface ThemeMemoryDisplayProps {
   onClose: () => void;
 }
 
-const ThemeMemoryDisplay: React.FC<ThemeMemoryDisplayProps> = ({ 
+/**
+ * Displays a history of themes the player has explored.
+ */
+const ThemeMemoryDisplay: React.FC<ThemeMemoryDisplayProps> = ({
   themeHistory, 
   isVisible, 
   onClose,

--- a/components/TitleMenu.tsx
+++ b/components/TitleMenu.tsx
@@ -17,6 +17,9 @@ interface TitleMenuProps {
   isGameActive: boolean;
 }
 
+/**
+ * Main title screen offering game start and load options.
+ */
 const TitleMenu: React.FC<TitleMenuProps> = ({
   isVisible,
   onClose,

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -5,36 +5,42 @@
  */
 import React from 'react';
 
+/** Renders a restart arrow icon. */
 export const RestartIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
   </svg>
 );
 
+/** Icon used for performing a manual reality shift. */
 export const RealityShiftIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L1.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.25 12L17 13.75l-1.25-1.75L13.5 12l1.25-1.25L16 9l1.25 1.75L18.25 12zM16 16.75l.813 2.846L15 18.75l-.813 2.846L13.375 18.75l-1.5.938L14.063 18l-1.188-1.5.938-1.5 1.188 1.5-1.188 1.5z" />
   </svg>
 );
 
+/** Icon for saving game progress. */
 export const SaveIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
   </svg>
 );
 
+/** Icon for loading a saved game. */
 export const LoadIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
   </svg>
 );
 
+/** Icon showing an in-game currency coin. */
 export const CoinIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M14.25 7.756a4.5 4.5 0 1 0 0 8.488M7.5 10.5h5.25m-5.25 3h5.25M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
   </svg>
 );
 
+/** Icon button for opening the visualizer. */
 export const VisualizeIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
@@ -42,55 +48,63 @@ export const VisualizeIcon: React.FC<{ className?: string }> = ({ className = "w
   </svg>
 );
 
+/** Icon representing the knowledge base book. */
 export const BookOpenIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6-2.292m0 0V3.75m0 16.5V18" />
   </svg>
 );
 
+/** Icon for toggling menus. */
 export const MenuIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
   </svg>
 );
 
+/** Icon that opens the info modal. */
 export const InfoIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
   </svg>
 );
 
+/** Icon representing stored theme memories. */
 export const ScrollIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
   </svg>
 );
 
+/** Icon used to open the map view. */
 export const MapIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className={className}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.447 2.724A1 1 0 0021 16.382V5.618a1 1 0 00-.553-.894L15 2m-6 5l6-3m0 0l6 3m-6-3v10" />
   </svg>
 );
 
-
+/** Icon representing the player's inventory. */
 export const InventoryIcon: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 inline-block text-amber-400" viewBox="0 0 20 20" fill="currentColor">
     <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v2h2a2 2 0 012 2v8a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h2V4zm0 4v10h10V8H5zm2-2h6V4H7v2z" />
   </svg>
 );
 
+/** Trash can icon for discarding items. */
 export const TrashIcon: React.FC<{ className?: string }> = ({ className = "w-4 h-4 inline-block mr-1" }) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
       <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12.56 0c1.153 0 2.243.032 3.223.094M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
     </svg>
 );
 
+/** Icon representing the game log. */
 export const LogIcon: React.FC = () => (
  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 inline-block text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
   <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
 </svg>
 );
 
+/** Icon used to view memory-related information. */
 export const MemoryIcon: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 inline-block text-purple-400" viewBox="0 0 20 20" fill="currentColor">
     <path fillRule="evenodd" d="M7 2a1 1 0 00-.707 1.707L7 4.414v3.272a1 1 0 102 0V4.414l.707-.707A1 1 0 009 2H7zm0 14a1 1 0 00.707-1.707L7 13.586V10.31a1 1 0 10-2 0v3.272l-.707.707A1 1 0 007 16h2a1 1 0 100-2H7zM3.293 7.293a1 1 0 010-1.414L4.586 4.586a1 1 0 011.414 0l1.293 1.293a1 1 0 01-1.414 1.414L4.586 5.707 3.293 7.021a1 1 0 010 .273zM12.979 15.293a1 1 0 010-1.414L14.272 12.586a1 1 0 011.414 0l1.293 1.293a1 1 0 01-1.414 1.414L14.272 13.707l-1.293 1.293a1 1 0 010 .273zM5 10a1 1 0 110-2h10a1 1 0 110 2H5z" clipRule="evenodd" />
@@ -98,12 +112,14 @@ export const MemoryIcon: React.FC = () => (
   </svg>
 );
 
+/** Icon representing a companion character. */
 export const CompanionIcon: React.FC<{ className?: string }> = ({ className = "h-4 w-4 inline-block mr-1 text-green-400" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className={className}>
     <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
   </svg>
 );
 
+/** Icon indicating a nearby NPC. */
 export const NearbyNPCIcon: React.FC<{ className?: string }> = ({ className = "h-4 w-4 inline-block mr-1 text-sky-400" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className={className}>
     <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />

--- a/components/map/MapControls.tsx
+++ b/components/map/MapControls.tsx
@@ -48,6 +48,9 @@ const renderParameterControl = (
   </div>
 );
 
+/**
+ * Collapsible panel for adjusting map layout parameters.
+ */
 const MapControls: React.FC<MapControlsProps> = props => {
   const [expanded, setExpanded] = useState(false);
   const {

--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -73,6 +73,9 @@ const splitTextIntoLines = (text: string, maxCharsPerLine: number, maxLines: num
   return lines;
 };
 
+/**
+ * SVG view for rendering map nodes and edges with tooltips.
+ */
 const MapNodeView: React.FC<MapNodeViewProps> = ({ nodes, edges, currentMapNodeId, layoutIdealEdgeLength }) => {
   const interactions = useMapInteractions();
   const { svgRef, viewBox, handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave, handleWheel, handleTouchStart, handleTouchMove, handleTouchEnd } = interactions;


### PR DESCRIPTION
## Summary
- document each exported component in `components/` with a short JSDoc comment
- provide comments for all icon components too

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68407dd8a3748324846b149c5545dc91