### PR TITLE
Add debug flow logs

### DIFF
--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -39,6 +39,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
   } = props;
 
   const handleDialogueOptionSelect = useCallback(async (option: string) => {
+    console.log('[DEBUG FLOW] Dialogue option selected:', option);
     const currentFullState = getCurrentGameState();
     const currentThemeObj = currentFullState.currentThemeObject;
 
@@ -88,6 +89,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
           option,
           stateAfterPlayerChoice.dialogueState!.participants
         );
+        console.log('[DEBUG FLOW] Dialogue turn data received:', turnData);
 
         const latestStateAfterFetch = getCurrentGameState();
         if (turnData && latestStateAfterFetch.dialogueState) {
@@ -109,6 +111,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
             lastTurnChanges: null,
           };
           commitGameState(stateWithNpcResponse);
+          console.log('[DEBUG FLOW] NPC responses processed and state committed.');
 
           if (turnData.dialogueEnds) {
             await initiateDialogueExit(stateWithNpcResponse);
@@ -123,6 +126,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
         }
       } catch (e) {
         console.error('Error during dialogue turn:', e);
+        console.log('[DEBUG FLOW] Error occurred while fetching dialogue turn');
         setError('An error occurred in the conversation. You might need to end it.');
         const stateToRevertToOnError = getCurrentGameState();
         if (stateToRevertToOnError.dialogueState) {
@@ -143,6 +147,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
         if (stillInActiveNonExitingDialogue) {
           setIsLoading(false);
           setLoadingReason(null);
+          console.log('[DEBUG FLOW] Dialogue turn complete, awaiting player choice');
         }
       }
     }

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -103,6 +103,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     ) => {
       const { baseStateSnapshot, isFromDialogueSummary = false, scoreChangeFromAction = 0 } = options;
 
+      console.log('[DEBUG FLOW] processAiResponse called. isFromDialogueSummary:', isFromDialogueSummary);
+
       const turnChanges: TurnChanges = {
         itemChanges: [],
         characterChanges: [],
@@ -118,6 +120,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       };
 
       if (!aiData) {
+        console.log('[DEBUG FLOW] processAiResponse: aiData is null or invalid.');
         setError('The Dungeon Master\'s connection is unstable... (Invalid AI response after retries)');
         if (!isFromDialogueSummary && 'actionOptions' in draftState) {
           draftState.actionOptions = [
@@ -254,6 +257,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       }
 
       if ('dialogueSetup' in aiData && aiData.dialogueSetup) {
+        console.log('[DEBUG FLOW] Valid dialogueSetup detected. Starting dialogue with:', aiData.dialogueSetup.participants);
         draftState.actionOptions = [];
         draftState.dialogueState = {
           participants: aiData.dialogueSetup.participants,
@@ -265,6 +269,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       }
 
       draftState.lastTurnChanges = turnChanges;
+      console.log('[DEBUG FLOW] processAiResponse completed.');
     }, [loadingReason, setLoadingReason, setError, setGameStateStack]);
 
   /**
@@ -274,6 +279,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
    */
   const executePlayerAction = useCallback(
     async (action: string, isFreeForm: boolean = false) => {
+      console.log('[DEBUG FLOW] executePlayerAction start:', action);
       const currentFullState = getCurrentGameState();
       if (isLoading || currentFullState.dialogueState) return;
 
@@ -333,6 +339,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       let encounteredError = false;
       try {
         const response = await executeAIMainTurn(prompt, currentThemeObj.systemInstructionModifier);
+        console.log('[DEBUG FLOW] AI raw response received.');
         if (draftState.lastDebugPacket) draftState.lastDebugPacket.rawResponseText = response.text ?? null;
 
         const currentThemeMapDataForParse = {
@@ -356,10 +363,13 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           currentFullState.inventory
         );
 
+        console.log('[DEBUG FLOW] AI response parsed:', parsedData);
+
         await processAiResponse(parsedData, currentThemeObj, draftState, { baseStateSnapshot, scoreChangeFromAction });
       } catch (e: any) {
         encounteredError = true;
         console.error('Error executing player action:', e);
+        console.log('[DEBUG FLOW] executePlayerAction encountered error');
         setError(`The Dungeon Master's connection seems unstable. Error: (${e.message || 'Unknown AI error'}). Please try again or consult the game log.`);
         draftState = structuredCloneGameState(baseStateSnapshot);
         draftState.lastActionLog = `Your action ("${action}") caused a ripple in reality, but the outcome is obscured.`;
@@ -372,6 +382,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           draftState.globalTurnNumber += 1;
         }
         commitGameState(draftState);
+        console.log('[DEBUG FLOW] executePlayerAction finished and state committed');
         setIsLoading(false);
         setLoadingReason(null);
 


### PR DESCRIPTION
## Summary
- add `[DEBUG FLOW]` console messages to track conversation logic
- log dialogue turn events for debugging

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68408eb5b22c8324873d3fe4125630f8