### PR TITLE
Improve new game start UX

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -291,11 +291,16 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
       processAiResponse,
     ]);
 
-  /** Starts a completely new game. */
+  /**
+   * Starts a completely new game.
+   * The current state is cleared immediately so the UI does not display stale
+   * information while the initial turn is loading.
+   */
   const handleStartNewGameFromButton = useCallback(() => {
+    commitGameState(getInitialGameStates());
     setHasGameBeenInitialized(false);
     loadInitialGame({ isRestart: true, customGameFlag: false });
-  }, [loadInitialGame, setHasGameBeenInitialized]);
+  }, [loadInitialGame, setHasGameBeenInitialized, commitGameState]);
 
   /** Starts a custom game using the provided theme name. */
   const startCustomGame = useCallback(

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -45,6 +45,10 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   const [freeFormActionText, setFreeFormActionText] = useState<string>('');
   const [hasGameBeenInitialized, setHasGameBeenInitialized] = useState<boolean>(false);
 
+  // Tracks whether a saved game from app initialization has already been
+  // applied to prevent re-loading it when starting a new game.
+  const hasLoadedInitialSave = useRef<boolean>(false);
+
   const triggerShiftRef = useRef<(c?: boolean) => void>(() => {});
   const manualShiftRef = useRef<() => void>(() => {});
   const loadInitialGameRef = useRef<(opts: any) => void>(() => {});
@@ -157,10 +161,14 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   });
 
   useEffect(() => {
-    if (isAppReady && !hasGameBeenInitialized) {
-      if (initialSavedStateFromApp) {
-        loadInitialGame({ savedStateToLoad: initialSavedStateFromApp });
-      }
+    if (
+      isAppReady &&
+      !hasGameBeenInitialized &&
+      initialSavedStateFromApp &&
+      !hasLoadedInitialSave.current
+    ) {
+      loadInitialGame({ savedStateToLoad: initialSavedStateFromApp });
+      hasLoadedInitialSave.current = true;
     }
   }, [isAppReady, hasGameBeenInitialized, initialSavedStateFromApp, loadInitialGame]);
 


### PR DESCRIPTION
## Summary
- clear game state instantly when starting a new game
- prevent reloading previous saved state after new game

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840a18ad0e08324b9f7afb91a9bdebe