### PR TITLE
Ensure stack cleared on new game

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -19,7 +19,10 @@ import {
   formatNewThemePostShiftPrompt,
   formatReturnToThemePostShiftPrompt,
 } from '../utils/promptFormatters/dialogue';
-import { getInitialGameStates } from '../utils/initialStates';
+import {
+  getInitialGameStates,
+  getInitialGameStatesWithSettings
+} from '../utils/initialStates';
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { getDefaultMapLayoutConfig } from './useMapUpdates';
 import { ProcessAiResponseFn } from './usePlayerActions';
@@ -47,6 +50,7 @@ export interface UseGameInitializationProps {
   ) => void;
   getCurrentGameState: () => FullGameState;
   commitGameState: (state: FullGameState) => void;
+  resetGameStateStack: (state: FullGameState) => void;
   processAiResponse: ProcessAiResponseFn;
 }
 
@@ -67,6 +71,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
     onSettingsUpdateFromLoad,
     getCurrentGameState,
     commitGameState,
+    resetGameStateStack,
     processAiResponse,
   } = props;
 
@@ -297,26 +302,71 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
    * information while the initial turn is loading.
    */
   const handleStartNewGameFromButton = useCallback(() => {
-    commitGameState(getInitialGameStates());
+    const blankState = getInitialGameStatesWithSettings(
+      playerGenderProp,
+      enabledThemePacksProp,
+      stabilityLevelProp,
+      chaosLevelProp
+    );
+    resetGameStateStack(blankState);
     setHasGameBeenInitialized(false);
     loadInitialGame({ isRestart: true, customGameFlag: false });
-  }, [loadInitialGame, setHasGameBeenInitialized, commitGameState]);
+  }, [
+    loadInitialGame,
+    setHasGameBeenInitialized,
+    resetGameStateStack,
+    playerGenderProp,
+    enabledThemePacksProp,
+    stabilityLevelProp,
+    chaosLevelProp,
+  ]);
 
   /** Starts a custom game using the provided theme name. */
   const startCustomGame = useCallback(
     (themeName: string) => {
+      const blankState = getInitialGameStatesWithSettings(
+        playerGenderProp,
+        enabledThemePacksProp,
+        stabilityLevelProp,
+        chaosLevelProp
+      );
+      resetGameStateStack(blankState);
       setHasGameBeenInitialized(false);
       loadInitialGame({ explicitThemeName: themeName, isRestart: true, customGameFlag: true });
     },
-    [loadInitialGame, setHasGameBeenInitialized]
+    [
+      loadInitialGame,
+      setHasGameBeenInitialized,
+      resetGameStateStack,
+      playerGenderProp,
+      enabledThemePacksProp,
+      stabilityLevelProp,
+      chaosLevelProp,
+    ]
   );
 
   /** Restarts the game from scratch. */
   const executeRestartGame = useCallback(() => {
     setError(null);
+    const blankState = getInitialGameStatesWithSettings(
+      playerGenderProp,
+      enabledThemePacksProp,
+      stabilityLevelProp,
+      chaosLevelProp
+    );
+    resetGameStateStack(blankState);
     setHasGameBeenInitialized(false);
     loadInitialGame({ isRestart: true, customGameFlag: false });
-  }, [loadInitialGame, setError, setHasGameBeenInitialized]);
+  }, [
+    loadInitialGame,
+    setError,
+    setHasGameBeenInitialized,
+    resetGameStateStack,
+    playerGenderProp,
+    enabledThemePacksProp,
+    stabilityLevelProp,
+    chaosLevelProp,
+  ]);
 
   /** Retry helper used when an error occurred in the main logic. */
   const handleRetry = useCallback(() => {

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -58,6 +58,13 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     setGameStateStack(prev => [newGameState, prev[0]]);
   }, []);
 
+  /**
+   * Replaces the entire game state stack with a blank state.
+   */
+  const resetGameStateStack = useCallback((newState: FullGameState) => {
+    setGameStateStack([newState, newState]);
+  }, []);
+
   const { handleMapLayoutConfigChange } = useMapUpdates({ setGameStateStack });
 
   const {
@@ -129,6 +136,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     onSettingsUpdateFromLoad,
     getCurrentGameState,
     commitGameState,
+    resetGameStateStack,
     processAiResponse,
   });
   loadInitialGameRef.current = loadInitialGame;

--- a/utils/initialStates.ts
+++ b/utils/initialStates.ts
@@ -5,9 +5,10 @@
  * @description Provides functions creating initial game states.
  */
 import {
-  FullGameState, 
-  MapData, 
-  MapLayoutConfig
+  FullGameState,
+  MapData,
+  MapLayoutConfig,
+  ThemePackName
 } from '../types';
 import { 
     CURRENT_SAVE_GAME_VERSION, 
@@ -74,4 +75,21 @@ export const getInitialGameStates = (): FullGameState => {
     stabilityLevel: DEFAULT_STABILITY_LEVEL,
     chaosLevel: DEFAULT_CHAOS_LEVEL,
   };
+};
+
+/**
+ * Returns a blank game state populated with the provided settings.
+ */
+export const getInitialGameStatesWithSettings = (
+  playerGender: string,
+  enabledThemePacks: ThemePackName[],
+  stabilityLevel: number,
+  chaosLevel: number
+): FullGameState => {
+  const base = getInitialGameStates();
+  base.playerGender = playerGender;
+  base.enabledThemePacks = [...enabledThemePacks];
+  base.stabilityLevel = stabilityLevel;
+  base.chaosLevel = chaosLevel;
+  return base;
 };


### PR DESCRIPTION
## Summary
- keep settings when generating blank game state
- reset the entire game stack when starting, restarting or launching a custom game

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840ac651aa483249635421b59e94d79