### PR TITLE
Implement map hierarchy generation

### DIFF
--- a/prompts/mapPrompts.ts
+++ b/prompts/mapPrompts.ts
@@ -144,3 +144,16 @@ CRITICAL INSTRUCTIONS:
 - Base your refinements on the context of MainNodeA, MainNodeB, the leaf suggestions, the edge details, and the overall game context.
 - The goal is to make these temporary connections feel like natural, integrated parts of the map.
 `;
+
+export const MAP_HIERARCHY_SYSTEM_INSTRUCTION = `
+You are an AI assistant generating hierarchical map nodes for a text adventure game.
+Given context about the player's current location and theme, return a JSON array describing
+locations from the broadest region down to the player's specific position.
+Each entry should have:
+  "placeName": string,
+  "description": string,
+  "aliases": ["string"],
+  "nodeType": ${VALID_NODE_TYPES_FOR_MAP_AI},
+  "status": ${VALID_NODE_STATUSES_FOR_MAP_AI},
+  "parentPlaceName"?: string|null
+The first entry must have parentPlaceName null. Respond ONLY with the JSON array.`;

--- a/services/mapHierarchyService.ts
+++ b/services/mapHierarchyService.ts
@@ -1,0 +1,104 @@
+/**
+ * @file mapHierarchyService.ts
+ * @description Service for generating hierarchical map nodes for a new theme.
+ */
+
+import { GenerateContentResponse } from '@google/genai';
+import { AdventureTheme, MapEdge, MapEdgeData, MapNode, MapNodeData } from '../types';
+import { AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
+import { MAP_HIERARCHY_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
+import { ai } from './geminiClient';
+import { isApiConfigured } from './apiClient';
+
+interface RawHierarchyNode {
+  placeName: string;
+  description: string;
+  aliases?: string[];
+  nodeType: NonNullable<MapNodeData['nodeType']>;
+  status: MapNodeData['status'];
+  parentPlaceName?: string | null;
+}
+
+export interface MapHierarchyResult {
+  nodes: MapNode[];
+  edges: MapEdge[];
+  debugInfo: { prompt: string; rawResponse: string };
+}
+
+/**
+ * Calls Gemini to generate a hierarchy of locations from the player's current position.
+ */
+export const fetchMapHierarchyFromLocation_Service = async (
+  localPlace: string,
+  sceneDescription: string | null,
+  currentTheme: AdventureTheme
+): Promise<MapHierarchyResult | null> => {
+  if (!isApiConfigured()) {
+    console.error('MapHierarchyService: API Key not configured.');
+    return null;
+  }
+
+  const prompt = `
+Theme: "${currentTheme.name}"
+Theme Guidance: ${currentTheme.systemInstructionModifier}
+Player Location: "${localPlace}"
+Scene Description: "${sceneDescription || ''}"
+Provide an array of location objects from largest region down to the player's location.`;
+
+  const debugInfo: MapHierarchyResult['debugInfo'] = { prompt, rawResponse: '' };
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response: GenerateContentResponse = await ai.models.generateContent({
+        model: AUXILIARY_MODEL_NAME,
+        contents: prompt,
+        config: {
+          systemInstruction: MAP_HIERARCHY_SYSTEM_INSTRUCTION,
+          responseMimeType: 'application/json',
+          temperature: 0.75,
+        },
+      });
+
+      debugInfo.rawResponse = response.text ?? '';
+      const cleaned = debugInfo.rawResponse.trim().replace(/^```json\s*|\s*```$/g, '');
+      const parsed = JSON.parse(cleaned);
+      if (Array.isArray(parsed)) {
+        const newNodes: MapNode[] = [];
+        const newEdges: MapEdge[] = [];
+        const idMap: Record<string, string> = {};
+        parsed.forEach((obj: RawHierarchyNode) => {
+          const base = obj.placeName.replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
+          const id = `${currentTheme.name}_${base}_${Date.now() % 10000}_${Math.random().toString(36).substring(2, 7)}`;
+          idMap[obj.placeName] = id;
+          const nodeData: MapNodeData = {
+            description: obj.description,
+            aliases: obj.aliases || [],
+            status: obj.status,
+            isLeaf: obj.nodeType === 'feature' || obj.nodeType === 'room',
+            nodeType: obj.nodeType,
+          };
+          newNodes.push({ id, themeName: currentTheme.name, placeName: obj.placeName, position: { x: 0, y: 0 }, data: nodeData });
+        });
+        parsed.forEach((obj: RawHierarchyNode) => {
+          if (obj.parentPlaceName) {
+            const childId = idMap[obj.placeName];
+            const parentId = idMap[obj.parentPlaceName];
+            if (childId && parentId) {
+              const edgeId = `${childId}_${parentId}_containment`;
+              const edgeData: MapEdgeData = { type: 'containment', status: 'open' };
+              newEdges.push({ id: edgeId, sourceNodeId: parentId, targetNodeId: childId, data: edgeData });
+              const childNode = newNodes.find(n => n.id === childId);
+              if (childNode) childNode.data.parentNodeId = parentId;
+            }
+          }
+        });
+        return { nodes: newNodes, edges: newEdges, debugInfo };
+      }
+    } catch (e) {
+      console.error(`MapHierarchyService attempt ${attempt + 1} failed:`, e);
+    }
+  }
+
+  return null;
+};
+


### PR DESCRIPTION
## Summary
- add system prompt for hierarchical map generation
- implement new `mapHierarchyService` to fetch parent nodes
- fetch hierarchy during new theme initialization
- render large region circles in `MapNodeView`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840c1026c1083249b00a894718ccfa2