### PR TITLE
Add nested circle map layout

### DIFF
--- a/components/MapDisplay.tsx
+++ b/components/MapDisplay.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { MapData, MapNode, MapEdge, MapLayoutConfig } from '../types';
 import {
   applyBasicLayoutAlgorithm,
+  applyNestedCircleLayout,
   LayoutForceConstants,
   DEFAULT_K_REPULSION,
   DEFAULT_K_SPRING,
@@ -45,6 +46,7 @@ const MapDisplay: React.FC<MapDisplayProps> = ({
   onClose,
 }) => {
   const [displayedNodes, setDisplayedNodes] = useState<MapNode[]>([]);
+  const [isNestedView, setIsNestedView] = useState(false);
 
   const [layoutKRepulsion, setLayoutKRepulsion] = useState(initialLayoutConfig?.K_REPULSION ?? DEFAULT_K_REPULSION);
   const [layoutKSpring, setLayoutKSpring] = useState(initialLayoutConfig?.K_SPRING ?? DEFAULT_K_SPRING);
@@ -109,6 +111,12 @@ const MapDisplay: React.FC<MapDisplayProps> = ({
   /** Prepares nodes for layout and runs the force algorithm. */
   const runLayout = useCallback(() => {
     const nodesToProcess = [...currentThemeNodes];
+
+    if (isNestedView) {
+      const nestedNodes = applyNestedCircleLayout(nodesToProcess);
+      setDisplayedNodes(nestedNodes);
+      return;
+    }
     const newPositions: { [id: string]: { x: number; y: number } } = {};
 
     nodesToProcess.forEach(node => {
@@ -172,7 +180,7 @@ const MapDisplay: React.FC<MapDisplayProps> = ({
     } else {
       setDisplayedNodes(preparedNodes);
     }
-  }, [currentThemeNodes, currentThemeEdges, layoutIterations, layoutKRepulsion, layoutKSpring, layoutIdealEdgeLength, layoutKCentering, layoutKUntangle, layoutKEdgeNodeRepulsion, layoutDampingFactor, layoutMaxDisplacement]);
+  }, [currentThemeNodes, currentThemeEdges, layoutIterations, layoutKRepulsion, layoutKSpring, layoutIdealEdgeLength, layoutKCentering, layoutKUntangle, layoutKEdgeNodeRepulsion, layoutDampingFactor, layoutMaxDisplacement, isNestedView]);
 
   useEffect(() => {
     if (isVisible) {
@@ -231,6 +239,8 @@ const MapDisplay: React.FC<MapDisplayProps> = ({
           setLayoutMaxDisplacement={setLayoutMaxDisplacement}
           layoutIterations={layoutIterations}
           setLayoutIterations={setLayoutIterations}
+          isNestedView={isNestedView}
+          onToggleNestedView={() => setIsNestedView(v => !v)}
           onReset={handleResetLayoutToDefaults}
           onRefreshLayout={handleRefreshLayout}
         />

--- a/components/map/MapControls.tsx
+++ b/components/map/MapControls.tsx
@@ -24,6 +24,8 @@ interface MapControlsProps {
   setLayoutMaxDisplacement: (val: number) => void;
   layoutIterations: number;
   setLayoutIterations: (val: number) => void;
+  isNestedView: boolean;
+  onToggleNestedView: () => void;
   onReset: () => void;
   onRefreshLayout: () => void;
 }
@@ -72,6 +74,8 @@ const MapControls: React.FC<MapControlsProps> = props => {
     setLayoutMaxDisplacement,
     layoutIterations,
     setLayoutIterations,
+    isNestedView,
+    onToggleNestedView,
     onReset,
     onRefreshLayout,
   } = props;
@@ -95,6 +99,9 @@ const MapControls: React.FC<MapControlsProps> = props => {
         </div>
       )}
       <div className="map-action-buttons-row">
+        <button onClick={onToggleNestedView} className="map-control-button">
+          {isNestedView ? 'Force Layout' : 'Nested Layout'}
+        </button>
         <button onClick={onRefreshLayout} className="map-control-button">
           Refresh Layout
         </button>

--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -20,8 +20,13 @@ interface MapNodeViewProps {
   layoutIdealEdgeLength: number;
 }
 
-/** Returns circle radius based on nodeType hierarchy. */
+/**
+ * Returns the radius for a node's circle. Uses the computed visualRadius from
+ * nested layouts when available, otherwise falls back to a default based on the
+ * node type.
+ */
 const getRadiusForNode = (node: MapNode): number => {
+  if (node.data.visualRadius) return node.data.visualRadius;
   switch (node.data.nodeType) {
     case 'region':
       return NODE_RADIUS * 1.4;
@@ -107,6 +112,9 @@ const MapNodeView: React.FC<MapNodeViewProps> = ({ nodes, edges, currentMapNodeI
     return nodes
       .filter(parent => nodes.some(n => n.data.parentNodeId === parent.id))
       .map(parent => {
+        if (parent.data.visualRadius) {
+          return { node: parent, radius: parent.data.visualRadius };
+        }
         const children = nodes.filter(n => n.data.parentNodeId === parent.id);
         const maxDistance = children.length > 0
           ? Math.max(

--- a/types.ts
+++ b/types.ts
@@ -273,6 +273,8 @@ export interface MapNodeData {
   isLeaf?: boolean; // If true, it's a detailed feature or connector. Defaults to false.
   parentNodeId?: string; // ID of parent node for hierarchical placement.
   nodeType?: 'region' | 'city' | 'building' | 'room' | 'feature';
+  /** Pre-calculated radius used by nested circle layouts. */
+  visualRadius?: number;
   [key: string]: any; // For any other custom data.
 }
 


### PR DESCRIPTION
## Summary
- support visualRadius in map nodes
- implement applyNestedCircleLayout
- toggle nested layout in map controls
- render node circles with nested sizes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840c9ad38948324a9d52b66ffb473f4