### PR TITLE
Map hierarchy refactor

### DIFF
--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -138,12 +138,13 @@ const MapNodeView: React.FC<MapNodeViewProps> = ({ nodes, edges, currentMapNodeI
     const svgRect = svgRef.current?.getBoundingClientRect();
     if (!svgRect) return;
     let content = `${node.placeName}`;
+    if (node.data.nodeType) content += `\nType: ${node.data.nodeType}`;
     if (node.data.description) content += `\nDescription: ${node.data.description}`;
     if (node.data.aliases && node.data.aliases.length > 0) content += `\nAliases: ${node.data.aliases.join(', ')}`;
     if (node.data.status) content += `\nStatus: ${node.data.status}`;
-    if (node.data.isLeaf && node.data.parentNodeId) {
+    if (node.data.parentNodeId) {
       const parentNode = nodes.find(n => n.id === node.data.parentNodeId);
-      content += `\n(Part of: ${parentNode?.placeName || 'Unknown Location'})`;
+      content += `\n(Parent: ${parentNode?.placeName || 'Unknown Location'})`;
     }
     setTooltip({ content, x: event.clientX - svgRect.left + 15, y: event.clientY - svgRect.top + 15 });
   };

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -279,11 +279,17 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
                 draftState.mapData.nodes.push(n);
               }
             });
-            hierarchy.edges.forEach(e => {
-              if (!draftState.mapData.edges.some(ex => ex.sourceNodeId === e.sourceNodeId && ex.targetNodeId === e.targetNodeId && ex.data.type === e.data.type)) {
-                draftState.mapData.edges.push(e);
-              }
-            });
+
+            // Assign topmost parent to orphan nodes
+            const roots = draftState.mapData.nodes.filter(n => n.themeName === themeObjToLoad.name && !n.data.parentNodeId);
+            if (roots.length > 0) {
+              const topParentId = roots[0].id;
+              draftState.mapData.nodes.forEach(n => {
+                if (n.themeName === themeObjToLoad.name && !n.data.parentNodeId && n.id !== topParentId) {
+                  n.data.parentNodeId = topParentId;
+                }
+              });
+            }
           }
         }
 

--- a/index.css
+++ b/index.css
@@ -370,11 +370,6 @@ body {
   stroke: #ca8a04;
   stroke-dasharray: 5, 2, 2, 2;
 } /* Yellowish, distinct dash */
-.map-edge.containment {
-  stroke: #888;
-  stroke-dasharray: 2, 2;
-  stroke-width: 1.5px;
-}
 
 .map-tooltip {
   position: absolute;

--- a/services/mapHierarchyService.ts
+++ b/services/mapHierarchyService.ts
@@ -64,7 +64,6 @@ Provide an array of location objects from largest region down to the player's lo
       const parsed = JSON.parse(cleaned);
       if (Array.isArray(parsed)) {
         const newNodes: MapNode[] = [];
-        const newEdges: MapEdge[] = [];
         const idMap: Record<string, string> = {};
         parsed.forEach((obj: RawHierarchyNode) => {
           const base = obj.placeName.replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
@@ -84,15 +83,12 @@ Provide an array of location objects from largest region down to the player's lo
             const childId = idMap[obj.placeName];
             const parentId = idMap[obj.parentPlaceName];
             if (childId && parentId) {
-              const edgeId = `${childId}_${parentId}_containment`;
-              const edgeData: MapEdgeData = { type: 'containment', status: 'open' };
-              newEdges.push({ id: edgeId, sourceNodeId: parentId, targetNodeId: childId, data: edgeData });
               const childNode = newNodes.find(n => n.id === childId);
               if (childNode) childNode.data.parentNodeId = parentId;
             }
           }
         });
-        return { nodes: newNodes, edges: newEdges, debugInfo };
+        return { nodes: newNodes, edges: [], debugInfo };
       }
     } catch (e) {
       console.error(`MapHierarchyService attempt ${attempt + 1} failed:`, e);

--- a/utils/mapPruningUtils.ts
+++ b/utils/mapPruningUtils.ts
@@ -43,7 +43,7 @@ export const pruneAndRefineMapConnections = (
   const themeNodeMap = new Map(themeNodes.map(n => [n.id, n]));
 
 
-  // Phase 1: Process M1 -(containment)- L - M2 cases
+  // Phase 1: Process M1 - L - M2 cases based on parent links
   const leafNodesInTheme = themeNodes.filter(node => node.data.isLeaf);
 
   for (const leafL of leafNodesInTheme) {
@@ -52,18 +52,11 @@ export const pruneAndRefineMapConnections = (
     const parentM1 = themeNodeMap.get(leafL.data.parentNodeId);
     if (!parentM1 || parentM1.data.isLeaf) continue; // Parent must be a main node
 
-    // Check for containment edge between M1 and L
-    const containmentEdgeM1L = workingMapData.edges.find(edge =>
-      edge.data.type === 'containment' &&
-      ((edge.sourceNodeId === parentM1.id && edge.targetNodeId === leafL.id) ||
-       (edge.sourceNodeId === leafL.id && edge.targetNodeId === parentM1.id))
-    );
-    if (!containmentEdgeM1L) continue;
+
 
     // Find edges connecting L to another main node M2 (not M1)
     const edgesFromL = workingMapData.edges.filter(edge =>
       (edge.sourceNodeId === leafL.id || edge.targetNodeId === leafL.id) &&
-      edge.data.type !== 'containment' && // Not another containment edge
       !edgesToRemoveIds.has(edge.id) // Not already marked for removal
     );
 
@@ -93,14 +86,7 @@ export const pruneAndRefineMapConnections = (
         workingMapData.nodes.push(tempLeafM2);
         themeNodeMap.set(tempLeafM2_Id, tempLeafM2); // Add to map for current phase
 
-        const containmentEdgeM2_LM2_Id = generateUniqueId(`edge_containM2_`);
-        const containmentEdgeM2_LM2: MapEdge = {
-          id: containmentEdgeM2_LM2_Id,
-          sourceNodeId: mainNodeM2.id,
-          targetNodeId: tempLeafM2.id,
-          data: { type: 'containment', status: 'open', description: `Connects ${mainNodeM2.placeName} to its entry point.` },
-        };
-        workingMapData.edges.push(containmentEdgeM2_LM2);
+
 
         const edge_L_LM2_Id = generateUniqueId(`edge_L_LM2_`);
         const edge_L_LM2: MapEdge = {
@@ -163,14 +149,6 @@ export const pruneAndRefineMapConnections = (
       workingMapData.nodes.push(leafM1);
       themeNodeMap.set(leafM1_Id, leafM1); 
 
-      const containmentEdgeM1_LM1_Id = generateUniqueId(`edge_containM1_`);
-      const containmentEdgeM1_LM1: MapEdge = {
-        id: containmentEdgeM1_LM1_Id,
-        sourceNodeId: sourceNode.id,
-        targetNodeId: leafM1.id,
-        data: { type: 'containment', status: 'open', description: `Connects ${sourceNode.placeName} to its exit point.` },
-      };
-      workingMapData.edges.push(containmentEdgeM1_LM1);
 
       // Create Leaf L_M2 (child of targetNode)
       const tempLeafM2_NameSuggestion = `Entrance to ${targetNode.placeName} from ${sourceNode.placeName}`;
@@ -192,14 +170,6 @@ export const pruneAndRefineMapConnections = (
       workingMapData.nodes.push(leafM2);
       themeNodeMap.set(leafM2_Id, leafM2);
 
-      const containmentEdgeM2_LM2_Id = generateUniqueId(`edge_containM2_`);
-      const containmentEdgeM2_LM2: MapEdge = {
-        id: containmentEdgeM2_LM2_Id,
-        sourceNodeId: targetNode.id,
-        targetNodeId: leafM2.id,
-        data: { type: 'containment', status: 'open', description: `Connects ${targetNode.placeName} to its entry point.` },
-      };
-      workingMapData.edges.push(containmentEdgeM2_LM2);
 
       // Create edge between Leaf L_M1 and Leaf L_M2
       const edgeBetweenLeaves_Id = generateUniqueId(`edge_leaves_`);

--- a/utils/mapUpdateValidationUtils.ts
+++ b/utils/mapUpdateValidationUtils.ts
@@ -7,7 +7,7 @@ import { AIMapUpdatePayload, MapNodeData, MapEdgeData } from '../types'; // AINo
 
 export const VALID_NODE_STATUS_VALUES: ReadonlyArray<MapNodeData['status']> = ['undiscovered', 'discovered', 'rumored', 'quest_target'];
 export const VALID_NODE_TYPE_VALUES: ReadonlyArray<NonNullable<MapNodeData['nodeType']>> = ['region', 'city', 'building', 'room', 'feature'];
-export const VALID_EDGE_TYPE_VALUES: ReadonlyArray<MapEdgeData['type']> = ['path', 'road', 'sea route', 'door', 'teleporter', 'secret_passage', 'river_crossing', 'temporary_bridge', 'boarding_hook', 'containment'];
+export const VALID_EDGE_TYPE_VALUES: ReadonlyArray<MapEdgeData['type']> = ['path', 'road', 'sea route', 'door', 'teleporter', 'secret_passage', 'river_crossing', 'temporary_bridge', 'boarding_hook'];
 export const VALID_EDGE_STATUS_VALUES: ReadonlyArray<MapEdgeData['status']> = ['open', 'accessible', 'closed', 'locked', 'blocked', 'hidden', 'rumored', 'one_way', 'collapsed', 'removed', 'active', 'inactive'];
 
 function isValidAINodeDataInternal(data: any, isNodeAddContext: boolean): boolean {


### PR DESCRIPTION
## Summary
- remove containment edges from map data and layout
- show parent node and nodeType in map tooltips
- default any orphan map nodes to the topmost parent on a new game
- treat parent-child links as layout edges
- drop `containment` from edge validation and styles

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841652412ac83249daf803daba08035