### PR TITLE
Handle map update errors

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -239,15 +239,22 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
 
       let mapAISuggestedNodeIdentifier: string | undefined = undefined;
       if (themeContextForResponse) {
-        mapAISuggestedNodeIdentifier = await handleMapUpdates(
-          aiData,
-          draftState,
-          baseStateSnapshot,
-          themeContextForResponse,
-          loadingReason,
-          setLoadingReason,
-          turnChanges
-        );
+        try {
+          mapAISuggestedNodeIdentifier = await handleMapUpdates(
+            aiData,
+            draftState,
+            baseStateSnapshot,
+            themeContextForResponse,
+            loadingReason,
+            setLoadingReason,
+            turnChanges
+          );
+        } catch (mapErr) {
+          setError(
+            mapErr instanceof Error ? mapErr.message : String(mapErr)
+          );
+          throw mapErr;
+        }
       }
 
       if (aiData.logMessage) {

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -49,6 +49,17 @@ export const handleMapUpdates = async (
     );
     setLoadingReason(originalLoadingReason);
 
+    if (!mapUpdateResult) {
+      throw new Error('Map Update Service returned no data.');
+    }
+    if (!mapUpdateResult.updatedMapData) {
+      const reason =
+        mapUpdateResult.debugInfo?.validationError ||
+        mapUpdateResult.debugInfo?.rawResponse ||
+        'Unknown error';
+      throw new Error(`Map update failed: ${reason}`);
+    }
+
     if (mapUpdateResult) {
       if (mapUpdateResult.updatedMapData && JSON.stringify(draftState.mapData) !== JSON.stringify(mapUpdateResult.updatedMapData)) {
         turnChanges.mapDataChanged = true;


### PR DESCRIPTION
## Summary
- propagate errors from map update service
- catch map update errors in `usePlayerActions`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841a12dacc48324b7864381c1ba17e2