### PR TITLE
Add AI model fallback dispatcher

### DIFF
--- a/services/gameAIService.ts
+++ b/services/gameAIService.ts
@@ -8,6 +8,7 @@ import { GameStateFromAI, Item, ItemChange, AdventureTheme, Character, MapNode }
 import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES, DEFAULT_PLAYER_GENDER } from '../constants';
 import { SYSTEM_INSTRUCTION } from '../prompts/mainPrompts';
 import { ai } from './geminiClient';
+import { dispatchAIRequest } from './modelDispatcher';
 import { isApiConfigured } from './apiClient';
 import { isServerOrClientError } from '../utils/aiErrorUtils';
 
@@ -96,14 +97,14 @@ Do not include any preamble. Just provide the summary text itself.
   for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) { // Extra retry for summarization
     try {
       console.log(`Summarizing adventure for theme "${themeToSummarize.name}" (Attempt ${attempt}/${MAX_RETRIES +1})`);
-      const response = await ai.models.generateContent({
-          model: AUXILIARY_MODEL_NAME, // Will now use gemini-2.5-flash-preview-04-17
-          contents: summarizationPrompt,
-          config: {
+      const response = await dispatchAIRequest(
+          [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+          summarizationPrompt,
+          undefined,
+          {
               temperature: 0.8,
-              // Omit thinkingConfig for higher quality (default enabled)
           }
-      });
+      );
       const text = (response.text ?? '').trim();
       if (text && text.length > 0) {
         return text;

--- a/services/mapHierarchyService.ts
+++ b/services/mapHierarchyService.ts
@@ -5,9 +5,9 @@
 
 import { GenerateContentResponse } from '@google/genai';
 import { AdventureTheme, MapEdge, MapEdgeData, MapNode, MapNodeData } from '../types';
-import { AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
+import { AUXILIARY_MODEL_NAME, MAX_RETRIES, GEMINI_MODEL_NAME } from '../constants';
 import { MAP_HIERARCHY_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
-import { ai } from './geminiClient';
+import { dispatchAIRequest } from './modelDispatcher';
 import { isApiConfigured } from './apiClient';
 
 interface RawHierarchyNode {
@@ -49,15 +49,15 @@ Provide an array of location objects from largest region down to the player's lo
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      const response: GenerateContentResponse = await ai.models.generateContent({
-        model: AUXILIARY_MODEL_NAME,
-        contents: prompt,
-        config: {
-          systemInstruction: MAP_HIERARCHY_SYSTEM_INSTRUCTION,
+      const response: GenerateContentResponse = await dispatchAIRequest(
+        [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        MAP_HIERARCHY_SYSTEM_INSTRUCTION,
+        {
           responseMimeType: 'application/json',
           temperature: 0.75,
-        },
-      });
+        }
+      );
 
       debugInfo.rawResponse = response.text ?? '';
       const cleaned = debugInfo.rawResponse.trim().replace(/^```json\s*|\s*```$/g, '');

--- a/services/mapUpdateService.ts
+++ b/services/mapUpdateService.ts
@@ -6,9 +6,9 @@
  */
 import { GenerateContentResponse } from "@google/genai";
 import { GameStateFromAI, AdventureTheme, MapData, MapNode, MapEdge, DialogueSummaryResponse, MapNodeData, MapEdgeData, AIMapUpdatePayload, AINodeUpdate } from '../types';
-import { AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
+import { AUXILIARY_MODEL_NAME, MAX_RETRIES, GEMINI_MODEL_NAME } from '../constants';
 import { MAP_UPDATE_SYSTEM_INSTRUCTION } from '../prompts/mapPrompts';
-import { ai } from './geminiClient';
+import { dispatchAIRequest } from './modelDispatcher';
 import { isApiConfigured } from './apiClient';
 import { formatKnownPlacesForPrompt } from '../utils/promptFormatters/map';
 import { isValidAIMapUpdatePayload, VALID_NODE_STATUS_VALUES, VALID_NODE_TYPE_VALUES, VALID_EDGE_TYPE_VALUES, VALID_EDGE_STATUS_VALUES } from '../utils/mapUpdateValidationUtils';
@@ -38,16 +38,15 @@ export interface MapUpdateServiceResult {
  * the raw response.
  */
 const callMapUpdateAI = async (prompt: string, systemInstruction: string): Promise<GenerateContentResponse> => {
-  return ai.models.generateContent({
-    model: AUXILIARY_MODEL_NAME, // Will now use gemini-2.5-flash-preview-04-17
-    contents: prompt,
-    config: {
-      systemInstruction: systemInstruction,
+  return dispatchAIRequest(
+    [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+    prompt,
+    systemInstruction,
+    {
       responseMimeType: "application/json",
       temperature: 0.75,
-      // Omit thinkingConfig for higher quality (default enabled)
     }
-  });
+  );
 };
 
 /**

--- a/services/modelDispatcher.ts
+++ b/services/modelDispatcher.ts
@@ -1,0 +1,64 @@
+/**
+ * @file services/modelDispatcher.ts
+ * @description Utility for dispatching AI requests with model fallback support.
+ */
+
+import { GenerateContentResponse } from '@google/genai';
+import { ai } from './geminiClient';
+import { isApiConfigured } from './apiClient';
+import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
+
+/** Determines if a model supports separate system instructions. */
+const supportsSystemInstruction = (model: string): boolean => !model.startsWith('gemma-');
+
+/**
+ * Sends an AI request, trying each model in order until one succeeds.
+ * Falls back to the next model only when a client or server error is returned.
+ *
+ * @param modelNames - Array of model names to try in order.
+ * @param prompt - The user prompt to send.
+ * @param systemInstruction - Optional system instruction to include.
+ * @param config - Additional generateContent configuration.
+ * @returns The GenerateContentResponse from the first successful model.
+ */
+export const dispatchAIRequest = async (
+  modelNames: string[],
+  prompt: string,
+  systemInstruction?: string,
+  config: Record<string, any> = {}
+): Promise<GenerateContentResponse> => {
+  if (!isApiConfigured() || !ai) {
+    return Promise.reject(new Error('API Key not configured.'));
+  }
+
+  let lastError: unknown = null;
+  for (const model of modelNames) {
+    try {
+      const modelSupportsSystem = supportsSystemInstruction(model);
+      const contents = modelSupportsSystem
+        ? prompt
+        : `${systemInstruction ? systemInstruction + '\n\n' : ''}${prompt}`;
+      const cfg = { ...config };
+      if (modelSupportsSystem && systemInstruction) {
+        cfg.systemInstruction = systemInstruction;
+      }
+
+      const response = await ai.models.generateContent({
+        model,
+        contents,
+        config: cfg,
+      });
+      return response;
+    } catch (err) {
+      lastError = err;
+      if (!isServerOrClientError(err)) {
+        throw err;
+      }
+      console.warn(
+        `dispatchAIRequest: Model ${model} failed with status ${extractStatusFromError(err)}. Trying next model if available.`
+      );
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+};
+


### PR DESCRIPTION
## Summary
- implement `dispatchAIRequest` utility that attempts multiple models
- use dispatcher in map update, correction, hierarchy and summary services
- update minimal correction helper to leverage dispatcher

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841a78b2e5c8324b9bf26a6aec09d44