### PR TITLE
Fix root parent handling in map layout and utilities

### DIFF
--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -143,7 +143,7 @@ const MapNodeView: React.FC<MapNodeViewProps> = ({ nodes, edges, currentMapNodeI
     if (node.data.description) content += `\nDescription: ${node.data.description}`;
     if (node.data.aliases && node.data.aliases.length > 0) content += `\nAliases: ${node.data.aliases.join(', ')}`;
     if (node.data.status) content += `\nStatus: ${node.data.status}`;
-    if (node.data.parentNodeId) {
+    if (node.data.parentNodeId && node.data.parentNodeId !== 'Universe') {
       const parentNode = nodes.find(n => n.id === node.data.parentNodeId);
       content += `\n(Parent: ${parentNode?.placeName || 'Unknown Location'})`;
     }

--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -39,7 +39,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
   } = props;
 
   const handleDialogueOptionSelect = useCallback(async (option: string) => {
-    console.log('[DEBUG FLOW] Dialogue option selected:', option);
     const currentFullState = getCurrentGameState();
     const currentThemeObj = currentFullState.currentThemeObject;
 
@@ -89,7 +88,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
           option,
           stateAfterPlayerChoice.dialogueState!.participants
         );
-        console.log('[DEBUG FLOW] Dialogue turn data received:', turnData);
 
         const latestStateAfterFetch = getCurrentGameState();
         if (turnData && latestStateAfterFetch.dialogueState) {
@@ -111,7 +109,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
             lastTurnChanges: null,
           };
           commitGameState(stateWithNpcResponse);
-          console.log('[DEBUG FLOW] NPC responses processed and state committed.');
 
           if (turnData.dialogueEnds) {
             await initiateDialogueExit(stateWithNpcResponse);
@@ -126,7 +123,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
         }
       } catch (e) {
         console.error('Error during dialogue turn:', e);
-        console.log('[DEBUG FLOW] Error occurred while fetching dialogue turn');
         setError('An error occurred in the conversation. You might need to end it.');
         const stateToRevertToOnError = getCurrentGameState();
         if (stateToRevertToOnError.dialogueState) {
@@ -147,7 +143,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
         if (stillInActiveNonExitingDialogue) {
           setIsLoading(false);
           setLoadingReason(null);
-          console.log('[DEBUG FLOW] Dialogue turn complete, awaiting player choice');
         }
       }
     }

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -104,8 +104,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     ) => {
       const { baseStateSnapshot, isFromDialogueSummary = false, scoreChangeFromAction = 0 } = options;
 
-      console.log('[DEBUG FLOW] processAiResponse called. isFromDialogueSummary:', isFromDialogueSummary);
-
       const turnChanges: TurnChanges = {
         itemChanges: [],
         characterChanges: [],
@@ -121,7 +119,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       };
 
       if (!aiData) {
-        console.log('[DEBUG FLOW] processAiResponse: aiData is null or invalid.');
         setError('The Dungeon Master\'s connection is unstable... (Invalid AI response after retries)');
         if (!isFromDialogueSummary && 'actionOptions' in draftState) {
           draftState.actionOptions = [
@@ -265,7 +262,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       }
 
       if ('dialogueSetup' in aiData && aiData.dialogueSetup) {
-        console.log('[DEBUG FLOW] Valid dialogueSetup detected. Starting dialogue with:', aiData.dialogueSetup.participants);
         draftState.actionOptions = [];
         draftState.dialogueState = {
           participants: aiData.dialogueSetup.participants,
@@ -277,7 +273,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       }
 
       draftState.lastTurnChanges = turnChanges;
-      console.log('[DEBUG FLOW] processAiResponse completed.');
     }, [loadingReason, setLoadingReason, setError, setGameStateStack]);
 
   /**
@@ -287,7 +282,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
    */
   const executePlayerAction = useCallback(
     async (action: string, isFreeForm: boolean = false) => {
-      console.log('[DEBUG FLOW] executePlayerAction start:', action);
       const currentFullState = getCurrentGameState();
       if (isLoading || currentFullState.dialogueState) return;
 
@@ -352,7 +346,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       let encounteredError = false;
       try {
         const response = await executeAIMainTurn(prompt, currentThemeObj.systemInstructionModifier);
-        console.log('[DEBUG FLOW] AI raw response received.');
         if (draftState.lastDebugPacket) draftState.lastDebugPacket.rawResponseText = response.text ?? null;
 
         const currentThemeMapDataForParse = {
@@ -376,13 +369,10 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           currentFullState.inventory
         );
 
-        console.log('[DEBUG FLOW] AI response parsed:', parsedData);
-
         await processAiResponse(parsedData, currentThemeObj, draftState, { baseStateSnapshot, scoreChangeFromAction });
       } catch (e: any) {
         encounteredError = true;
         console.error('Error executing player action:', e);
-        console.log('[DEBUG FLOW] executePlayerAction encountered error');
         if (isServerOrClientError(e)) {
           const status = extractStatusFromError(e);
           setError(`AI service error (${status ?? 'unknown'}). Please retry.`);
@@ -400,7 +390,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           draftState.globalTurnNumber += 1;
         }
         commitGameState(draftState);
-        console.log('[DEBUG FLOW] executePlayerAction finished and state committed');
         setIsLoading(false);
         setLoadingReason(null);
 

--- a/services/mapUpdateService.ts
+++ b/services/mapUpdateService.ts
@@ -493,12 +493,16 @@ Key points:
     for (const nodeAddOp of unresolvedQueue) {
       let resolvedParentId: string | undefined = undefined;
       if (nodeAddOp.data?.parentNodeId) {
-        const parent = findNodeByIdentifier(nodeAddOp.data.parentNodeId) as MapNode | undefined;
-        if (parent) {
-          resolvedParentId = parent.id;
+        if (nodeAddOp.data.parentNodeId === 'Universe') {
+          resolvedParentId = undefined;
         } else {
-          nextQueue.push(nodeAddOp);
-          continue;
+          const parent = findNodeByIdentifier(nodeAddOp.data.parentNodeId) as MapNode | undefined;
+          if (parent) {
+            resolvedParentId = parent.id;
+          } else {
+            nextQueue.push(nodeAddOp);
+            continue;
+          }
         }
       }
 
@@ -548,13 +552,17 @@ Key points:
             if (nodeUpdateOp.newData.parentNodeId === null) { // Explicitly clearing parent
                 resolvedParentIdOnUpdate = undefined; // Store as undefined if cleared
             } else if (typeof nodeUpdateOp.newData.parentNodeId === 'string') {
-                // Allow parent to be ANY node (main or leaf)
-                const parentNode = findNodeByIdentifier(nodeUpdateOp.newData!.parentNodeId) as MapNode | undefined;
-                if (parentNode) {
-                    resolvedParentIdOnUpdate = parentNode.id;
+                if (nodeUpdateOp.newData.parentNodeId === 'Universe') {
+                    resolvedParentIdOnUpdate = undefined;
                 } else {
-                    console.warn(`MapUpdate (nodesToUpdate): Leaf node "${nodeUpdateOp.placeName}" trying to update parentNodeId to NAME "${nodeUpdateOp.newData.parentNodeId}" which was not found.`);
-                    resolvedParentIdOnUpdate = undefined; // Or keep old one: node.data.parentNodeId
+                    // Allow parent to be ANY node (main or leaf)
+                    const parentNode = findNodeByIdentifier(nodeUpdateOp.newData!.parentNodeId) as MapNode | undefined;
+                    if (parentNode) {
+                        resolvedParentIdOnUpdate = parentNode.id;
+                    } else {
+                        console.warn(`MapUpdate (nodesToUpdate): Leaf node "${nodeUpdateOp.placeName}" trying to update parentNodeId to NAME "${nodeUpdateOp.newData.parentNodeId}" which was not found.`);
+                        resolvedParentIdOnUpdate = undefined; // Or keep old one: node.data.parentNodeId
+                    }
                 }
             }
         }

--- a/utils/mapGraphUtils.ts
+++ b/utils/mapGraphUtils.ts
@@ -17,7 +17,7 @@ export const getParent = (
   node: MapNode,
   nodeMap: Map<string, MapNode>
 ): MapNode | undefined => {
-  if (!node.data.parentNodeId) return undefined;
+  if (!node.data.parentNodeId || node.data.parentNodeId === 'Universe') return undefined;
   return nodeMap.get(node.data.parentNodeId);
 };
 

--- a/utils/mapLayoutUtils.ts
+++ b/utils/mapLayoutUtils.ts
@@ -396,9 +396,10 @@ export const applyNestedCircleLayout = (nodes: MapNode[]): MapNode[] => {
   const nodeMap = new Map(nodes.map(n => [n.id, structuredCloneGameState(n)]));
   const childMap: Map<string, MapNode[]> = new Map();
   nodes.forEach(n => {
-    if (n.data.parentNodeId && nodeMap.has(n.data.parentNodeId)) {
-      if (!childMap.has(n.data.parentNodeId)) childMap.set(n.data.parentNodeId, []);
-      childMap.get(n.data.parentNodeId)!.push(nodeMap.get(n.id)!);
+    const parentId = n.data.parentNodeId && n.data.parentNodeId !== 'Universe' ? n.data.parentNodeId : undefined;
+    if (parentId && nodeMap.has(parentId)) {
+      if (!childMap.has(parentId)) childMap.set(parentId, []);
+      childMap.get(parentId)!.push(nodeMap.get(n.id)!);
     }
   });
 
@@ -418,7 +419,7 @@ export const applyNestedCircleLayout = (nodes: MapNode[]): MapNode[] => {
     return node.data.visualRadius!;
   };
 
-  const roots = nodes.filter(n => !n.data.parentNodeId).map(n => nodeMap.get(n.id)!);
+  const roots = nodes.filter(n => !n.data.parentNodeId || n.data.parentNodeId === 'Universe').map(n => nodeMap.get(n.id)!);
   roots.forEach(r => computeRadius(r));
 
   /** Recursively positions a node and its children. */
@@ -481,10 +482,11 @@ export const applyNestedForceLayout = (
   const parentMap: Record<string, string | undefined> = {};
   const childMap: Record<string, string[]> = {};
   nodeMap.forEach(node => {
-    parentMap[node.id] = node.data.parentNodeId;
-    if (node.data.parentNodeId) {
-      if (!childMap[node.data.parentNodeId]) childMap[node.data.parentNodeId] = [];
-      childMap[node.data.parentNodeId].push(node.id);
+    const parentId = node.data.parentNodeId && node.data.parentNodeId !== 'Universe' ? node.data.parentNodeId : undefined;
+    parentMap[node.id] = parentId;
+    if (parentId) {
+      if (!childMap[parentId]) childMap[parentId] = [];
+      childMap[parentId].push(node.id);
     }
   });
 

--- a/utils/mapNodeMatcher.ts
+++ b/utils/mapNodeMatcher.ts
@@ -338,7 +338,7 @@ export const selectBestMatchingMapNode = (
   
   if (bestMatchNodeId && overallBestScore > 0) {
     const bestNode = themeNodes.find(n => n.id === bestMatchNodeId);
-    if (bestNode && bestNode.data.nodeType !== 'feature' && !bestNode.data.parentNodeId) {
+    if (bestNode && bestNode.data.nodeType !== 'feature' && (!bestNode.data.parentNodeId || bestNode.data.parentNodeId === 'Universe')) {
       const leafChildren = themeNodes.filter(leaf => leaf.data.nodeType === 'feature' && leaf.data.parentNodeId === bestNode.id);
       for (const leafChild of leafChildren) {
         const leafName = leafChild.placeName;

--- a/utils/promptFormatters/map.ts
+++ b/utils/promptFormatters/map.ts
@@ -226,7 +226,7 @@ export const formatMapContextForPrompt = (
   if (currentNode.data.status) context += ` Status: ${currentNode.data.status}.`;
 
   const parentNodeForCurrent =
-    (currentNode.data.nodeType === 'feature') && currentNode.data.parentNodeId
+    currentNode.data.nodeType === 'feature' && currentNode.data.parentNodeId && currentNode.data.parentNodeId !== 'Universe'
       ? allNodesForTheme.find(n => n.id === currentNode.data.parentNodeId)
       : null;
 
@@ -241,7 +241,7 @@ export const formatMapContextForPrompt = (
 
   const areaMainNodeId =
     currentNode.data.nodeType === 'feature'
-      ? currentNode.data.parentNodeId
+      ? (currentNode.data.parentNodeId && currentNode.data.parentNodeId !== 'Universe' ? currentNode.data.parentNodeId : undefined)
       : currentNode.id;
   let exitsContext = '';
   if (areaMainNodeId) {
@@ -263,7 +263,8 @@ export const formatMapContextForPrompt = (
               entryLeaf &&
               entryLeaf.data.nodeType === 'feature' &&
               entryLeaf.data.parentNodeId &&
-              entryLeaf.data.parentNodeId !== areaMainNode.id
+              entryLeaf.data.parentNodeId !== areaMainNode.id &&
+              entryLeaf.data.parentNodeId !== 'Universe'
             ) {
               const otherAreaMainNode = allNodesForTheme.find(
                 node => node.id === entryLeaf.data.parentNodeId && !(node.data.nodeType === "feature")


### PR DESCRIPTION
## Summary
- handle 'Universe' parent in map graph utils
- treat 'Universe' as root in layout calculations
- account for 'Universe' in map node matcher and map prompts
- avoid showing parent tooltip if parent is 'Universe'
- remove temporary DEBUG FLOW logging from dialogue hooks

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841d49508908324b3a9216fd984b42f