### PR TITLE
Configure eslint to treat warnings as errors

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
   },
   ignorePatterns: ['node_modules', 'dist', 'build'],
   rules: {
-    'react/react-in-jsx-scope': 'off'
+    'react/react-in-jsx-scope': 'off',
+    'react-hooks/exhaustive-deps': 'error'
   }
 };


### PR DESCRIPTION
## Summary
- update `.eslintrc.cjs` to fail on `react-hooks/exhaustive-deps` warnings

## Testing
- `npm install`
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842acd891888324a74f08cce5a7c48f