### PR TITLE
Refactor dialogue hooks

### DIFF
--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -9,7 +9,6 @@ import {
   DialogueSummaryResponse,
   FullGameState,
   DialogueSummaryContext,
-  DialogueData,
   LoadingReason,
   MapData,
   DialogueSummaryRecord,
@@ -80,7 +79,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
     setDialogueUiCloseDelayTargetMs(Date.now() + DIALOGUE_EXIT_READ_DELAY_MS);
     setError(null);
 
-    let workingGameState = structuredCloneGameState(stateAtDialogueConclusionStart);
+    const workingGameState = structuredCloneGameState(stateAtDialogueConclusionStart);
 
     setLoadingReason('dialogue_memory_creation');
     const memorySummaryContext: DialogueMemorySummaryContext = {
@@ -177,7 +176,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
         lastTurnChanges: null,
       };
       commitGameState(stateWithForceExit);
-      initiateDialogueExit(stateWithForceExit);
+      void initiateDialogueExit(stateWithForceExit);
     }
   }, [getCurrentGameState, commitGameState, isDialogueExiting, initiateDialogueExit]);
 

--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -53,7 +53,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
     const stateAfterPlayerChoice: FullGameState = {
       ...currentFullState,
       dialogueState: {
-        ...(currentFullState.dialogueState as DialogueData),
+        ...currentFullState.dialogueState,
         history: historyWithPlayerChoice,
         options: [],
       },
@@ -115,7 +115,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
           }
         } else if (latestStateAfterFetch.dialogueState) {
           setError('The conversation faltered. Try choosing an option again or ending the dialogue.');
-          let errorDialogueState = { ...latestStateAfterFetch.dialogueState };
+          const errorDialogueState = { ...latestStateAfterFetch.dialogueState };
           if (errorDialogueState.options.length === 0) {
             errorDialogueState.options = originalOptions.length > 0 ? originalOptions : ['End Conversation.'];
           }


### PR DESCRIPTION
## Summary
- clean up imports in `useDialogueSummary`
- make `workingGameState` const
- avoid floating promise when forcing dialogue exit
- remove redundant type assertion and prefer const

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842b8f307988324a721ed0bcc08e87b