### PR TITLE
Improve correction services typing

### DIFF
--- a/services/corrections/base.ts
+++ b/services/corrections/base.ts
@@ -14,10 +14,15 @@ export const CORRECTION_TEMPERATURE = 0.75;
  * Makes a single AI call expecting a JSON response and parses the result.
  * Uses AUXILIARY_MODEL_NAME.
  */
-export const callCorrectionAI = async (
+/**
+ * Dispatches a JSON-returning AI request using the auxiliary model.
+ * The generic type allows callers to specify the expected shape of the
+ * parsed JSON result.
+ */
+export const callCorrectionAI = async <T = any>(
   prompt: string,
   systemInstruction: string
-): Promise<any | null> => {
+): Promise<T | null> => {
   try {
     const response = await dispatchAIRequest(
       [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
@@ -34,7 +39,7 @@ export const callCorrectionAI = async (
     if (fenceMatch && fenceMatch[1]) {
       jsonStr = fenceMatch[1].trim();
     }
-    return JSON.parse(jsonStr);
+    return JSON.parse(jsonStr) as T;
   } catch (error) {
     console.error(`callCorrectionAI: Error during single AI call or parsing for prompt starting with "${prompt.substring(0, 100)}...":`, error);
     if (isServerOrClientError(error)) {

--- a/services/corrections/character.ts
+++ b/services/corrections/character.ts
@@ -66,18 +66,18 @@ Constraints:
   const systemInstructionForFix = `You generate detailed JSON objects for new game characters based on narrative context. Provide description, aliases, presenceStatus, lastKnownLocation, and preciseLocation. Adhere strictly to the JSON format and field requirements. Derive all information strictly from the provided context.`;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const correctedDetails = await callCorrectionAI(prompt, systemInstructionForFix);
+    const correctedDetails = await callCorrectionAI<CorrectedCharacterDetails>(prompt, systemInstructionForFix);
     if (
       correctedDetails &&
       typeof correctedDetails.description === 'string' && correctedDetails.description.trim() !== '' &&
-      Array.isArray(correctedDetails.aliases) && correctedDetails.aliases.every((a: any) => typeof a === 'string') &&
+      Array.isArray(correctedDetails.aliases) && correctedDetails.aliases.every((a): a is string => typeof a === 'string') &&
       typeof correctedDetails.presenceStatus === 'string' && ['distant', 'nearby', 'companion', 'unknown'].includes(correctedDetails.presenceStatus) &&
       (correctedDetails.lastKnownLocation === null || typeof correctedDetails.lastKnownLocation === 'string') &&
       (correctedDetails.preciseLocation === null || typeof correctedDetails.preciseLocation === 'string') &&
       !((correctedDetails.presenceStatus === 'nearby' || correctedDetails.presenceStatus === 'companion') && correctedDetails.preciseLocation === null && correctedDetails.preciseLocation !== '') &&
       !((correctedDetails.presenceStatus === 'distant' || correctedDetails.presenceStatus === 'unknown') && correctedDetails.preciseLocation !== null)
     ) {
-      return correctedDetails as CorrectedCharacterDetails;
+      return correctedDetails;
     } else {
       console.warn(`fetchCorrectedCharacterDetails_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): Corrected details for "${characterName}" invalid or incomplete. Response:`, correctedDetails);
       if (attempt === MAX_RETRIES) return null;

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -21,7 +21,7 @@ export const fetchCorrectedDialogueSetup_Service = async (
   allRelevantMapNodes: MapNode[],
   currentInventory: Item[],
   playerGender: string,
-  malformedDialogueSetup: Partial<DialogueSetupPayload> | any
+  malformedDialogueSetup: Partial<DialogueSetupPayload> | unknown
 ): Promise<DialogueSetupPayload | null> => {
   if (!isApiConfigured()) {
     console.error('fetchCorrectedDialogueSetup_Service: API Key not configured.');
@@ -63,9 +63,9 @@ Respond ONLY with the single, complete, corrected JSON object for 'dialogueSetup
   const systemInstructionForFix = `Correct a malformed 'dialogueSetup' JSON payload. Ensure 'participants' are valid NPCs, 'initialNpcResponses' are logical, and 'initialPlayerOptions' are varied with an exit option. Adhere strictly to the JSON format.`;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const correctedPayload = await callCorrectionAI(prompt, systemInstructionForFix);
+    const correctedPayload = await callCorrectionAI<DialogueSetupPayload>(prompt, systemInstructionForFix);
     if (correctedPayload && isDialogueSetupPayloadStructurallyValid(correctedPayload)) {
-      return correctedPayload as DialogueSetupPayload;
+      return correctedPayload;
     } else {
       console.warn(`fetchCorrectedDialogueSetup_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): Corrected dialogueSetup payload invalid. Response:`, correctedPayload);
     }

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -115,9 +115,9 @@ Respond ONLY with the single, complete, corrected JSON object for the 'item' fie
   const systemInstructionForFix = `Correct JSON item payloads based on the provided structure, context, and specific instructions for the action type. Adhere strictly to the JSON format. Preserve the original intent of the item change if discernible. CRITICAL: Ensure the 'type' field is never 'junk'; use 'isJunk: true' and a valid type instead.`;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const correctedItemPayload = await callCorrectionAI(prompt, systemInstructionForFix);
+    const correctedItemPayload = await callCorrectionAI<Item>(prompt, systemInstructionForFix);
     if (correctedItemPayload && isValidItem(correctedItemPayload, actionType === 'gain' ? 'gain' : 'update')) {
-      return correctedItemPayload as Item;
+      return correctedItemPayload;
     } else {
       console.warn(`fetchCorrectedItemPayload_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): Corrected '${actionType}' payload invalid after validation. Response:`, correctedItemPayload);
       if (attempt === MAX_RETRIES) return null;
@@ -168,9 +168,9 @@ If no action can be confidently determined, respond with an empty string.`;
     const correctedActionResponse = await callMinimalCorrectionAI(prompt, systemInstructionForFix);
     if (correctedActionResponse !== null) {
       const action = correctedActionResponse.trim().toLowerCase();
-      if (['gain', 'lose', 'update'].includes(action)) {
+      if (action === 'gain' || action === 'lose' || action === 'update') {
         console.warn(`fetchCorrectedItemAction_Service: Returned corrected itemAction `, action, `.`);
-        return action as ItemChange['action'];
+        return action;
       } else if (action === '') {
         console.warn(`fetchCorrectedItemAction_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): AI indicated no confident action for itemChange: ${malformedItemChangeString}`);
         return null;

--- a/services/corrections/map.ts
+++ b/services/corrections/map.ts
@@ -114,14 +114,14 @@ Respond ONLY with the single, complete, corrected JSON object.`;
   const systemInstructionForFix = `Correct or complete a JSON payload for a map location. Ensure "name" (string, non-empty), "description" (string, non-empty), and "aliases" (array of strings, can be empty) are provided. Adhere strictly to the JSON format.`;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const correctedPayload = await callCorrectionAI(prompt, systemInstructionForFix);
+    const correctedPayload = await callCorrectionAI<{ name: string; description: string; aliases?: string[] }>(prompt, systemInstructionForFix);
     if (
       correctedPayload &&
       typeof correctedPayload.name === 'string' && correctedPayload.name.trim() !== '' &&
       typeof correctedPayload.description === 'string' && correctedPayload.description.trim() !== '' &&
-      Array.isArray(correctedPayload.aliases) && correctedPayload.aliases.every((a: any) => typeof a === 'string')
+      Array.isArray(correctedPayload.aliases) && correctedPayload.aliases.every((a): a is string => typeof a === 'string')
     ) {
-      return correctedPayload as { name: string; description: string; aliases?: string[] };
+      return correctedPayload;
     } else {
       console.warn(`fetchCorrectedPlaceDetails_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): Corrected map location payload invalid. Response:`, correctedPayload);
     }
@@ -167,14 +167,14 @@ Respond ONLY with the single, complete JSON object.`;
   const systemInstructionForFix = `Generate detailed JSON for a new game map location. The 'name' field in the output is predetermined and MUST match the input. Focus on creating a fitting, non-empty description and aliases (array of strings, can be empty). Adhere strictly to the JSON format.`;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const correctedPayload = await callCorrectionAI(prompt, systemInstructionForFix);
+    const correctedPayload = await callCorrectionAI<{ name: string; description: string; aliases?: string[] }>(prompt, systemInstructionForFix);
     if (
       correctedPayload &&
       typeof correctedPayload.name === 'string' && correctedPayload.name === mapNodePlaceName &&
       typeof correctedPayload.description === 'string' && correctedPayload.description.trim() !== '' &&
-      Array.isArray(correctedPayload.aliases) && correctedPayload.aliases.every((alias: any) => typeof alias === 'string')
+      Array.isArray(correctedPayload.aliases) && correctedPayload.aliases.every((alias): alias is string => typeof alias === 'string')
     ) {
-      return correctedPayload as { name: string; description: string; aliases?: string[] };
+      return correctedPayload;
     } else {
       console.warn(`fetchFullPlaceDetailsForNewMapNode_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): Corrected map location payload invalid or name mismatch for "${mapNodePlaceName}". Response:`, correctedPayload);
     }
@@ -254,7 +254,7 @@ export const fetchCorrectedNodeType_Service = async (
 
   if (nodeInfo.nodeType) {
     const normalized = synonyms[nodeInfo.nodeType.toLowerCase()] || nodeInfo.nodeType.toLowerCase();
-    if (VALID_NODE_TYPE_VALUES.includes(normalized as any)) {
+    if (VALID_NODE_TYPE_VALUES.includes(normalized as NonNullable<MapNodeData['nodeType']>)) {
       return normalized as NonNullable<MapNodeData['nodeType']>;
     }
   }
@@ -290,7 +290,7 @@ Respond ONLY with the single node type.`;
     if (typeResp) {
       const cleaned = typeResp.trim().toLowerCase();
       const mapped = synonyms[cleaned] || cleaned;
-      if (VALID_NODE_TYPE_VALUES.includes(mapped as any)) {
+      if (VALID_NODE_TYPE_VALUES.includes(mapped as NonNullable<MapNodeData['nodeType']>)) {
         return mapped as NonNullable<MapNodeData['nodeType']>;
       }
     }
@@ -337,7 +337,7 @@ export const fetchCorrectedEdgeType_Service = async (
 
   if (edgeInfo.type) {
     const normalized = synonyms[edgeInfo.type.toLowerCase()] || edgeInfo.type.toLowerCase();
-    if (VALID_EDGE_TYPE_VALUES.includes(normalized as any)) {
+    if (VALID_EDGE_TYPE_VALUES.includes(normalized as MapEdgeData['type'])) {
       return normalized as MapEdgeData['type'];
     }
   }
@@ -376,7 +376,7 @@ Respond ONLY with the single edge type.`;
     if (typeResp) {
       const cleaned = typeResp.trim().toLowerCase();
       const mapped = synonyms[cleaned] || cleaned;
-      if (VALID_EDGE_TYPE_VALUES.includes(mapped as any)) {
+      if (VALID_EDGE_TYPE_VALUES.includes(mapped as MapEdgeData['type'])) {
         return mapped as MapEdgeData['type'];
       }
     }


### PR DESCRIPTION
## Summary
- make `callCorrectionAI` generic for typed results
- tighten character correction response checks
- strongly type dialogue correction inputs/outputs
- simplify item correction action parsing
- add precise typing checks to map correction helpers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842be1266dc8324b844f138705d90fa