### PR TITLE
Improve type safety in utility modules

### DIFF
--- a/utils/aiErrorUtils.ts
+++ b/utils/aiErrorUtils.ts
@@ -12,10 +12,14 @@
  */
 export const extractStatusFromError = (err: unknown): number | null => {
   if (!err || typeof err !== 'object') return null;
-  const anyErr = err as any;
-  if (typeof anyErr.status === 'number') return anyErr.status;
-  if (anyErr.error && typeof anyErr.error.code === 'number') return anyErr.error.code;
-  const msg = String(anyErr.message || '');
+  const errObj = err as {
+    status?: number;
+    error?: { code?: number };
+    message?: unknown;
+  };
+  if (typeof errObj.status === 'number') return errObj.status;
+  if (errObj.error && typeof errObj.error.code === 'number') return errObj.error.code;
+  const msg = String(errObj.message ?? '');
   const match = msg.match(/status:\s*(\d{3})/);
   if (match) return parseInt(match[1], 10);
   return null;

--- a/utils/cloneUtils.ts
+++ b/utils/cloneUtils.ts
@@ -13,8 +13,9 @@
  * @returns A deep copy of the input object.
  */
 export function structuredCloneGameState<T>(state: T): T {
-  if (typeof (globalThis as any).structuredClone === 'function') {
-    return (globalThis as any).structuredClone(state);
+  const globalObj = globalThis as unknown as { structuredClone?: (value: unknown) => unknown };
+  if (typeof globalObj.structuredClone === 'function') {
+    return globalObj.structuredClone(state) as T;
   }
   return deepCopy(state);
 }
@@ -31,17 +32,17 @@ function deepCopy<T>(value: T): T {
   }
 
   if (value instanceof Date) {
-    return new Date(value.getTime()) as any;
+    return new Date(value.getTime()) as unknown as T;
   }
 
   if (Array.isArray(value)) {
     return (value.map(v => deepCopy(v)) as unknown) as T;
   }
 
-  const clonedObj: Record<string, any> = {};
-  for (const key in value as Record<string, any>) {
+  const clonedObj: Record<string, unknown> = {};
+  for (const key in value as Record<string, unknown>) {
     if (Object.prototype.hasOwnProperty.call(value, key)) {
-      clonedObj[key] = deepCopy((value as Record<string, any>)[key]);
+      clonedObj[key] = deepCopy((value as Record<string, unknown>)[key]);
     }
   }
   return clonedObj as T;

--- a/utils/gameLogicUtils.ts
+++ b/utils/gameLogicUtils.ts
@@ -58,7 +58,7 @@ export const applyItemChangeAction = (currentInventory: Item[], itemChange: Item
     }
     
     const existingItem = newInventory[itemIndexInNewInventory];
-    let updatedItem: Item = { ...existingItem }; 
+    const updatedItem: Item = { ...existingItem };
 
     if (updatePayload.type !== undefined) updatedItem.type = updatePayload.type;
     if (updatePayload.description !== undefined) updatedItem.description = updatePayload.description;
@@ -75,7 +75,7 @@ export const applyItemChangeAction = (currentInventory: Item[], itemChange: Item
     }
 
     if (updatePayload.addKnownUse) {
-      let currentKnownUses = updatedItem.knownUses ? [...updatedItem.knownUses] : [];
+      const currentKnownUses = updatedItem.knownUses ? [...updatedItem.knownUses] : [];
       const kuIndex = currentKnownUses.findIndex(ku => ku.actionName === updatePayload.addKnownUse!.actionName);
       if (kuIndex !== -1) currentKnownUses[kuIndex] = updatePayload.addKnownUse; 
       else currentKnownUses.push(updatePayload.addKnownUse); 
@@ -125,10 +125,9 @@ export const selectNextThemeName = (
   if (availableThemes.length === 0) {
     return null;
   }
-  let filteredThemes = availableThemes;
-  if (currentThemeName && availableThemes.length > 1) {
-    filteredThemes = availableThemes.filter(theme => theme.name !== currentThemeName);
-  }
+  const filteredThemes = currentThemeName && availableThemes.length > 1
+    ? availableThemes.filter(theme => theme.name !== currentThemeName)
+    : availableThemes;
   const themesToChooseFrom = filteredThemes.length > 0 ? filteredThemes : availableThemes;
   const randomIndex = Math.floor(Math.random() * themesToChooseFrom.length);
   return themesToChooseFrom[randomIndex].name;
@@ -175,7 +174,7 @@ export const buildItemChangeRecords = (
 
       if (oldItem) {
         const oldItemCopy = { ...oldItem }; 
-        let newItemData: Item = {
+        const newItemData: Item = {
           name: updatePayload.newName || oldItemCopy.name,
           type: updatePayload.type !== undefined ? updatePayload.type : oldItemCopy.type,
           description: updatePayload.description !== undefined ? updatePayload.description : oldItemCopy.description,
@@ -185,7 +184,7 @@ export const buildItemChangeRecords = (
           knownUses: Array.isArray(updatePayload.knownUses) ? updatePayload.knownUses : (oldItemCopy.knownUses || []),
         };
         if (updatePayload.addKnownUse) {
-          let currentKnownUses = [...(newItemData.knownUses || [])]; 
+          const currentKnownUses = [...(newItemData.knownUses || [])];
           const kuIndex = currentKnownUses.findIndex(ku => ku.actionName === updatePayload.addKnownUse!.actionName);
           if (kuIndex !== -1) currentKnownUses[kuIndex] = updatePayload.addKnownUse;
           else currentKnownUses.push(updatePayload.addKnownUse);
@@ -252,7 +251,7 @@ export const buildCharacterChangeRecords = (
   (charactersUpdatedFromAI || []).forEach(cUpdate => {
     const oldChar = currentAllCharacters.find(c => c.name === cUpdate.name && c.themeName === currentThemeName);
     if (oldChar) {
-      let newCharData: Character = { ...oldChar, dialogueSummaries: oldChar.dialogueSummaries || [] }; // Preserve summaries
+      const newCharData: Character = { ...oldChar, dialogueSummaries: oldChar.dialogueSummaries || [] }; // Preserve summaries
       if (cUpdate.newDescription !== undefined) newCharData.description = cUpdate.newDescription;
       if (cUpdate.newAliases !== undefined) newCharData.aliases = cUpdate.newAliases;
       if (cUpdate.addAlias) {

--- a/utils/initialStates.ts
+++ b/utils/initialStates.ts
@@ -36,6 +36,10 @@ const getDefaultMapLayoutConfig = (): MapLayoutConfig => ({
     iterations: DEFAULT_LAYOUT_ITERATIONS,
 });
 
+/**
+ * Creates a default FullGameState with all numeric counters and collections
+ * initialized to their starting values.
+ */
 export const getInitialGameStates = (): FullGameState => {
   return {
     saveGameVersion: CURRENT_SAVE_GAME_VERSION, 
@@ -78,7 +82,8 @@ export const getInitialGameStates = (): FullGameState => {
 };
 
 /**
- * Returns a blank game state populated with the provided settings.
+ * Creates an initial game state using the specified configuration options.
+ * Useful when starting a new game with user-supplied settings.
  */
 export const getInitialGameStatesWithSettings = (
   playerGender: string,

--- a/utils/mapNodeMatcher.ts
+++ b/utils/mapNodeMatcher.ts
@@ -202,6 +202,18 @@ export const attemptMatchAndSetNode = (
     return { matched: true, nodeId: firstMatch.id };
 };
 
+/**
+ * Determines the most appropriate map node based on a textual place description.
+ * The function scores each node by comparing tokens and prepositions extracted
+ * from the description, preferring nodes that were previously nearby.
+ *
+ * @param localPlace - The freeform location string from the player.
+ * @param currentTheme - The current active theme object.
+ * @param mapData - Complete map graph data.
+ * @param allNodesForTheme - Nodes belonging to the current theme.
+ * @param previousMapNodeId - ID of the player's previous map node if any.
+ * @returns The best matching node ID or null when no suitable match is found.
+ */
 export const selectBestMatchingMapNode = (
   localPlace: string | null,
   currentTheme: AdventureTheme | null,

--- a/utils/mapUpdateValidationUtils.ts
+++ b/utils/mapUpdateValidationUtils.ts
@@ -10,68 +10,74 @@ export const VALID_NODE_TYPE_VALUES: ReadonlyArray<NonNullable<MapNodeData['node
 export const VALID_EDGE_TYPE_VALUES: ReadonlyArray<MapEdgeData['type']> = ['path', 'road', 'sea route', 'door', 'teleporter', 'secret_passage', 'river_crossing', 'temporary_bridge', 'boarding_hook'];
 export const VALID_EDGE_STATUS_VALUES: ReadonlyArray<MapEdgeData['status']> = ['open', 'accessible', 'closed', 'locked', 'blocked', 'hidden', 'rumored', 'one_way', 'collapsed', 'removed', 'active', 'inactive'];
 
-function isValidAINodeDataInternal(data: any, isNodeAddContext: boolean): boolean {
+/**
+ * Validates a MapNodeData object used in map update operations.
+ * @param data - The value to validate.
+ * @param isNodeAddContext - Whether the validation is for a node addition.
+ */
+function isValidAINodeDataInternal(data: unknown, isNodeAddContext: boolean): boolean {
   if (typeof data !== 'object' || data === null) {
     console.warn("Validation Error (NodeData): Data is not an object. Value:", data);
     return false;
   }
+  const node = data as Record<string, unknown>;
 
   // Status: Required for Add, Optional for Update. Must be valid if present.
   if (isNodeAddContext) {
-    if (typeof data.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(data.status as any)) {
-      console.warn("Validation Error (NodeData - Add): 'status' is mandatory and invalid. Value:", data.status, "Valid are:", VALID_NODE_STATUS_VALUES);
+    if (typeof node.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(node.status as MapNodeData['status'])) {
+      console.warn("Validation Error (NodeData - Add): 'status' is mandatory and invalid. Value:", node.status, "Valid are:", VALID_NODE_STATUS_VALUES);
       return false;
     }
   } else { // Update context
-    if (data.status !== undefined && (typeof data.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(data.status as any))) {
-      console.warn("Validation Error (NodeData - Update): Invalid 'status'. Value:", data.status);
+    if (node.status !== undefined && (typeof node.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(node.status as MapNodeData['status']))) {
+      console.warn("Validation Error (NodeData - Update): Invalid 'status'. Value:", node.status);
       return false;
     }
   }
 
   // Description: Required for Add (non-empty string), Optional for Update (string if present).
   if (isNodeAddContext) {
-    if (typeof data.description !== 'string' || data.description.trim() === '') {
-      console.warn("Validation Error (NodeData - Add): 'description' is mandatory and must be a non-empty string. Value:", data.description);
+    if (typeof node.description !== 'string' || node.description.trim() === '') {
+      console.warn("Validation Error (NodeData - Add): 'description' is mandatory and must be a non-empty string. Value:", node.description);
       return false;
     }
   } else { // Update context
-    if (data.description !== undefined && typeof data.description !== 'string') {
-      console.warn("Validation Error (NodeData - Update): 'description' if present must be a string. Value:", data.description);
+    if (node.description !== undefined && typeof node.description !== 'string') {
+      console.warn("Validation Error (NodeData - Update): 'description' if present must be a string. Value:", node.description);
       return false;
     }
   }
 
   // Aliases: Required for Add (array of strings, can be empty), Optional for Update (array of strings if present).
   if (isNodeAddContext) {
-    if (!Array.isArray(data.aliases) || !data.aliases.every((a: any) => typeof a === 'string')) {
-      console.warn("Validation Error (NodeData - Add): 'aliases' is mandatory and must be an array of strings (can be empty []). Value:", data.aliases);
+    if (!Array.isArray(node.aliases) || !node.aliases.every(a => typeof a === 'string')) {
+      console.warn("Validation Error (NodeData - Add): 'aliases' is mandatory and must be an array of strings (can be empty []). Value:", node.aliases);
       return false;
     }
   } else { // Update context
-    if (data.aliases !== undefined && !(Array.isArray(data.aliases) && data.aliases.every((a: any) => typeof a === 'string'))) {
-      console.warn("Validation Error (NodeData - Update): 'aliases' if present must be an array of strings. Value:", data.aliases);
+    if (node.aliases !== undefined && !(Array.isArray(node.aliases) && node.aliases.every(a => typeof a === 'string'))) {
+      console.warn("Validation Error (NodeData - Update): 'aliases' if present must be an array of strings. Value:", node.aliases);
       return false;
     }
   }
   
 
   if (isNodeAddContext) {
-    if (typeof data.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(data.nodeType as any)) {
-      console.warn("Validation Error (NodeData - Add): 'nodeType' is mandatory and invalid. Value:", data.nodeType, "Valid are:", VALID_NODE_TYPE_VALUES);
+    if (typeof node.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(node.nodeType as NonNullable<MapNodeData['nodeType']>)) {
+      console.warn("Validation Error (NodeData - Add): 'nodeType' is mandatory and invalid. Value:", node.nodeType, "Valid are:", VALID_NODE_TYPE_VALUES);
       return false;
     }
   } else {
-    if (data.nodeType !== undefined && (typeof data.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(data.nodeType as any))) {
-      console.warn("Validation Error (NodeData - Update): 'nodeType' is invalid. Value:", data.nodeType);
+    if (node.nodeType !== undefined && (typeof node.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(node.nodeType as NonNullable<MapNodeData['nodeType']>))) {
+      console.warn("Validation Error (NodeData - Update): 'nodeType' is invalid. Value:", node.nodeType);
       return false;
     }
   }
 
   // parentNodeId: Optional for both. String if present.
-  if (data.parentNodeId !== undefined && (data.parentNodeId !== null && (typeof data.parentNodeId !== 'string' || data.parentNodeId.trim() === ''))) {
+  if (node.parentNodeId !== undefined && (node.parentNodeId !== null && (typeof node.parentNodeId !== 'string' || node.parentNodeId.trim() === ''))) {
     // Allow null to clear parentNodeId
-    console.warn("Validation Error (NodeData): 'parentNodeId' must be a non-empty string or null if present. Value:", data.parentNodeId);
+    console.warn("Validation Error (NodeData): 'parentNodeId' must be a non-empty string or null if present. Value:", node.parentNodeId);
     return false;
   }
   
@@ -79,120 +85,152 @@ function isValidAINodeDataInternal(data: any, isNodeAddContext: boolean): boolea
 }
 
 
-function isValidAIEdgeDataInternal(data: any, isEdgeAddContext: boolean): boolean {
+/**
+ * Validates a MapEdgeData object used in map update operations.
+ * @param data - The value to validate.
+ * @param isEdgeAddContext - Whether the validation is for adding a new edge.
+ */
+function isValidAIEdgeDataInternal(data: unknown, isEdgeAddContext: boolean): boolean {
   if (typeof data !== 'object' || data === null) return false;
+  const edge = data as Record<string, unknown>;
   
   if (isEdgeAddContext) { // Type and status are required for new edges
-    if (typeof data.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(data.type as any)) {
-      console.warn("Validation Error (EdgeData - Add): 'type' is required and invalid. Value:", data.type, "Valid are:", VALID_EDGE_TYPE_VALUES);
+    if (typeof edge.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(edge.type as MapEdgeData['type'])) {
+      console.warn("Validation Error (EdgeData - Add): 'type' is required and invalid. Value:", edge.type, "Valid are:", VALID_EDGE_TYPE_VALUES);
       return false;
     }
-    if (typeof data.status !== 'string' || !VALID_EDGE_STATUS_VALUES.includes(data.status as any)) {
-      console.warn("Validation Error (EdgeData - Add): 'status' is required and invalid. Value:", data.status, "Valid are:", VALID_EDGE_STATUS_VALUES);
+    if (typeof edge.status !== 'string' || !VALID_EDGE_STATUS_VALUES.includes(edge.status as MapEdgeData['status'])) {
+      console.warn("Validation Error (EdgeData - Add): 'status' is required and invalid. Value:", edge.status, "Valid are:", VALID_EDGE_STATUS_VALUES);
       return false;
     }
   } else { // For updates, type and status are optional
-    if (data.type !== undefined && (typeof data.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(data.type as any))) {
-        console.warn("Validation Error (EdgeData - Update): Invalid 'type'. Value:", data.type, "Valid are:", VALID_EDGE_TYPE_VALUES);
+    if (edge.type !== undefined && (typeof edge.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(edge.type as MapEdgeData['type']))) {
+        console.warn("Validation Error (EdgeData - Update): Invalid 'type'. Value:", edge.type, "Valid are:", VALID_EDGE_TYPE_VALUES);
         return false;
     }
-    if (data.status !== undefined && (typeof data.status !== 'string' || !VALID_EDGE_STATUS_VALUES.includes(data.status as any))) {
-        console.warn("Validation Error (EdgeData - Update): Invalid 'status'. Value:", data.status, "Valid are:", VALID_EDGE_STATUS_VALUES);
+    if (edge.status !== undefined && (typeof edge.status !== 'string' || !VALID_EDGE_STATUS_VALUES.includes(edge.status as MapEdgeData['status']))) {
+        console.warn("Validation Error (EdgeData - Update): Invalid 'status'. Value:", edge.status, "Valid are:", VALID_EDGE_STATUS_VALUES);
         return false;
     }
   }
 
-  if (data.description !== undefined && typeof data.description !== 'string') {
-    console.warn("Validation Error (EdgeData): Invalid 'description'. Value:", data.description);
+  if (edge.description !== undefined && typeof edge.description !== 'string') {
+    console.warn("Validation Error (EdgeData): Invalid 'description'. Value:", edge.description);
     return false;
   }
-  if (data.travelTime !== undefined && typeof data.travelTime !== 'string') {
-    console.warn("Validation Error (EdgeData): Invalid 'travelTime'. Value:", data.travelTime);
+  if (edge.travelTime !== undefined && typeof edge.travelTime !== 'string') {
+    console.warn("Validation Error (EdgeData): Invalid 'travelTime'. Value:", edge.travelTime);
     return false;
   }
   return true;
 }
 
-function isValidAINodeOperationInternal(nodeOp: any, isNodeAddOperation: boolean): boolean {
+/**
+ * Validates a node add/update operation object.
+ * @param nodeOp - The node operation data.
+ * @param isNodeAddOperation - Whether this validation is for adding a node.
+ */
+function isValidAINodeOperationInternal(nodeOp: unknown, isNodeAddOperation: boolean): boolean {
   if (typeof nodeOp !== 'object' || nodeOp === null) return false;
-  if (typeof nodeOp.placeName !== 'string' || nodeOp.placeName.trim() === '') {
-    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): 'placeName' is required. Value:`, nodeOp.placeName);
+  const op = nodeOp as Record<string, unknown>;
+  if (typeof op.placeName !== 'string' || op.placeName.trim() === '') {
+    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): 'placeName' is required. Value:`, op.placeName);
     return false;
   }
-  
+
   const dataFieldKey = isNodeAddOperation ? 'data' : 'newData';
-  const dataField = nodeOp[dataFieldKey];
+  const dataField = op[dataFieldKey];
 
   if (typeof dataField !== 'object' || dataField === null) {
     console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): '${dataFieldKey}' field is required. Value:`, dataField);
     return false;
   }
 
-  if (!isValidAINodeDataInternal(dataField, isNodeAddOperation)) { 
-    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): Invalid '${dataFieldKey}' for placeName "${nodeOp.placeName}". Details above.`);
+  if (!isValidAINodeDataInternal(dataField, isNodeAddOperation)) {
+    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): Invalid '${dataFieldKey}' for placeName "${op.placeName}". Details above.`);
     return false;
   }
 
-  if (isNodeAddOperation && nodeOp.initialPosition !== undefined) {
-    if (typeof nodeOp.initialPosition !== 'object' || nodeOp.initialPosition === null ||
-        typeof nodeOp.initialPosition.x !== 'number' || typeof nodeOp.initialPosition.y !== 'number') {
-      console.warn("Validation Error (NodeAdd): 'initialPosition' must be {x: number, y: number}. Value:", nodeOp.initialPosition);
+  if (isNodeAddOperation && op.initialPosition !== undefined) {
+    const pos = op.initialPosition as Record<string, unknown>;
+    if (typeof pos !== 'object' || pos === null ||
+        typeof pos.x !== 'number' || typeof pos.y !== 'number') {
+      console.warn("Validation Error (NodeAdd): 'initialPosition' must be {x: number, y: number}. Value:", op.initialPosition);
       return false;
     }
   }
   return true;
 }
 
-function isValidAINodeRemovalInternal(nodeRemove: any): boolean {
+/**
+ * Validates a node removal operation object.
+ */
+function isValidAINodeRemovalInternal(nodeRemove: unknown): boolean {
   if (typeof nodeRemove !== 'object' || nodeRemove === null) return false;
-  if (typeof nodeRemove.placeName !== 'string' || nodeRemove.placeName.trim() === '') {
-    console.warn("Validation Error (NodeRemove): 'placeName' is required. Value:", nodeRemove.placeName);
+  const rem = nodeRemove as Record<string, unknown>;
+  if (typeof rem.placeName !== 'string' || rem.placeName.trim() === '') {
+    console.warn("Validation Error (NodeRemove): 'placeName' is required. Value:", rem.placeName);
     return false;
   }
   return true;
 }
 
-function isValidAIEdgeOperationInternal(edgeOp: any, isEdgeAddOperation: boolean): boolean {
+/**
+ * Validates an edge add/update operation object.
+ * @param edgeOp - The edge operation data.
+ * @param isEdgeAddOperation - Whether this validation is for adding an edge.
+ */
+function isValidAIEdgeOperationInternal(edgeOp: unknown, isEdgeAddOperation: boolean): boolean {
   if (typeof edgeOp !== 'object' || edgeOp === null) return false;
-  if (typeof edgeOp.sourcePlaceName !== 'string' || edgeOp.sourcePlaceName.trim() === '') {
-    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): 'sourcePlaceName' is required. Value:`, edgeOp.sourcePlaceName);
+  const op = edgeOp as Record<string, unknown>;
+  if (typeof op.sourcePlaceName !== 'string' || op.sourcePlaceName.trim() === '') {
+    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): 'sourcePlaceName' is required. Value:`, op.sourcePlaceName);
     return false;
   }
-  if (typeof edgeOp.targetPlaceName !== 'string' || edgeOp.targetPlaceName.trim() === '') {
-    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): 'targetPlaceName' is required. Value:`, edgeOp.targetPlaceName);
+  if (typeof op.targetPlaceName !== 'string' || op.targetPlaceName.trim() === '') {
+    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): 'targetPlaceName' is required. Value:`, op.targetPlaceName);
     return false;
   }
 
   const dataFieldKey = isEdgeAddOperation ? 'data' : 'newData';
-  const dataField = edgeOp[dataFieldKey];
+  const dataField = op[dataFieldKey];
   if (typeof dataField !== 'object' || dataField === null) {
      console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): '${dataFieldKey}' field is required. Value:`, dataField);
     return false;
   }
   if (!isValidAIEdgeDataInternal(dataField, isEdgeAddOperation)) {
-    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): Invalid '${dataFieldKey}' for edge between "${edgeOp.sourcePlaceName}" and "${edgeOp.targetPlaceName}".`);
+    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): Invalid '${dataFieldKey}' for edge between "${op.sourcePlaceName}" and "${op.targetPlaceName}".`);
     return false;
   }
   return true;
 }
 
-function isValidAIEdgeRemovalInternal(edgeRemove: any): boolean {
+/**
+ * Validates an edge removal operation object.
+ */
+function isValidAIEdgeRemovalInternal(edgeRemove: unknown): boolean {
   if (typeof edgeRemove !== 'object' || edgeRemove === null) return false;
-  if (typeof edgeRemove.sourcePlaceName !== 'string' || edgeRemove.sourcePlaceName.trim() === '') {
-    console.warn("Validation Error (EdgeRemove): 'sourcePlaceName' is required. Value:", edgeRemove.sourcePlaceName);
+  const rem = edgeRemove as Record<string, unknown>;
+  if (typeof rem.sourcePlaceName !== 'string' || rem.sourcePlaceName.trim() === '') {
+    console.warn("Validation Error (EdgeRemove): 'sourcePlaceName' is required. Value:", rem.sourcePlaceName);
     return false;
   }
-  if (typeof edgeRemove.targetPlaceName !== 'string' || edgeRemove.targetPlaceName.trim() === '') {
-    console.warn("Validation Error (EdgeRemove): 'targetPlaceName' is required. Value:", edgeRemove.targetPlaceName);
+  if (typeof rem.targetPlaceName !== 'string' || rem.targetPlaceName.trim() === '') {
+    console.warn("Validation Error (EdgeRemove): 'targetPlaceName' is required. Value:", rem.targetPlaceName);
     return false;
   }
-  if (edgeRemove.type !== undefined && (typeof edgeRemove.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(edgeRemove.type as any))) {
-    console.warn("Validation Error (EdgeRemove): Optional 'type' is invalid. Value:", edgeRemove.type);
+  if (rem.type !== undefined && (typeof rem.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(rem.type as MapEdgeData['type']))) {
+    console.warn("Validation Error (EdgeRemove): Optional 'type' is invalid. Value:", rem.type);
     return false;
   }
   return true;
 }
 
+/**
+ * Validates a full AIMapUpdatePayload object received from the map AI service.
+ * @param payload - The parsed payload to validate.
+ * @returns True if the payload conforms to expected structure.
+ */
 export function isValidAIMapUpdatePayload(payload: AIMapUpdatePayload | null): payload is AIMapUpdatePayload {
   if (typeof payload !== 'object' || payload === null) {
     console.warn("Validation Error (AIMapUpdatePayload): Payload is not an object or is null.");


### PR DESCRIPTION
## Summary
- tighten error extraction types
- use structured clone fallbacks without `any`
- convert eligible `let` declarations to `const`
- document initial-state helpers and matcher util
- add comprehensive validation comments and safer unknown handling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842c10bf01c8324b2f1ced5fea9b1c9