### PR TITLE
Adjust ESLint config to ignore build directories

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,11 @@ const compat = new FlatCompat({
   allConfig: js.configs.all
 });
 
-export const ignores = ['node_modules', 'dist', 'build'];
+
+// Explicitly ignore generated and dependency directories.
+const ignoreConfig = {
+  ignores: ['node_modules', 'dist', 'build']
+};
 
 const tsCompat = compat.config({
   parser: '@typescript-eslint/parser',
@@ -47,4 +51,9 @@ const tsCompat = compat.config({
   }
 }).map(c => ({ ...c, files: ['**/*.{ts,tsx}'] }));
 
-export default [js.configs.recommended, ...compat.plugins('@typescript-eslint', 'react', 'react-hooks'), ...tsCompat];
+export default [
+  ignoreConfig,
+  js.configs.recommended,
+  ...compat.plugins('@typescript-eslint', 'react', 'react-hooks'),
+  ...tsCompat
+];


### PR DESCRIPTION
## Summary
- ensure dist and build directories are skipped by ESLint by adding an ignore object to `eslint.config.js`
- run lint and build to confirm setup

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842aace6e088324b7031f91e3508fe9