### PR TITLE
Refactor localStorage loader

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,8 +60,8 @@ const App: React.FC = () => {
   const [appReady, setAppReady] = useState(false);
 
   useEffect(() => {
-    const loadInitialData = async () => {
-      const loadedState = await loadGameStateFromLocalStorage();
+    const loadInitialData = () => {
+      const loadedState = loadGameStateFromLocalStorage();
       if (loadedState) {
         setPlayerGender(loadedState.playerGender ?? DEFAULT_PLAYER_GENDER);
         setEnabledThemePacks(loadedState.enabledThemePacks ?? [...DEFAULT_ENABLED_THEME_PACKS]);
@@ -73,9 +73,8 @@ const App: React.FC = () => {
       }
       setAppReady(true);
     };
-    // Execute the async data loading and explicitly ignore the returned promise
-    // since we handle all state updates internally.
-    void loadInitialData();
+    // Load initial data and update settings; no async operations needed here.
+    loadInitialData();
   }, []);
 
   const handleSettingsUpdateFromLoad = useCallback((loadedSettings: Partial<Pick<FullGameState, 'playerGender' | 'enabledThemePacks' | 'stabilityLevel' | 'chaosLevel'>>) => {

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -38,12 +38,17 @@ export const saveGameStateToLocalStorage = (gameState: FullGameState): boolean =
  * Loads the latest saved game from localStorage if available.
  * Handles version conversion and validation steps.
  */
-export const loadGameStateFromLocalStorage = async (): Promise<FullGameState | null> => {
+export const loadGameStateFromLocalStorage = (): FullGameState | null => {
   try {
     const savedDataString = localStorage.getItem(LOCAL_STORAGE_SAVE_KEY);
     if (!savedDataString) return null;
 
-    let parsedData = JSON.parse(savedDataString);
+    const parsedData: unknown = JSON.parse(savedDataString);
+    if (typeof parsedData !== 'object' || parsedData === null) {
+      console.warn('Saved data found in localStorage is not an object.');
+      return null;
+    }
+
     let dataToValidateAndExpand: SavedGameDataShape | null = null;
 
     if (parsedData && parsedData.saveGameVersion === '2') {


### PR DESCRIPTION
## Summary
- make `loadGameStateFromLocalStorage` synchronous and add runtime checks
- update `App` to match new synchronous loader

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842ce74b6d8832497c3f60e3356fcc1