### PR TITLE
Fix lint issues in parser and save modules

### DIFF
--- a/components/ItemChangeAnimator.tsx
+++ b/components/ItemChangeAnimator.tsx
@@ -4,7 +4,7 @@
  * @description Animates item gain, loss, and changes.
  */
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { Item, TurnChanges, ItemChangeRecord, KnownUse } from '../types';
+import { Item, TurnChanges, KnownUse } from '../types';
 import { ItemTypeDisplay } from './InventoryDisplay';
 
 type AnimationType = 'gain' | 'loss' | 'change';

--- a/components/MapDisplay.tsx
+++ b/components/MapDisplay.tsx
@@ -6,7 +6,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { MapData, MapNode, MapEdge, MapLayoutConfig } from '../types';
 import {
-  LayoutForceConstants,
   DEFAULT_K_REPULSION,
   DEFAULT_K_SPRING,
   DEFAULT_IDEAL_EDGE_LENGTH,
@@ -112,22 +111,12 @@ const MapDisplay: React.FC<MapDisplayProps> = ({
    */
   const runLayout = useCallback(() => {
     const nodesToProcess = [...currentThemeNodes];
-    const forceConstants: LayoutForceConstants = {
-      K_REPULSION: layoutKRepulsion,
-      K_SPRING: layoutKSpring,
-      IDEAL_EDGE_LENGTH: layoutIdealEdgeLength,
-      K_CENTERING: 0,
-      K_UNTANGLE: layoutKUntangle,
-      K_EDGE_NODE_REPULSION: layoutKEdgeNodeRepulsion,
-      DAMPING_FACTOR: layoutDampingFactor,
-      MAX_DISPLACEMENT: layoutMaxDisplacement,
-    };
 
     // Previously the layout algorithm adjusted node positions here using
     // a force-directed approach, but automatic adjustments are disabled.
 
     setDisplayedNodes(nodesToProcess);
-  }, [currentThemeNodes, layoutIterations, layoutKRepulsion, layoutKSpring, layoutIdealEdgeLength, layoutKUntangle, layoutKEdgeNodeRepulsion, layoutDampingFactor, layoutMaxDisplacement]);
+  }, [currentThemeNodes]);
 
   useEffect(() => {
     if (isVisible) {

--- a/components/SettingsDisplay.tsx
+++ b/components/SettingsDisplay.tsx
@@ -147,7 +147,7 @@ const SettingsDisplay: React.FC<SettingsDisplayProps> = ({
                 // disabled={isCustomGameMode} // REMOVED: Slider is now interactive
               />
               <p id="chaosSliderLabel" className={`settings-explanation ${sliderControlOpacityClass}`}>
-                Percentage chance (0-100%) of a random reality shift occurring each turn, *after* the 'Stability' period has passed.
+                Percentage chance (0-100%) of a random reality shift occurring each turn, *after* the &apos;Stability&apos; period has passed.
                 Higher values mean more frequent shifts.
               </p>
             </div>
@@ -160,7 +160,7 @@ const SettingsDisplay: React.FC<SettingsDisplayProps> = ({
           <div className="mb-8">
             <h2 className="text-xl font-semibold text-amber-400 mb-3 pb-1 border-b border-amber-600">Player Character Gender</h2>
             <p className="settings-explanation mb-3">
-              Choose your character's gender. This may subtly influence descriptions and interactions in the game. Changing it in the middle of the game can have unexpected effects.
+              Choose your character&apos;s gender. This may subtly influence descriptions and interactions in the game. Changing it in the middle of the game can have unexpected effects.
             </p>
             <div className="space-y-3">
               {(['Male', 'Female', 'Custom'] as const).map(option => (
@@ -182,7 +182,7 @@ const SettingsDisplay: React.FC<SettingsDisplayProps> = ({
                   type="text"
                   value={customGenderInput}
                   onChange={handleCustomGenderInputChange}
-                  placeholder="Enter custom gender (or leave blank for 'Not Specified')"
+                  placeholder="Enter custom gender (or leave blank for &apos;Not Specified&apos;)"
                   className="w-full p-2 mt-2 bg-slate-600 text-slate-100 border border-slate-500 rounded-md focus:ring-sky-500 focus:border-sky-500"
                   aria-label="Custom gender input"
                 />

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -90,7 +90,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
 
   const {
     processAiResponse,
-    executePlayerAction,
     handleActionSelect,
     handleItemInteraction,
     handleDiscardJunkItem,
@@ -150,7 +149,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     setIsLoading,
     setLoadingReason,
     onDialogueConcluded: (summaryPayload, preparedGameState) => {
-      let draftState = structuredCloneGameState(preparedGameState);
+      const draftState = structuredCloneGameState(preparedGameState);
       processAiResponse(summaryPayload, preparedGameState.currentThemeObject, draftState, {
         baseStateSnapshot: structuredCloneGameState(preparedGameState),
         isFromDialogueSummary: true,

--- a/services/corrections/base.ts
+++ b/services/corrections/base.ts
@@ -19,7 +19,7 @@ export const CORRECTION_TEMPERATURE = 0.75;
  * The generic type allows callers to specify the expected shape of the
  * parsed JSON result.
  */
-export const callCorrectionAI = async <T = any>(
+export const callCorrectionAI = async <T = unknown>(
   prompt: string,
   systemInstruction: string
 ): Promise<T | null> => {

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -21,7 +21,7 @@ export const fetchCorrectedDialogueSetup_Service = async (
   allRelevantMapNodes: MapNode[],
   currentInventory: Item[],
   playerGender: string,
-  malformedDialogueSetup: Partial<DialogueSetupPayload> | unknown
+  malformedDialogueSetup: Partial<DialogueSetupPayload>
 ): Promise<DialogueSetupPayload | null> => {
   if (!isApiConfigured()) {
     console.error('fetchCorrectedDialogueSetup_Service: API Key not configured.');

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -5,7 +5,6 @@
 import { Item, AdventureTheme, ItemChange } from '../../types';
 import { MAX_RETRIES, VALID_ITEM_TYPES_STRING } from '../../constants';
 import { isValidItem } from '../parsers/validation';
-import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
 import { callCorrectionAI, callMinimalCorrectionAI } from './base';
 import { isApiConfigured } from '../apiClient';
 
@@ -26,7 +25,7 @@ export const fetchCorrectedItemPayload_Service = async (
 
   let originalItemNameFromMalformed = 'Not specified or unparseable from malformed payload';
   try {
-    const malformedObj = JSON.parse(malformedPayloadString);
+    const malformedObj: Record<string, unknown> = JSON.parse(malformedPayloadString) as Record<string, unknown>;
     if (malformedObj && typeof malformedObj.name === 'string') {
       originalItemNameFromMalformed = `"${malformedObj.name}"`;
     }

--- a/services/corrections/map.ts
+++ b/services/corrections/map.ts
@@ -77,7 +77,8 @@ export const fetchCorrectedPlaceDetails_Service = async (
 
   let originalPlaceNameFromMalformed = 'Not specified or unparseable';
   try {
-    const malformedObj = JSON.parse(malformedMapNodePayloadString);
+    const malformedObj: Record<string, unknown> =
+      JSON.parse(malformedMapNodePayloadString) as Record<string, unknown>;
     if (malformedObj && typeof malformedObj.name === 'string') {
       originalPlaceNameFromMalformed = `"${malformedObj.name}"`;
     } else if (typeof malformedMapNodePayloadString === 'string' && !malformedMapNodePayloadString.startsWith('{')) {
@@ -187,8 +188,7 @@ Respond ONLY with the single, complete JSON object.`;
  * Attempts to correct or infer a missing or invalid nodeType for a MapNode.
  */
 export const fetchCorrectedNodeType_Service = async (
-  nodeInfo: { placeName: string; nodeType?: string; description?: string },
-  currentTheme: AdventureTheme
+  nodeInfo: { placeName: string; nodeType?: string; description?: string }
 ): Promise<NonNullable<MapNodeData['nodeType']> | null> => {
   const synonyms: Record<string, NonNullable<MapNodeData['nodeType']>> = {
     area: 'region',
@@ -254,8 +254,8 @@ export const fetchCorrectedNodeType_Service = async (
 
   if (nodeInfo.nodeType) {
     const normalized = synonyms[nodeInfo.nodeType.toLowerCase()] || nodeInfo.nodeType.toLowerCase();
-    if (VALID_NODE_TYPE_VALUES.includes(normalized as NonNullable<MapNodeData['nodeType']>)) {
-      return normalized as NonNullable<MapNodeData['nodeType']>;
+    if (VALID_NODE_TYPE_VALUES.includes(normalized as MapNodeData['nodeType'])) {
+      return normalized as MapNodeData['nodeType'];
     }
   }
 
@@ -290,8 +290,8 @@ Respond ONLY with the single node type.`;
     if (typeResp) {
       const cleaned = typeResp.trim().toLowerCase();
       const mapped = synonyms[cleaned] || cleaned;
-      if (VALID_NODE_TYPE_VALUES.includes(mapped as NonNullable<MapNodeData['nodeType']>)) {
-        return mapped as NonNullable<MapNodeData['nodeType']>;
+      if (VALID_NODE_TYPE_VALUES.includes(mapped as MapNodeData['nodeType'])) {
+        return mapped as MapNodeData['nodeType'];
       }
     }
   }
@@ -302,8 +302,7 @@ Respond ONLY with the single node type.`;
  * Attempts to correct or infer a missing or invalid edge type for a MapEdge.
  */
 export const fetchCorrectedEdgeType_Service = async (
-  edgeInfo: { type?: string; description?: string },
-  currentTheme: AdventureTheme
+  edgeInfo: { type?: string; description?: string }
 ): Promise<MapEdgeData['type'] | null> => {
   const synonyms: Record<string, MapEdgeData['type']> = {
     trail: 'path',

--- a/services/dialogueService.ts
+++ b/services/dialogueService.ts
@@ -6,9 +6,9 @@
 import { GenerateContentResponse } from "@google/genai";
 import {
   DialogueAIResponse, DialogueHistoryEntry, DialogueSummaryContext, DialogueSummaryResponse,
-  Item, Character, GameStateFromAI, MapNode, MapData, DialogueMemorySummaryContext, AdventureTheme // Added AdventureTheme
+  Item, Character, MapNode, DialogueMemorySummaryContext, AdventureTheme
 } from '../types';
-import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MINIMAL_MODEL_NAME, MAX_RETRIES, MAX_DIALOGUE_SUMMARIES_IN_PROMPT } from '../constants';
+import { GEMINI_MODEL_NAME, MAX_RETRIES, MAX_DIALOGUE_SUMMARIES_IN_PROMPT } from '../constants';
 import { 
     DIALOGUE_SYSTEM_INSTRUCTION, 
     DIALOGUE_SUMMARY_SYSTEM_INSTRUCTION

--- a/services/gameAIService.ts
+++ b/services/gameAIService.ts
@@ -4,8 +4,8 @@
  * @description Wrapper functions for the main storytelling AI interactions.
  */
 import { GenerateContentResponse } from "@google/genai";
-import { GameStateFromAI, Item, ItemChange, AdventureTheme, Character, MapNode } from '../types'; // Removed Place, added MapNode
-import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES, DEFAULT_PLAYER_GENDER } from '../constants';
+import { AdventureTheme } from '../types';
+import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
 import { SYSTEM_INSTRUCTION } from '../prompts/mainPrompts';
 import { ai } from './geminiClient';
 import { dispatchAIRequest } from './modelDispatcher';
@@ -50,7 +50,8 @@ export const executeAIMainTurn = async (
         } catch (error) {
             console.error(`Error executing AI Main Turn (Attempt ${attempt}/${MAX_RETRIES}):`, error);
             if (isServerOrClientError(error)) {
-                return Promise.reject(error);
+                const err = error instanceof Error ? error : new Error(String(error));
+                return Promise.reject(err);
             }
             if (attempt === MAX_RETRIES) {
                 return Promise.reject(new Error(`Failed to execute AI Main Turn after maximum retries: ${error instanceof Error ? error.message : String(error)}`));

--- a/services/geminiClient.ts
+++ b/services/geminiClient.ts
@@ -3,7 +3,7 @@
  * @description Provides a shared GoogleGenAI client instance.
  */
 import { GoogleGenAI } from "@google/genai";
-import { geminiClient, isApiConfigured, getApiKey } from "./apiClient";
+import { geminiClient, isApiConfigured } from "./apiClient";
 
 if (!isApiConfigured()) {
   console.error("GEMINI_API_KEY environment variable is not set. The application will not be able to connect to the Gemini API.");

--- a/services/mapRenameService.ts
+++ b/services/mapRenameService.ts
@@ -69,7 +69,7 @@ export const applyRenamePayload = (
   payload: RenameMapElementsPayload
 ): void => {
   payload.nodes.forEach(nu => {
-    const node = (mapData.nodes as MapNode[]).find(n => n.id === nu.id);
+    const node = mapData.nodes.find(n => n.id === nu.id);
     if (node) {
       node.placeName = nu.placeName;
       node.data.description = nu.description;
@@ -77,7 +77,7 @@ export const applyRenamePayload = (
     }
   });
   payload.edges.forEach(eu => {
-    const edge = (mapData.edges as MapEdge[]).find(e => e.id === eu.id);
+    const edge = mapData.edges.find(e => e.id === eu.id);
     if (edge) {
       edge.data.description = eu.description;
     }

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -2,50 +2,59 @@
  * @file validation.ts
  * @description Shared validation helpers for AI payloads.
  */
-import { Item, KnownUse, ItemType, Character, DialogueTurnResponsePart, ValidCharacterUpdatePayload, ValidNewCharacterPayload, DialogueSetupPayload } from '../../types';
+import {
+  Item,
+  KnownUse,
+  ValidCharacterUpdatePayload,
+  ValidNewCharacterPayload,
+  DialogueSetupPayload,
+} from '../../types';
 import { VALID_ITEM_TYPES } from '../../constants';
 
 export function isValidKnownUse(ku: unknown): ku is KnownUse {
-  return ku &&
-    typeof ku.actionName === 'string' && ku.actionName.trim() !== '' &&
-    typeof ku.promptEffect === 'string' && ku.promptEffect.trim() !== '' && // Ensure non-empty
-    (ku.appliesWhenActive === undefined || typeof ku.appliesWhenActive === 'boolean') &&
-    (ku.appliesWhenInactive === undefined || typeof ku.appliesWhenInactive === 'boolean') &&
-    (ku.description === undefined || typeof ku.description === 'string');
+  if (!ku || typeof ku !== 'object') return false;
+  const obj = ku as Partial<KnownUse>;
+  if (typeof obj.actionName !== 'string' || obj.actionName.trim() === '') return false;
+  if (typeof obj.promptEffect !== 'string' || obj.promptEffect.trim() === '') return false;
+  if (obj.appliesWhenActive !== undefined && typeof obj.appliesWhenActive !== 'boolean') return false;
+  if (obj.appliesWhenInactive !== undefined && typeof obj.appliesWhenInactive !== 'boolean') return false;
+  if (obj.description !== undefined && typeof obj.description !== 'string') return false;
+  return true;
 }
 
 export function isValidItem(item: unknown, context?: 'gain' | 'update'): item is Item {
   if (!item || typeof item !== 'object') return false;
+  const obj = item as Partial<Item>;
 
   // Name is always required
-  if (typeof item.name !== 'string' || item.name.trim() === '') {
+  if (typeof obj.name !== 'string' || obj.name.trim() === '') {
     console.warn("isValidItem: 'name' is missing or invalid.", item);
     return false;
   }
 
   // Fields required for 'gain' or if it's not an 'update' context
   if (context === 'gain' || !context) {
-    if (typeof item.type !== 'string' || !(VALID_ITEM_TYPES as readonly string[]).includes(item.type)) {
+    if (typeof obj.type !== 'string' || !VALID_ITEM_TYPES.includes(obj.type)) {
         console.warn(`isValidItem (context: ${context || 'default'}): 'type' is missing or invalid.`, item);
         return false;
     }
-    if (typeof item.description !== 'string' || item.description.trim() === '') {
+    if (typeof obj.description !== 'string' || obj.description.trim() === '') {
         console.warn(`isValidItem (context: ${context || 'default'}): 'description' is missing or invalid.`, item);
         return false;
     }
   }
 
   // Fields required for 'update' if it's a transformation (newName is present)
-  if (context === 'update' && item.newName !== undefined && item.newName !== null) {
-    if (typeof item.newName !== 'string' || item.newName.trim() === '') {
+  if (context === 'update' && obj.newName !== undefined && obj.newName !== null) {
+    if (typeof obj.newName !== 'string' || obj.newName.trim() === '') {
         console.warn("isValidItem (context: update, with newName): 'newName' is invalid.", item);
         return false;
     }
-    if (typeof item.type !== 'string' || !(VALID_ITEM_TYPES as readonly string[]).includes(item.type)) {
+    if (typeof obj.type !== 'string' || !VALID_ITEM_TYPES.includes(obj.type)) {
         console.warn("isValidItem (context: update, with newName): 'type' is missing or invalid for transformed item.", item);
         return false;
     }
-    if (typeof item.description !== 'string' || item.description.trim() === '') {
+    if (typeof obj.description !== 'string' || obj.description.trim() === '') {
         console.warn("isValidItem (context: update, with newName): 'description' is missing or invalid for transformed item.", item);
         return false;
     }
@@ -53,35 +62,35 @@ export function isValidItem(item: unknown, context?: 'gain' | 'update'): item is
 
 
   // Validate optional fields if they are present, regardless of context (unless specific context requires them)
-  if (item.type !== undefined && (typeof item.type !== 'string' || !(VALID_ITEM_TYPES as readonly string[]).includes(item.type))) {
+  if (obj.type !== undefined && (typeof obj.type !== 'string' || !VALID_ITEM_TYPES.includes(obj.type))) {
     console.warn("isValidItem: 'type' is present but invalid.", item);
     return false;
   }
-  if (item.description !== undefined && (typeof item.description !== 'string' || item.description.trim() === '')) {
+  if (obj.description !== undefined && (typeof obj.description !== 'string' || obj.description.trim() === '')) {
       // Allow empty description if it's an update payload and not a transformation,
       // as it might be intentionally cleared, but an empty description for a gain/new item is bad.
-      if ((context === 'gain' || (context === 'update' && item.newName)) && item.description.trim() === '') {
+      if ((context === 'gain' || (context === 'update' && obj.newName)) && obj.description.trim() === '') {
         console.warn(`isValidItem: 'description' is present but empty, which is invalid for a gain or transformation.`, item);
         return false;
       }
   }
-  if (item.activeDescription !== undefined && typeof item.activeDescription !== 'string') {
+  if (obj.activeDescription !== undefined && typeof obj.activeDescription !== 'string') {
     console.warn("isValidItem: 'activeDescription' is present but invalid.", item);
     return false;
   }
-  if (item.isActive !== undefined && typeof item.isActive !== 'boolean') {
+  if (obj.isActive !== undefined && typeof obj.isActive !== 'boolean') {
     console.warn("isValidItem: 'isActive' is present but invalid.", item);
     return false;
   }
-  if (item.isJunk !== undefined && typeof item.isJunk !== 'boolean') {
+  if (obj.isJunk !== undefined && typeof obj.isJunk !== 'boolean') {
     console.warn("isValidItem: 'isJunk' is present but invalid.", item);
     return false;
   }
-  if (item.knownUses !== undefined && !(Array.isArray(item.knownUses) && item.knownUses.every(isValidKnownUse))) {
+  if (obj.knownUses !== undefined && !(Array.isArray(obj.knownUses) && obj.knownUses.every(isValidKnownUse))) {
     console.warn("isValidItem: 'knownUses' is present but invalid.", item);
     return false;
   }
-  if (item.addKnownUse !== undefined && !isValidKnownUse(item.addKnownUse)) {
+  if (obj.addKnownUse !== undefined && !isValidKnownUse(obj.addKnownUse)) {
     console.warn("isValidItem: 'addKnownUse' is present but invalid.", item);
     return false;
   }
@@ -90,26 +99,45 @@ export function isValidItem(item: unknown, context?: 'gain' | 'update'): item is
 }
 
 
-export function isValidNameDescAliasesPair(obj: unknown): obj is { name: string; description: string; aliases?: string[] } {
-    return obj && typeof obj.name === 'string' && obj.name.trim() !== '' &&
-           typeof obj.description === 'string' && 
-           (obj.aliases === undefined || (Array.isArray(obj.aliases) && obj.aliases.every((alias: unknown) => typeof alias === 'string')));
+/**
+ * Checks if the provided object contains a valid name, description and optional
+ * aliases array.
+ */
+export function isValidNameDescAliasesPair(
+  obj: unknown,
+): obj is { name: string; description: string; aliases?: string[] } {
+  if (!obj || typeof obj !== 'object') return false;
+  const maybe = obj as {
+    name?: unknown;
+    description?: unknown;
+    aliases?: unknown;
+  };
+  return (
+    typeof maybe.name === 'string' &&
+    maybe.name.trim() !== '' &&
+    typeof maybe.description === 'string' &&
+    (maybe.aliases === undefined ||
+      (Array.isArray(maybe.aliases) &&
+        maybe.aliases.every((alias: unknown) => typeof alias === 'string')))
+  );
 }
 
 // Specific validator for CharacterUpdate payload elements from AI
 export function isValidCharacterUpdate(obj: unknown): obj is ValidCharacterUpdatePayload {
-    if (!obj || typeof obj.name !== 'string' || obj.name.trim() === '') return false;
-    if (obj.newDescription !== undefined && typeof obj.newDescription !== 'string') return false;
-    if (obj.newAliases !== undefined && !(Array.isArray(obj.newAliases) && obj.newAliases.every((alias: unknown) => typeof alias === 'string'))) return false;
-    if (obj.addAlias !== undefined && typeof obj.addAlias !== 'string') return false; 
-    if (obj.newPresenceStatus !== undefined && !['distant', 'nearby', 'companion', 'unknown'].includes(obj.newPresenceStatus)) return false;
-    if (obj.newLastKnownLocation !== undefined && obj.newLastKnownLocation !== null && typeof obj.newLastKnownLocation !== 'string') return false; 
-    if (obj.newPreciseLocation !== undefined && obj.newPreciseLocation !== null && typeof obj.newPreciseLocation !== 'string') return false;
+    if (!obj || typeof obj !== 'object') return false;
+    const maybe = obj as Partial<ValidCharacterUpdatePayload>;
+    if (typeof maybe.name !== 'string' || maybe.name.trim() === '') return false;
+    if (maybe.newDescription !== undefined && typeof maybe.newDescription !== 'string') return false;
+    if (maybe.newAliases !== undefined && !(Array.isArray(maybe.newAliases) && maybe.newAliases.every((alias: unknown) => typeof alias === 'string'))) return false;
+    if (maybe.addAlias !== undefined && typeof maybe.addAlias !== 'string') return false;
+    if (maybe.newPresenceStatus !== undefined && !['distant', 'nearby', 'companion', 'unknown'].includes(maybe.newPresenceStatus)) return false;
+    if (maybe.newLastKnownLocation !== undefined && maybe.newLastKnownLocation !== null && typeof maybe.newLastKnownLocation !== 'string') return false;
+    if (maybe.newPreciseLocation !== undefined && maybe.newPreciseLocation !== null && typeof maybe.newPreciseLocation !== 'string') return false;
     
-    if ((obj.newPresenceStatus === 'nearby' || obj.newPresenceStatus === 'companion') && obj.newPreciseLocation === undefined) {
+    if ((maybe.newPresenceStatus === 'nearby' || maybe.newPresenceStatus === 'companion') && maybe.newPreciseLocation === undefined) {
       // This could be problematic if AI intends to set a location but omits the field.
     }
-    if ((obj.newPresenceStatus === 'distant' || obj.newPresenceStatus === 'unknown') && obj.newPreciseLocation !== undefined && obj.newPreciseLocation !== null) {
+    if ((maybe.newPresenceStatus === 'distant' || maybe.newPresenceStatus === 'unknown') && maybe.newPreciseLocation !== undefined && maybe.newPreciseLocation !== null) {
       // console.warn("Character update: preciseLocation provided for a non-present character. This will be ignored or nulled by game logic.");
     }
     return true;
@@ -117,17 +145,19 @@ export function isValidCharacterUpdate(obj: unknown): obj is ValidCharacterUpdat
 
 // Validator for Character object from AI charactersAdded
 export function isValidNewCharacterPayload(obj: unknown): obj is ValidNewCharacterPayload {
-    if (!obj || typeof obj.name !== 'string' || obj.name.trim() === '') return false;
-    if (typeof obj.description !== 'string' || obj.description.trim() === '') return false; 
-    if (obj.aliases !== undefined && !(Array.isArray(obj.aliases) && obj.aliases.every((alias: unknown) => typeof alias === 'string'))) return false;
-    if (obj.presenceStatus !== undefined && !['distant', 'nearby', 'companion', 'unknown'].includes(obj.presenceStatus)) return false;
-    if (obj.lastKnownLocation !== undefined && obj.lastKnownLocation !== null && typeof obj.lastKnownLocation !== 'string') return false; 
-    if (obj.preciseLocation !== undefined && obj.preciseLocation !== null && typeof obj.preciseLocation !== 'string') return false;
+    if (!obj || typeof obj !== 'object') return false;
+    const maybe = obj as Partial<ValidNewCharacterPayload>;
+    if (typeof maybe.name !== 'string' || maybe.name.trim() === '') return false;
+    if (typeof maybe.description !== 'string' || maybe.description.trim() === '') return false;
+    if (maybe.aliases !== undefined && !(Array.isArray(maybe.aliases) && maybe.aliases.every((alias: unknown) => typeof alias === 'string'))) return false;
+    if (maybe.presenceStatus !== undefined && !['distant', 'nearby', 'companion', 'unknown'].includes(maybe.presenceStatus)) return false;
+    if (maybe.lastKnownLocation !== undefined && maybe.lastKnownLocation !== null && typeof maybe.lastKnownLocation !== 'string') return false;
+    if (maybe.preciseLocation !== undefined && maybe.preciseLocation !== null && typeof maybe.preciseLocation !== 'string') return false;
 
-    if ((obj.presenceStatus === 'nearby' || obj.presenceStatus === 'companion') && obj.preciseLocation === undefined) {
+    if ((maybe.presenceStatus === 'nearby' || maybe.presenceStatus === 'companion') && maybe.preciseLocation === undefined) {
       // console.warn("New character: preciseLocation undefined for a present character.");
     }
-    if ((obj.presenceStatus === 'distant' || obj.presenceStatus === 'unknown') && obj.preciseLocation !== undefined && obj.preciseLocation !== null) {
+    if ((maybe.presenceStatus === 'distant' || maybe.presenceStatus === 'unknown') && maybe.preciseLocation !== undefined && maybe.preciseLocation !== null) {
        // console.warn("New character: preciseLocation provided for a non-present character.");
     }
     return true;
@@ -140,45 +170,62 @@ export function isValidNewCharacterPayload(obj: unknown): obj is ValidNewCharact
  * @returns {boolean} True if `dialogueSetup` has a valid structure, false otherwise.
  */
 export function isDialogueSetupPayloadStructurallyValid(
-  dialogueSetup?: unknown // Can be malformed or undefined
+  dialogueSetup?: unknown, // Can be malformed or undefined
 ): dialogueSetup is DialogueSetupPayload {
-  
   if (!dialogueSetup || typeof dialogueSetup !== 'object') {
-    console.warn("isDialogueSetupPayloadStructurallyValid: dialogueSetup is missing or not an object.");
+    console.warn(
+      'isDialogueSetupPayloadStructurallyValid: dialogueSetup is missing or not an object.',
+    );
     return false;
   }
 
-  // Validate dialogueSetup.participants
-  if (
-    !Array.isArray(dialogueSetup.participants) ||
-    dialogueSetup.participants.length === 0 ||
-    !dialogueSetup.participants.every((p: unknown) => typeof p === 'string' && p.trim() !== '')
-  ) {
-    console.warn("isDialogueSetupPayloadStructurallyValid: dialogueSetup.participants is invalid.", dialogueSetup.participants);
-    return false;
-  }
+  const obj = dialogueSetup as Partial<DialogueSetupPayload>;
 
-  // Validate dialogueSetup.initialNpcResponses
   if (
-    !Array.isArray(dialogueSetup.initialNpcResponses) ||
-    dialogueSetup.initialNpcResponses.length === 0 || // Must have at least one NPC response
-    !dialogueSetup.initialNpcResponses.every((r: unknown) =>
-      r && typeof r.speaker === 'string' && r.speaker.trim() !== '' &&
-      dialogueSetup.participants.includes(r.speaker) && // Speaker must be one of the participants
-      typeof r.line === 'string' && r.line.trim() !== ''
+    !Array.isArray(obj.participants) ||
+    obj.participants.length === 0 ||
+    !obj.participants.every(
+      (p: unknown) => typeof p === 'string' && p.trim() !== '',
     )
   ) {
-    console.warn("isDialogueSetupPayloadStructurallyValid: dialogueSetup.initialNpcResponses is invalid.", dialogueSetup.initialNpcResponses);
+    console.warn(
+      'isDialogueSetupPayloadStructurallyValid: dialogueSetup.participants is invalid.',
+      obj.participants,
+    );
     return false;
   }
 
-  // Validate dialogueSetup.initialPlayerOptions
   if (
-    !Array.isArray(dialogueSetup.initialPlayerOptions) ||
-    dialogueSetup.initialPlayerOptions.length < 4 || // Must have at least 4 options (e.g., 3 choices + end)
-    !dialogueSetup.initialPlayerOptions.every((opt: unknown) => typeof opt === 'string' && opt.trim() !== '')
+    !Array.isArray(obj.initialNpcResponses) ||
+    obj.initialNpcResponses.length === 0 ||
+    !obj.initialNpcResponses.every(
+      (r: unknown) =>
+        r &&
+        typeof (r as { speaker?: unknown }).speaker === 'string' &&
+        (r as { speaker: string }).speaker.trim() !== '' &&
+        obj.participants.includes((r as { speaker: string }).speaker) &&
+        typeof (r as { line?: unknown }).line === 'string' &&
+        (r as { line: string }).line.trim() !== '',
+    )
   ) {
-    console.warn("isDialogueSetupPayloadStructurallyValid: dialogueSetup.initialPlayerOptions is invalid.", dialogueSetup.initialPlayerOptions);
+    console.warn(
+      'isDialogueSetupPayloadStructurallyValid: dialogueSetup.initialNpcResponses is invalid.',
+      obj.initialNpcResponses,
+    );
+    return false;
+  }
+
+  if (
+    !Array.isArray(obj.initialPlayerOptions) ||
+    obj.initialPlayerOptions.length < 4 ||
+    !obj.initialPlayerOptions.every(
+      (opt: unknown) => typeof opt === 'string' && opt.trim() !== '',
+    )
+  ) {
+    console.warn(
+      'isDialogueSetupPayloadStructurallyValid: dialogueSetup.initialPlayerOptions is invalid.',
+      obj.initialPlayerOptions,
+    );
     return false;
   }
 

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -49,21 +49,27 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
       return null;
     }
 
+    const parsedObj = parsedData as Record<string, unknown>;
+
     let dataToValidateAndExpand: SavedGameDataShape | null = null;
 
-    if (parsedData && parsedData.saveGameVersion === '2') {
+    if (parsedObj && parsedObj.saveGameVersion === '2') {
       console.log('V2 save data detected from localStorage. Attempting conversion to V3...');
-      dataToValidateAndExpand = convertV2toV3Shape(parsedData as V2IntermediateSavedGameState);
-    } else if (parsedData && (parsedData.saveGameVersion === CURRENT_SAVE_GAME_VERSION || (typeof parsedData.saveGameVersion === 'string' && parsedData.saveGameVersion.startsWith(CURRENT_SAVE_GAME_VERSION.split('.')[0])))) {
-      if (parsedData.saveGameVersion !== CURRENT_SAVE_GAME_VERSION) {
-        console.warn(`Potentially compatible future V${CURRENT_SAVE_GAME_VERSION.split('.')[0]}.x save version '${parsedData.saveGameVersion}' from localStorage. Attempting to treat as current version (V3) for validation.`);
+      dataToValidateAndExpand = convertV2toV3Shape(parsedObj as V2IntermediateSavedGameState);
+    } else if (
+      parsedObj &&
+      (parsedObj.saveGameVersion === CURRENT_SAVE_GAME_VERSION ||
+        (typeof parsedObj.saveGameVersion === 'string' && parsedObj.saveGameVersion.startsWith(CURRENT_SAVE_GAME_VERSION.split('.')[0])))
+    ) {
+      if (parsedObj.saveGameVersion !== CURRENT_SAVE_GAME_VERSION) {
+        console.warn(`Potentially compatible future V${CURRENT_SAVE_GAME_VERSION.split('.')[0]}.x save version '${String(parsedObj.saveGameVersion)}' from localStorage. Attempting to treat as current version (V3) for validation.`);
       }
-      dataToValidateAndExpand = parsedData as SavedGameDataShape;
+      dataToValidateAndExpand = parsedObj as SavedGameDataShape;
       ensureCompleteMapLayoutConfig(dataToValidateAndExpand);
       ensureCompleteMapNodeDataDefaults(dataToValidateAndExpand.mapData);
-    } else if (parsedData) {
-      console.warn(`Unknown save version '${parsedData.saveGameVersion}' from localStorage. This might fail validation.`);
-      dataToValidateAndExpand = parsedData as SavedGameDataShape;
+    } else if (parsedObj) {
+      console.warn(`Unknown save version '${String(parsedObj.saveGameVersion)}' from localStorage. This might fail validation.`);
+      dataToValidateAndExpand = parsedObj as SavedGameDataShape;
       if (dataToValidateAndExpand) {
         ensureCompleteMapLayoutConfig(dataToValidateAndExpand);
         ensureCompleteMapNodeDataDefaults(dataToValidateAndExpand.mapData);
@@ -78,11 +84,11 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
     }
 
     if (dataToValidateAndExpand) {
-      const gt = (dataToValidateAndExpand as { globalTurnNumber?: unknown }).globalTurnNumber;
-      if (typeof gt === 'string') {
-        const parsed = parseInt(gt, 10);
+      const gtRaw = (parsedObj as { globalTurnNumber?: unknown }).globalTurnNumber;
+      if (typeof gtRaw === 'string') {
+        const parsed = parseInt(gtRaw, 10);
         dataToValidateAndExpand.globalTurnNumber = isNaN(parsed) ? 0 : parsed;
-      } else if (gt === undefined || gt === null) {
+      } else if (gtRaw === undefined || gtRaw === null) {
         dataToValidateAndExpand.globalTurnNumber = 0;
       }
     }
@@ -95,7 +101,7 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
       dataToValidateAndExpand.localTime = dataToValidateAndExpand.localTime ?? null;
       dataToValidateAndExpand.localEnvironment = dataToValidateAndExpand.localEnvironment ?? null;
       dataToValidateAndExpand.localPlace = dataToValidateAndExpand.localPlace ?? null;
-      dataToValidateAndExpand.allCharacters = dataToValidateAndExpand.allCharacters.map((c: unknown) => ({
+      dataToValidateAndExpand.allCharacters = dataToValidateAndExpand.allCharacters.map((c) => ({
         ...c,
         aliases: c.aliases || [],
         presenceStatus: c.presenceStatus || 'unknown',

--- a/utils/gameLogicUtils.ts
+++ b/utils/gameLogicUtils.ts
@@ -154,7 +154,7 @@ export const buildItemChangeRecords = (
     let record: ItemChangeRecord | null = null;
 
     if (change.action === 'gain' && typeof itemPayload === 'object' && itemPayload !== null && 'name' in itemPayload) {
-      const gainedItemData = itemPayload as Item;
+      const gainedItemData = itemPayload;
       const cleanGainedItem: Item = {
         name: gainedItemData.name, type: gainedItemData.type, description: gainedItemData.description,
         activeDescription: gainedItemData.activeDescription,
@@ -168,7 +168,7 @@ export const buildItemChangeRecords = (
       const lostItem = currentInventory.find(i => i.name === itemName);
       if (lostItem) record = { type: 'loss', lostItem: { ...lostItem } }; 
     } else if (change.action === 'update' && typeof itemPayload === 'object' && itemPayload !== null && 'name' in itemPayload) {
-      const updatePayload = itemPayload as Item;
+      const updatePayload = itemPayload;
       const originalItemName = updatePayload.name;
       const oldItem = currentInventory.find(i => i.name === originalItemName);
 


### PR DESCRIPTION
## Summary
- tighten validation helpers and remove unused imports
- sanitize save load helpers with explicit typing and consts
- drop unused helper functions from save converters

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842d1c119c08324ad7d63e05ce8de79