### PR TITLE
Fix map feature upgrade handling

### DIFF
--- a/components/InventoryDisplay.tsx
+++ b/components/InventoryDisplay.tsx
@@ -26,6 +26,7 @@ export const ItemTypeDisplay: React.FC<{ type: Item['type'] }> = ({ type }) => {
     equipment: 'text-sky-400',
     container: 'text-orange-400',
     key: 'text-lime-400',
+    weapon: 'text-amber-400',
     ammunition: 'text-cyan-400',
     vehicle: 'text-indigo-400',
     knowledge: 'text-purple-400',

--- a/services/aiResponseParser.ts
+++ b/services/aiResponseParser.ts
@@ -182,7 +182,7 @@ async function processItemChanges(
     const processedItemChanges: ItemChange[] = [];
     for (const rawIc of changes) {
         const ic = typeof rawIc === 'object' && rawIc !== null
-            ? ({ ...(rawIc as Record<string, unknown>) } as ItemChange)
+            ? ({ ...(rawIc as Record<string, unknown>) } as unknown as ItemChange)
             : (rawIc as ItemChange);
         if (typeof ic === 'object' && ic !== null && Object.keys(ic).length === 0 && ic.constructor === Object) {
             console.warn("parseAIResponse ('itemChange'): Skipping empty itemChange object:", ic);
@@ -379,7 +379,10 @@ async function handleCharacterChanges(
             typeof (cUpdate as { name?: unknown }).name === 'string' &&
             (cUpdate as { name: string }).name.trim() !== ''
         ) {
-            const currentCUpdatePayload: { [key: string]: unknown; name: string } = { ...(cUpdate as Record<string, unknown>) };
+            const currentCUpdatePayload: { [key: string]: unknown; name: string } = {
+                ...(cUpdate as Record<string, unknown>),
+                name: (cUpdate as { name: string }).name,
+            };
             const allKnownAndCurrentlyAddedCharNames = new Set([
                 ...context.allRelevantCharacters.map(c => c.name),
                 ...finalCharactersAdded.map(c => c.name),

--- a/services/dialogueService.ts
+++ b/services/dialogueService.ts
@@ -42,7 +42,7 @@ const callDialogueGeminiAPI = async (
   if (disableThinking) {
     config.thinkingConfig = { thinkingBudget: 0 };
   }
-  return ai.models.generateContent({
+  return ai!.models.generateContent({
     model: GEMINI_MODEL_NAME, // Will use gemini-2.5-flash-preview-04-17
     contents: prompt,
     config: config

--- a/services/gameAIService.ts
+++ b/services/gameAIService.ts
@@ -29,7 +29,7 @@ export const executeAIMainTurn = async (
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         try {
-            const response = await ai.models.generateContent({
+            const response = await ai!.models.generateContent({
                 model: GEMINI_MODEL_NAME,
                 contents: fullPrompt,
                 config: {

--- a/services/mapRenameService.ts
+++ b/services/mapRenameService.ts
@@ -49,13 +49,13 @@ Each array can be empty. Keep IDs exactly as provided.`;
   const systemInst = 'Rename provided map nodes and edges with thematic names. Return strict JSON.';
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const result = await callCorrectionAI(prompt, systemInst);
+    const result = await callCorrectionAI<RenameMapElementsPayload>(prompt, systemInst);
     if (
       result &&
       Array.isArray(result.nodes) &&
       Array.isArray(result.edges)
     ) {
-      return result as RenameMapElementsPayload;
+      return result;
     }
   }
   return null;

--- a/services/mapUpdateService.ts
+++ b/services/mapUpdateService.ts
@@ -474,7 +474,7 @@ Key points:
         aliases: aliases || [],
         status,
         parentNodeId: resolvedParentId,
-        nodeType,
+        nodeType: nodeType ?? 'feature',
         ...rest,
       };
 

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -195,6 +195,8 @@ export function isDialogueSetupPayloadStructurallyValid(
     return false;
   }
 
+  const participants = obj.participants;
+
   if (
     !Array.isArray(obj.initialNpcResponses) ||
     obj.initialNpcResponses.length === 0 ||
@@ -203,7 +205,7 @@ export function isDialogueSetupPayloadStructurallyValid(
         r &&
         typeof (r as { speaker?: unknown }).speaker === 'string' &&
         (r as { speaker: string }).speaker.trim() !== '' &&
-        obj.participants.includes((r as { speaker: string }).speaker) &&
+        participants.includes((r as { speaker: string }).speaker) &&
         typeof (r as { line?: unknown }).line === 'string' &&
         (r as { line: string }).line.trim() !== '',
     )

--- a/services/saveConverters/index.ts
+++ b/services/saveConverters/index.ts
@@ -189,6 +189,7 @@ export async function convertV1toV2Intermediate(v1Data: V1SavedGameState): Promi
         status: 'discovered',
         isFeature: false,
         visited: true,
+        nodeType: 'location',
       },
     };
   });
@@ -300,6 +301,7 @@ export function convertV2toV3Shape(v2Data: V2IntermediateSavedGameState): SavedG
           isFeature: node.data.isFeature ?? false,
           visited: node.data.visited ?? false,
           parentNodeId: node.data.parentNodeId,
+          nodeType: node.data.nodeType ?? 'location',
           ...Object.fromEntries(Object.entries(node.data).filter(([key]) => !['description', 'aliases', 'status', 'isFeature', 'visited', 'parentNodeId'].includes(key)))
         }
       })),

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -55,7 +55,7 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
 
     if (parsedObj && parsedObj.saveGameVersion === '2') {
       console.log('V2 save data detected from localStorage. Attempting conversion to V3...');
-      dataToValidateAndExpand = convertV2toV3Shape(parsedObj as V2IntermediateSavedGameState);
+      dataToValidateAndExpand = convertV2toV3Shape(parsedObj as unknown as V2IntermediateSavedGameState);
     } else if (
       parsedObj &&
       (parsedObj.saveGameVersion === CURRENT_SAVE_GAME_VERSION ||

--- a/utils/mapHierarchyUpgradeUtils.ts
+++ b/utils/mapHierarchyUpgradeUtils.ts
@@ -118,7 +118,9 @@ export const upgradeFeaturesWithChildren = (
       if (hasChild) {
         const res = upgradeFeatureToRegion(working, node.id, 'Temp Connector');
         working = res.updatedMapData;
-        addedNodes.push(res.newNode);
+        if (res.newNode) {
+          addedNodes.push(res.newNode);
+        }
         addedEdges.push(...res.newEdges);
       }
     }


### PR DESCRIPTION
## Summary
- avoid pushing `null` nodes when upgrading features to regions
- clean up debug view generics for type safety
- default missing fields during save/load conversions
- ensure map update node types are non-null
- add color styling for weapon items

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433d6d291883249e2d43871f79c647