### PR TITLE
Enhance map rename debugging

### DIFF
--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -179,9 +179,18 @@ const DebugView: React.FC<DebugViewProps> = ({ isVisible, onClose, debugPacket, 
                   {debugPacket.mapPruningDebugInfo.refinementDebugInfo?.prompt && renderContent("Map Pruning - Refinement AI Prompt", debugPacket.mapPruningDebugInfo.refinementDebugInfo.prompt, false)}
                   {debugPacket.mapPruningDebugInfo.refinementDebugInfo?.rawResponse && renderContent("Map Pruning - Refinement AI Raw Response", debugPacket.mapPruningDebugInfo.refinementDebugInfo.rawResponse, false)}
                   {debugPacket.mapPruningDebugInfo.refinementDebugInfo?.parsedPayload && renderContent("Map Pruning - Refinement Parsed Payload", debugPacket.mapPruningDebugInfo.refinementDebugInfo.parsedPayload)}
-                  {debugPacket.mapPruningDebugInfo.refinementDebugInfo?.validationError && renderContent("Map Pruning - Refinement Validation Error", debugPacket.mapPruningDebugInfo.refinementDebugInfo.validationError, false)}
-                </>
-              )}
+              {debugPacket.mapPruningDebugInfo.refinementDebugInfo?.validationError && renderContent("Map Pruning - Refinement Validation Error", debugPacket.mapPruningDebugInfo.refinementDebugInfo.validationError, false)}
+            </>
+          )}
+            {debugPacket?.mapRenameDebugInfo && (
+              <>
+                <h3 className="text-lg font-semibold text-sky-400 mt-3 mb-1">Map Rename Details</h3>
+                {renderContent("Map Rename AI Prompt", debugPacket.mapRenameDebugInfo.prompt, false)}
+                {debugPacket.mapRenameDebugInfo.rawResponse && renderContent("Map Rename AI Raw Response", debugPacket.mapRenameDebugInfo.rawResponse, false)}
+                {debugPacket.mapRenameDebugInfo.parsedPayload && renderContent("Map Rename Parsed Payload", debugPacket.mapRenameDebugInfo.parsedPayload)}
+                {debugPacket.mapRenameDebugInfo.validationError && renderContent("Map Rename Validation Error", debugPacket.mapRenameDebugInfo.validationError, false)}
+              </>
+            )}
           </>
         );
       case "Inventory":

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -144,6 +144,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         timestamp: new Date().toISOString(),
         mapUpdateDebugInfo: null,
         mapPruningDebugInfo: null,
+        mapRenameDebugInfo: null,
       };
 
       if (aiData.localTime !== undefined) {

--- a/types.ts
+++ b/types.ts
@@ -361,6 +361,11 @@ export interface MinimalModelCallRecord {
   responseText: string;
 }
 
+export interface RenameMapElementsPayload {
+  nodes: { id: string; placeName: string; description: string; aliases?: string[] }[];
+  edges: { id: string; description: string }[];
+}
+
 export interface DebugPacket {
   prompt: string;
   rawResponseText: string | null;
@@ -382,6 +387,12 @@ export interface DebugPacket {
       parsedPayload?: AIMapUpdatePayload;
       validationError?: string;
     };
+  } | null;
+  mapRenameDebugInfo?: {
+    prompt: string;
+    rawResponse?: string;
+    parsedPayload?: RenameMapElementsPayload;
+    validationError?: string;
   } | null;
 }
 

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -138,15 +138,18 @@ export const handleMapUpdates = async (
   if (upgradeResult.addedNodes.length > 0 || upgradeResult.addedEdges.length > 0) {
     draftState.mapData = upgradeResult.updatedMapData;
     turnChanges.mapDataChanged = true;
-    const renamePayload = await renameMapElements_Service(
+    const renameResult = await renameMapElements_Service(
       draftState.mapData,
       upgradeResult.addedNodes,
       upgradeResult.addedEdges,
       themeContextForResponse,
       { sceneDescription: 'sceneDescription' in aiData ? aiData.sceneDescription : baseStateSnapshot.currentScene || '', gameLogTail }
     );
-    if (renamePayload) {
-      applyRenamePayload(draftState.mapData, renamePayload);
+    if (renameResult.payload) {
+      applyRenamePayload(draftState.mapData, renameResult.payload);
+    }
+    if (draftState.lastDebugPacket) {
+      draftState.lastDebugPacket.mapRenameDebugInfo = renameResult.debugInfo;
     }
   }
 


### PR DESCRIPTION
## Summary
- expose `RenameMapElementsPayload` type to all modules
- extend `DebugPacket` with `mapRenameDebugInfo`
- add debug capture to `renameMapElements_Service`
- store rename debug info in `handleMapUpdates`
- reset debug packet in `usePlayerActions`
- display rename debug info in `DebugView`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a8e1bc9083248b2bcb1d6b61a1b1