### PR TITLE
Add AI model usage indicator

### DIFF
--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -4,6 +4,7 @@
  * @description Top-level toolbar with action buttons.
  */
 import React from 'react';
+import ModelUsageIndicators from './ModelUsageIndicators';
 import {
   CoinIcon,
   VisualizeIcon, BookOpenIcon, MenuIcon, InfoIcon, RealityShiftIcon, ScrollIcon, MapIcon // Added MapIcon
@@ -54,7 +55,7 @@ const MainToolbar: React.FC<MainToolbarProps> = ({
           <span className="text-amber-400 font-semibold text-lg">{score}</span>
         </div>
         {currentThemeName && (
-          <div 
+          <div
             className="flex items-center p-2 border border-indigo-500 rounded-md shadow-md"
             title={`Turns since last reality shift: ${turnsSinceLastShift}`}
             aria-label={`Turns since last reality shift: ${turnsSinceLastShift}`}
@@ -65,6 +66,9 @@ const MainToolbar: React.FC<MainToolbarProps> = ({
             <span className="text-indigo-400 font-semibold text-lg">{turnsSinceLastShift}</span>
           </div>
         )}
+        <div className="p-2 border border-slate-500 rounded-md shadow-md">
+          <ModelUsageIndicators />
+        </div>
       </div>
 
 

--- a/components/ModelUsageIndicators.tsx
+++ b/components/ModelUsageIndicators.tsx
@@ -1,0 +1,37 @@
+/**
+ * @file ModelUsageIndicators.tsx
+ * @description Shows recent AI model usage levels.
+ */
+import React from 'react';
+import { useModelUsage } from '../hooks/useModelUsage';
+
+const squareClass = 'w-4 h-4 rounded';
+
+const getColorClass = (pct: number) => {
+  if (pct < 0.25) return 'bg-green-500';
+  if (pct < 0.5) return 'bg-yellow-500';
+  return 'bg-red-500';
+};
+
+const ModelUsageIndicators: React.FC = () => {
+  const usage = useModelUsage();
+
+  return (
+    <div className="flex space-x-1" aria-label="Model usage last minute">
+      {Object.values(usage).map(info => {
+        const pct = info.count / info.limit;
+        const title = `${info.model}: ${info.count}/${info.limit} calls last minute`;
+        return (
+          <div
+            key={info.model}
+            className={`${squareClass} ${getColorClass(pct)}`}
+            title={title}
+            aria-label={title}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ModelUsageIndicators;

--- a/constants.ts
+++ b/constants.ts
@@ -10,6 +10,12 @@ import { ALL_THEME_PACK_NAMES } from './themes';
 export const GEMINI_MODEL_NAME = "gemini-2.5-flash-preview-05-20";
 export const AUXILIARY_MODEL_NAME = "gemini-2.0-flash"; // Updated for better capability
 export const MINIMAL_MODEL_NAME = "gemma-3-27b-it" // Model for simplest string outputs
+
+// Per-minute rate limits for each model
+export const GEMINI_RATE_LIMIT_PER_MINUTE = 10;
+export const AUXILIARY_RATE_LIMIT_PER_MINUTE = 15;
+export const MINIMAL_RATE_LIMIT_PER_MINUTE = 30;
+
 export const MAX_RETRIES = 3; // Max retries for most API calls
 export const MAX_LOG_MESSAGES = 50; // Maximum number of messages to keep in the game log
 

--- a/hooks/useModelUsage.ts
+++ b/hooks/useModelUsage.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import {
+  GEMINI_MODEL_NAME,
+  AUXILIARY_MODEL_NAME,
+  MINIMAL_MODEL_NAME,
+  GEMINI_RATE_LIMIT_PER_MINUTE,
+  AUXILIARY_RATE_LIMIT_PER_MINUTE,
+  MINIMAL_RATE_LIMIT_PER_MINUTE,
+} from '../constants';
+import {
+  getModelUsageCount,
+  subscribeToModelUsage,
+} from '../utils/modelUsageTracker';
+
+export interface ModelUsageInfo {
+  model: string;
+  count: number;
+  limit: number;
+}
+
+export const useModelUsage = () => {
+  const [usage, setUsage] = useState<Record<string, ModelUsageInfo>>(() => ({
+    [GEMINI_MODEL_NAME]: {
+      model: GEMINI_MODEL_NAME,
+      count: getModelUsageCount(GEMINI_MODEL_NAME),
+      limit: GEMINI_RATE_LIMIT_PER_MINUTE,
+    },
+    [AUXILIARY_MODEL_NAME]: {
+      model: AUXILIARY_MODEL_NAME,
+      count: getModelUsageCount(AUXILIARY_MODEL_NAME),
+      limit: AUXILIARY_RATE_LIMIT_PER_MINUTE,
+    },
+    [MINIMAL_MODEL_NAME]: {
+      model: MINIMAL_MODEL_NAME,
+      count: getModelUsageCount(MINIMAL_MODEL_NAME),
+      limit: MINIMAL_RATE_LIMIT_PER_MINUTE,
+    },
+  }));
+
+  useEffect(() => {
+    const update = () =>
+      setUsage({
+        [GEMINI_MODEL_NAME]: {
+          model: GEMINI_MODEL_NAME,
+          count: getModelUsageCount(GEMINI_MODEL_NAME),
+          limit: GEMINI_RATE_LIMIT_PER_MINUTE,
+        },
+        [AUXILIARY_MODEL_NAME]: {
+          model: AUXILIARY_MODEL_NAME,
+          count: getModelUsageCount(AUXILIARY_MODEL_NAME),
+          limit: AUXILIARY_RATE_LIMIT_PER_MINUTE,
+        },
+        [MINIMAL_MODEL_NAME]: {
+          model: MINIMAL_MODEL_NAME,
+          count: getModelUsageCount(MINIMAL_MODEL_NAME),
+          limit: MINIMAL_RATE_LIMIT_PER_MINUTE,
+        },
+      });
+
+    const unsub = subscribeToModelUsage(update);
+    const intervalId = setInterval(update, 1000);
+    return () => {
+      unsub();
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return usage;
+};

--- a/services/dialogueService.ts
+++ b/services/dialogueService.ts
@@ -14,6 +14,7 @@ import {
     DIALOGUE_SUMMARY_SYSTEM_INSTRUCTION
 } from '../prompts/dialoguePrompts';
 import { ai } from './geminiClient';
+import { recordModelCall } from '../utils/modelUsageTracker';
 import { callMinimalCorrectionAI } from './corrections/base';
 import { isApiConfigured } from './apiClient';
 import { formatKnownPlacesForPrompt } from '../utils/promptFormatters/map';
@@ -43,6 +44,7 @@ const callDialogueGeminiAPI = async (
   if (disableThinking) {
     config.thinkingConfig = { thinkingBudget: 0 };
   }
+  recordModelCall(GEMINI_MODEL_NAME);
   return ai!.models.generateContent({
     model: GEMINI_MODEL_NAME, // Will use gemini-2.5-flash-preview-04-17
     contents: prompt,

--- a/services/gameAIService.ts
+++ b/services/gameAIService.ts
@@ -12,6 +12,7 @@ import { dispatchAIRequest } from './modelDispatcher';
 import { isApiConfigured } from './apiClient';
 import { isServerOrClientError } from '../utils/aiErrorUtils';
 import { addProgressSymbol } from '../utils/loadingProgress';
+import { recordModelCall } from '../utils/modelUsageTracker';
 
 // This function is now the primary way gameAIService interacts with Gemini for main game turns. It takes a fully constructed prompt.
 export const executeAIMainTurn = async (
@@ -31,6 +32,7 @@ export const executeAIMainTurn = async (
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         try {
+            recordModelCall(GEMINI_MODEL_NAME);
             const response = await ai!.models.generateContent({
                 model: GEMINI_MODEL_NAME,
                 contents: fullPrompt,

--- a/services/modelDispatcher.ts
+++ b/services/modelDispatcher.ts
@@ -8,6 +8,7 @@ import { ai } from './geminiClient';
 import { isApiConfigured } from './apiClient';
 import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
 import { MinimalModelCallRecord } from '../types';
+import { recordModelCall } from '../utils/modelUsageTracker';
 
 /** Determines if a model supports separate system instructions. */
 const supportsSystemInstruction = (model: string): boolean => !model.startsWith('gemma-');
@@ -44,6 +45,7 @@ export const dispatchAIRequest = async (
         cfg.systemInstruction = systemInstruction;
       }
 
+      recordModelCall(model);
       const response = await ai.models.generateContent({
         model,
         contents,
@@ -85,6 +87,7 @@ export const dispatchAIRequestWithModelInfo = async (
       if (modelSupportsSystem && systemInstruction) {
         cfg.systemInstruction = systemInstruction;
       }
+      recordModelCall(model);
 
       const response = await ai.models.generateContent({
         model,

--- a/utils/modelUsageTracker.ts
+++ b/utils/modelUsageTracker.ts
@@ -1,0 +1,46 @@
+// Utility to track AI model usage within the last minute
+import {
+  GEMINI_MODEL_NAME,
+  AUXILIARY_MODEL_NAME,
+  MINIMAL_MODEL_NAME,
+} from '../constants';
+
+const usageHistories: Record<string, number[]> = {
+  [GEMINI_MODEL_NAME]: [],
+  [AUXILIARY_MODEL_NAME]: [],
+  [MINIMAL_MODEL_NAME]: [],
+};
+
+let subscribers: Array<() => void> = [];
+
+const purgeOld = () => {
+  const cutoff = Date.now() - 60_000;
+  Object.values(usageHistories).forEach(arr => {
+    while (arr.length && arr[0] < cutoff) arr.shift();
+  });
+};
+
+const notify = () => {
+  subscribers.forEach(fn => fn());
+};
+
+export const recordModelCall = (model: string) => {
+  if (!usageHistories[model]) {
+    usageHistories[model] = [];
+  }
+  usageHistories[model].push(Date.now());
+  purgeOld();
+  notify();
+};
+
+export const getModelUsageCount = (model: string): number => {
+  purgeOld();
+  return usageHistories[model]?.length || 0;
+};
+
+export const subscribeToModelUsage = (fn: () => void): (() => void) => {
+  subscribers.push(fn);
+  return () => {
+    subscribers = subscribers.filter(s => s !== fn);
+  };
+};


### PR DESCRIPTION
## Summary
- track per-model call counts with `modelUsageTracker`
- expose usage data via `useModelUsage` hook
- show three color-coded squares in `MainToolbar`
- record calls in all AI services
- define per-minute rate limits for models

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849987877c48324935f5a766a27bf70