### PR TITLE
Add Storyteller utilities index

### DIFF
--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @file services/storyteller/index.ts
+ * @description Re-exports utilities for interacting with the Storyteller AI.
+ */
+
+export * from '../gameAIService';
+export * from '../dialogueService';
+export * from '../aiResponseParser';
+export * from '../mapUpdateService';
+export * from '../modelDispatcher';
+export * from '../geminiClient';
+export * from '../apiClient';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "noUncheckedSideEffectImports": true,
 
     "paths": {
-      "@/*" :  ["./*"]
+      "@/*": ["./*"],
+      "@/services/*": ["./services/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- export Storyteller AI helpers via `services/storyteller/index.ts`
- map the new directory with an explicit TS path alias

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ba41410883248dafc0c45ae5acc2