### PR TITLE
Move system prompt to storyteller service

### DIFF
--- a/services/gameAIService.ts
+++ b/services/gameAIService.ts
@@ -6,7 +6,7 @@
 import { GenerateContentResponse } from "@google/genai";
 import { AdventureTheme } from '../types';
 import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
-import { SYSTEM_INSTRUCTION } from '../prompts/mainPrompts';
+import { SYSTEM_INSTRUCTION } from './storyteller/systemPrompt';
 import { ai } from './geminiClient';
 import { dispatchAIRequest } from './modelDispatcher';
 import { isApiConfigured } from './apiClient';

--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -5,6 +5,7 @@
 
 export * from '../gameAIService';
 export * from '../dialogueService';
+export * from "./systemPrompt";
 export * from '../aiResponseParser';
 export * from '../mapUpdateService';
 export * from '../modelDispatcher';

--- a/services/storyteller/systemPrompt.ts
+++ b/services/storyteller/systemPrompt.ts
@@ -1,11 +1,10 @@
-
 /**
- * @file mainPrompts.ts
- * @description Core system prompt templates for the main storytelling flow.
+ * @file systemPrompt.ts
+ * @description System instruction for the main storyteller AI.
  */
 
-import { ITEMS_GUIDE, LOCAL_CONDITIONS_GUIDE } from './helperPrompts';
-import { VALID_PRESENCE_STATUS_VALUES_STRING, ALIAS_INSTRUCTION } from '../constants';
+import { ITEMS_GUIDE, LOCAL_CONDITIONS_GUIDE } from '../../prompts/helperPrompts';
+import { VALID_PRESENCE_STATUS_VALUES_STRING, ALIAS_INSTRUCTION } from '../../constants';
 
 export const SYSTEM_INSTRUCTION = `You are the Dungeon Master for a text-based adventure game. Your role is to describe scenes, provide action/dialogue choices, manage inventory, player goals, track known characters (including their presence, general location, and precise location in scene), and maintain local time/environment/place.
 


### PR DESCRIPTION
## Summary
- move `SYSTEM_INSTRUCTION` to `services/storyteller/systemPrompt.ts`
- update `gameAIService` import
- re-export prompt in storyteller service index

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849bb602f3c832483b4bd33d4c5a16b