### PR TITLE
Refactor prompt builders into storyteller service

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -19,7 +19,7 @@ import {
   formatNewGameFirstTurnPrompt,
   formatNewThemePostShiftPrompt,
   formatReturnToThemePostShiftPrompt,
-} from '../utils/promptFormatters';
+} from '../services/storyteller';
 import {
   getInitialGameStates,
   getInitialGameStatesWithSettings

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -33,7 +33,7 @@ import {
   buildItemChangeRecords,
   applyAllItemChanges,
 } from '../utils/gameLogicUtils';
-import { formatMainGameTurnPrompt } from '../utils/promptFormatters';
+import { formatMainGameTurnPrompt } from '../services/storyteller';
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { handleMapUpdates } from '../utils/mapUpdateHandlers';
 

--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -1,0 +1,1 @@
+export * from './promptBuilder';

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -1,0 +1,213 @@
+/**
+ * @file promptBuilder.ts
+ * @description Storyteller prompt construction helpers.
+ */
+
+import {
+  Item,
+  AdventureTheme,
+  ThemeMemory,
+  MapData,
+  MapNode,
+  Character,
+  ThemeHistoryState,
+} from '../../types';
+
+import {
+  formatInventoryForPrompt,
+  formatKnownPlacesForPrompt,
+  formatKnownCharactersForPrompt,
+  formatRecentEventsForPrompt,
+  formatDetailedContextForMentionedEntities,
+  formatMapContextForPrompt,
+  formatTravelPlanLine,
+} from '../../utils/promptFormatters';
+
+export const formatNewGameFirstTurnPrompt = (
+  theme: AdventureTheme,
+  playerGender: string
+): string => {
+  const prompt = `Start a new adventure in the theme "${theme.name}".
+Player's Character Gender: "${playerGender}"
+Suggested Initial Scene: "${theme.initialSceneDescriptionSeed}" (Adjust to add variely)
+Suggested Initial Main Quest: "${theme.initialMainQuest}" (Adjust to add variely)
+Suggested Initial Current Objective: "${theme.initialCurrentObjective}" (Adjust to add variely)
+Suggested Initial Inventory to be granted: "${theme.initialItems}" (Adjust the names and descriptions to add variely)
+
+Last player's action was unremarkable, something very common, what people do in the described situation.
+
+Creatively generate the variation of the mainQuest and currentObjective, based on the suggested Quest and Objective, but noticeably different.
+Creatively generate the initial scene description, action options, items (variation based on 'Initial Inventory to be granted') and logMessage.
+Creatively add possible important quest item(s), if any, based on your generated Quest and Objective.
+ALWAYS SET "mapUpdated": true.
+Of all the optional variables, your response MUST include at least the "mainQuest", "currentObjective", "localTime", "localEnvironment", and "localPlace".
+Ensure the response adheres to the JSON structure specified in the SYSTEM_INSTRUCTION.`;
+  return prompt;
+};
+
+export const formatNewThemePostShiftPrompt = (
+  theme: AdventureTheme,
+  inventory: Item[],
+  playerGender: string
+): string => {
+  const inventoryPrompt = formatInventoryForPrompt(inventory);
+  const prompt = `The player is entering a NEW theme "${theme.name}" after a reality shift.
+Player's Character Gender: "${playerGender}"
+Initial Scene: "${theme.initialSceneDescriptionSeed}" (Adapt this to an arrival scene, describing the disorienting transition).
+Main Quest: "${theme.initialMainQuest}" (Adjust to add variely)
+Current Objective: "${theme.initialCurrentObjective}" (Adjust to add variely)
+
+Player's Current Inventory (brought from previous reality or last visit):\n - ${inventoryPrompt}
+IMPORTANT:
+- EXAMINE the player's Current Inventory for any items that are CLEARLY ANACHRONISTIC for the theme "${theme.name}".
+- If anachronistic items are found, TRANSFORM them into thematically appropriate equivalents using an "itemChange" "update" action with "newName", "type", and "description". Creatively explain this transformation in the "logMessage". Refer to ITEMS_GUIDE for anachronistic item handling.
+- If no items are anachronistic, no transformation is needed.
+
+Generate the scene description for a disoriented arrival, and provide appropriate initial action options for the player to orient themselves.
+The response MUST include at least the "mainQuest", "currentObjective", "localTime", "localEnvironment", and "localPlace".
+Set "mapUpdated": true if your generated Scene, Quest or Objective mention specific locations that should be on a map.
+Ensure the response adheres to the JSON structure specified in the SYSTEM_INSTRUCTION.`;
+  return prompt;
+};
+
+export const formatReturnToThemePostShiftPrompt = (
+  theme: AdventureTheme,
+  inventory: Item[],
+  playerGender: string,
+  themeMemory: ThemeMemory,
+  mapDataForTheme: MapData,
+  allCharactersForTheme: Character[]
+): string => {
+  const inventoryPrompt = formatInventoryForPrompt(inventory);
+  const currentThemeMainMapNodes = mapDataForTheme.nodes.filter(
+    n =>
+      n.themeName === theme.name &&
+      n.data.nodeType !== 'feature' &&
+      n.data.nodeType !== 'room'
+  );
+  const placesContext = formatKnownPlacesForPrompt(currentThemeMainMapNodes, false);
+  const charactersContext = formatKnownCharactersForPrompt(allCharactersForTheme, false);
+  const prompt = `The player is CONTINUING their adventure by re-entering the theme "${theme.name}" after a reality shift.
+Player's Character Gender: "${playerGender}"
+The Adventure Summary: "${themeMemory.summary}"
+Main Quest: "${themeMemory.mainQuest}"
+Current Objective: "${themeMemory.currentObjective}"
+
+Player's Current Inventory (brought from previous reality or last visit):\n - ${inventoryPrompt}
+IMPORTANT:
+- EXAMINE the player's Current Inventory for any items that are CLEARLY ANACHRONISTIC for the theme "${theme.name}".
+- If anachronistic items are found, TRANSFORM them into thematically appropriate equivalents using an "itemChange" "update" action with "newName", "type", and "description". Creatively explain this transformation in the "logMessage". Refer to ITEMS_GUIDE for anachronistic item handling.
+- CRITICALLY IMPORTANT: ALWAYS transform some items into important quest items you must have already had in this reality, based on Main Quest, Current Objective, or the Adventure Summary even if they are NOT anachronistic, using an "itemChange" "update" action with "newName", "type", "description". Creatively explain this transformation in the "logMessage".
+
+Known Locations: ${placesContext}
+Known Characters (including presence): ${charactersContext}
+
+Describe the scene as they re-enter, potentially in a state of confusion from the shift, making it feel like a continuation or a new starting point consistent with the Adventure Summary and current quest/objective.
+Provide appropriate action options for the player to orient themselves.
+The response MUST include at least the "mainQuest", "currentObjective", "localTime", "localEnvironment", and "localPlace".
+Set "mapUpdated": true if your generated Scene, Quest or Objective mention specific locations that should be on a map or if existing map information needs updating based on the re-entry context.
+Ensure the response adheres to the JSON structure specified in the SYSTEM_INSTRUCTION.`;
+  return prompt;
+};
+
+export const formatMainGameTurnPrompt = (
+  currentScene: string,
+  playerAction: string,
+  inventory: Item[],
+  locationItems: Item[],
+  mainQuest: string | null,
+  currentObjective: string | null,
+  currentTheme: AdventureTheme,
+  recentLogEntries: string[],
+  currentThemeMainMapNodes: MapNode[],
+  currentThemeCharacters: Character[],
+  localTime: string | null,
+  localEnvironment: string | null,
+  localPlace: string | null,
+  playerGender: string,
+  themeHistory: ThemeHistoryState,
+  currentMapNodeDetails: MapNode | null,
+  fullMapData: MapData,
+  destinationNodeId: string | null
+): string => {
+  const inventoryPrompt = formatInventoryForPrompt(inventory);
+  const locationItemsPrompt =
+    locationItems.length > 0 ? formatInventoryForPrompt(locationItems) : '';
+  const placesContext = formatKnownPlacesForPrompt(currentThemeMainMapNodes, true);
+  const charactersContext = formatKnownCharactersForPrompt(currentThemeCharacters, true);
+  const recentEventsContext = formatRecentEventsForPrompt(recentLogEntries);
+
+  const allNodesForCurrentTheme = fullMapData.nodes.filter(node => node.themeName === currentTheme.name);
+  const allEdgesForCurrentTheme = fullMapData.edges.filter(edge => {
+    const sourceNode = allNodesForCurrentTheme.find(n => n.id === edge.sourceNodeId);
+    const targetNode = allNodesForCurrentTheme.find(n => n.id === edge.targetNodeId);
+    return sourceNode && targetNode;
+  });
+  const mapContext = formatMapContextForPrompt(
+    fullMapData,
+    currentMapNodeDetails?.id || null,
+    currentTheme,
+    allNodesForCurrentTheme,
+    allEdgesForCurrentTheme
+  );
+
+  const travelPlanLine = formatTravelPlanLine(
+    fullMapData,
+    currentMapNodeDetails?.id || null,
+    destinationNodeId
+  );
+
+  let travelPlanOrUnknown = '';
+  if (travelPlanLine) {
+    travelPlanOrUnknown = travelPlanLine;
+  } else if (destinationNodeId) {
+    const destNode = fullMapData.nodes.find(n => n.id === destinationNodeId);
+    const placeName = destNode?.placeName || destinationNodeId;
+    travelPlanOrUnknown = `Player wants to reach ${placeName}, but does not know how to get there.`;
+  }
+
+  const detailedEntityContext = formatDetailedContextForMentionedEntities(
+    currentThemeMainMapNodes,
+    currentThemeCharacters,
+    `${currentScene} ${playerAction}`,
+    '### Details on relevant locations mentioned in current scene or action:',
+    '### Details on relevant characters mentioned in current scene or action:'
+  );
+
+  const prompt = `Based on the Previous Scene and Player Action, and taking into account the provided context (including map context), generate the next scene description, options, item changes, log message, etc.
+
+## Context:
+Player's Character Gender: "${playerGender}"
+Previous Local Time: "${localTime || 'Unknown'}"
+Previous Local Environment: "${localEnvironment || 'Undetermined'}"
+Previous Local Place: "${localPlace || 'Undetermined Location'}"
+Main Quest: "${mainQuest || 'Not set'}"
+Current Objective: "${currentObjective || 'Not set'}"
+
+### Current Inventory:
+${inventoryPrompt} ${locationItemsPrompt ? `\nThere are items at this location:\n${locationItemsPrompt}` : ''}
+
+### Known Locations:
+${placesContext}
+
+### Known Characters:
+${charactersContext}
+
+### Current Map Context (including your location, possible exits, nearby paths, and other nearby locations):
+${mapContext}
+
+${detailedEntityContext}
+
+### Recent Events to keep in mind (for context and continuity):
+${recentEventsContext}
+ - A bit later you look around and consider your next move.
+IMPORTANT: Recent Events are provided ONLY for extra context, these actions have already been processed by the game and should NEVER cause item actions to avoid double counting.
+
+---
+
+Current Theme: "${currentTheme.name}"
+Previous Scene: "${currentScene}"
+Player Action: "${playerAction}"
+${travelPlanOrUnknown ? travelPlanOrUnknown : ''}`;
+  return prompt;
+};


### PR DESCRIPTION
## Summary
- move main prompt builder functions into new `services/storyteller` module
- update game hooks to import builders from the storyteller service
- trim unused utilities from `utils/promptFormatters/main.ts`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c0227b388324838e593bbea5064f