### PR TITLE
Add named template prompt builders

### DIFF
--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -11,3 +11,4 @@ export * from '../mapUpdateService';
 export * from '../modelDispatcher';
 export * from '../geminiClient';
 export * from '../apiClient';
+export * from './promptBuilder';


### PR DESCRIPTION
## Summary
- implement `promptBuilder.ts` with helper `applySubstitutions`
- expose new builder utilities via storyteller service index

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c2953ca08324923e32ce9ffc1ef4