### PR TITLE
Refactor game AI service location

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ This layer abstracts external interactions and complex data processing.
 
 *   **AI Interaction Services:**
     *   `services/geminiClient.ts`: Initializes the Google Gemini API client.
-    *   `services/gameAIService.ts`: Handles main game turn AI calls and theme summarization.
+    *   `services/storyteller/api.ts`: Handles main game turn AI calls and theme summarization.
     *   `services/dialogueService.ts`: Manages AI calls for dialogue turns and summaries.
     *   `services/correctionService.ts`: Attempts to fix malformed data from AI responses. `fetchFullPlaceDetailsForNewMapNode_Service` is key for completing main map node data.
     *   `services/mapUpdateService.ts`:
@@ -125,7 +125,7 @@ The game's state transitions are primarily driven by changes to `FullGameState` 
 
 ### 2.2. Location Data Flow
 
-*   **Storyteller AI (`gameAIService`)**: Provides `sceneDescription`, `logMessage`, `localPlace`, and a `mapUpdated` flag.
+*   **Storyteller AI (`storyteller/api`)**: Provides `sceneDescription`, `logMessage`, `localPlace`, and a `mapUpdated` flag.
 *   **`useGameLogic`**:
     *   If `mapUpdated` is true or `localPlace` significantly changes, calls `mapUpdateService`.
     *   Receives `AIMapUpdatePayload` from `mapUpdateService`.

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -9,7 +9,7 @@ import {
   ThemePackName,
   LoadingReason,
 } from '../types';
-import { executeAIMainTurn } from '../services/gameAIService';
+import { executeAIMainTurn } from '../services/storyteller/api';
 import { parseAIResponse } from '../services/aiResponseParser';
 import { getThemesFromPacks } from '../themes';
 import { CURRENT_SAVE_GAME_VERSION, PLAYER_HOLDER_ID } from '../constants';

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -18,7 +18,7 @@ import {
   LoadingReason,
   TurnChanges,
 } from '../types';
-import { executeAIMainTurn } from '../services/gameAIService';
+import { executeAIMainTurn } from '../services/storyteller/api';
 import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
 import { fetchCorrectedName_Service } from '../services/corrections';
 import { parseAIResponse } from '../services/aiResponseParser';

--- a/hooks/useRealityShift.ts
+++ b/hooks/useRealityShift.ts
@@ -13,7 +13,7 @@ import {
   ThemeMemory
 } from '../types';
 import { getThemesFromPacks } from '../themes';
-import { summarizeThemeAdventure_Service } from '../services/gameAIService';
+import { summarizeThemeAdventure_Service } from '../services/storyteller/api';
 import { selectNextThemeName } from '../utils/gameLogicUtils';
 import { getInitialGameStates } from '../utils/initialStates';
 

--- a/services/storyteller/api.ts
+++ b/services/storyteller/api.ts
@@ -1,18 +1,18 @@
 
 /**
- * @file gameAIService.ts
+ * @file api.ts
  * @description Wrapper functions for the main storytelling AI interactions.
  */
 import { GenerateContentResponse } from "@google/genai";
-import { AdventureTheme } from '../types';
-import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../constants';
-import { SYSTEM_INSTRUCTION } from './storyteller/systemPrompt';
-import { ai } from './geminiClient';
-import { dispatchAIRequest } from './modelDispatcher';
-import { isApiConfigured } from './apiClient';
-import { isServerOrClientError } from '../utils/aiErrorUtils';
-import { addProgressSymbol } from '../utils/loadingProgress';
-import { recordModelCall } from '../utils/modelUsageTracker';
+import { AdventureTheme } from '../../types';
+import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../../constants';
+import { SYSTEM_INSTRUCTION } from './systemPrompt';
+import { ai } from '../geminiClient';
+import { dispatchAIRequest } from '../modelDispatcher';
+import { isApiConfigured } from '../apiClient';
+import { isServerOrClientError } from '../../utils/aiErrorUtils';
+import { addProgressSymbol } from '../../utils/loadingProgress';
+import { recordModelCall } from '../../utils/modelUsageTracker';
 
 // This function is now the primary way gameAIService interacts with Gemini for main game turns. It takes a fully constructed prompt.
 export const executeAIMainTurn = async (

--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -3,7 +3,7 @@
  * @description Re-exports utilities for interacting with the Storyteller AI.
  */
 
-export * from '../gameAIService';
+export * from './api';
 export * from '../dialogueService';
 export * from "./systemPrompt";
 export * from '../aiResponseParser';


### PR DESCRIPTION
## Summary
- move `gameAIService.ts` into storyteller folder as `api.ts`
- expose `api.ts` from `storyteller/index.ts`
- update hooks to import from the new path
- document new file path in architecture doc

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c599045c8324b832e001a0911e0b