### PR TITLE
Update storyteller imports

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -9,17 +9,17 @@ import {
   ThemePackName,
   LoadingReason,
 } from '../types';
-import { executeAIMainTurn } from '../services/storyteller/api';
-import { parseAIResponse } from '../services/storyteller/responseParser';
+import {
+  executeAIMainTurn,
+  parseAIResponse,
+  buildNewGameFirstTurnPrompt,
+  buildNewThemePostShiftPrompt,
+  buildReturnToThemePostShiftPrompt
+} from '../services/storyteller';
 import { getThemesFromPacks } from '../themes';
 import { CURRENT_SAVE_GAME_VERSION, PLAYER_HOLDER_ID } from '../constants';
 import { findThemeByName } from '../services/themeUtils';
 import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
-import {
-  formatNewGameFirstTurnPrompt,
-  formatNewThemePostShiftPrompt,
-  formatReturnToThemePostShiftPrompt,
-} from '../utils/promptFormatters';
 import {
   getInitialGameStates,
   getInitialGameStatesWithSettings
@@ -234,7 +234,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
       let prompt = '';
       if (isTransitioningFromShift && draftState.themeHistory[themeObjToLoad.name]) {
         const currentThemeCharacters = draftState.allCharacters.filter((c) => c.themeName === themeObjToLoad.name);
-        prompt = formatReturnToThemePostShiftPrompt(
+        prompt = buildReturnToThemePostShiftPrompt(
           themeObjToLoad,
           draftState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID),
           playerGenderProp,
@@ -243,9 +243,13 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
           currentThemeCharacters
         );
       } else if (isTransitioningFromShift) {
-        prompt = formatNewThemePostShiftPrompt(themeObjToLoad, draftState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID), playerGenderProp);
+        prompt = buildNewThemePostShiftPrompt(
+          themeObjToLoad,
+          draftState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID),
+          playerGenderProp
+        );
       } else {
-        prompt = formatNewGameFirstTurnPrompt(themeObjToLoad, playerGenderProp);
+        prompt = buildNewGameFirstTurnPrompt(themeObjToLoad, playerGenderProp);
       }
       draftState.lastDebugPacket = { prompt, rawResponseText: null, parsedResponse: null, timestamp: new Date().toISOString() };
 

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -18,10 +18,13 @@ import {
   LoadingReason,
   TurnChanges,
 } from '../types';
-import { executeAIMainTurn } from '../services/storyteller/api';
+import {
+  executeAIMainTurn,
+  parseAIResponse,
+  buildMainGameTurnPrompt
+} from '../services/storyteller';
 import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
 import { fetchCorrectedName_Service } from '../services/corrections';
-import { parseAIResponse } from '../services/storyteller/responseParser';
 import {
   FREE_FORM_ACTION_COST,
   MAX_LOG_MESSAGES,
@@ -33,7 +36,6 @@ import {
   buildItemChangeRecords,
   applyAllItemChanges,
 } from '../utils/gameLogicUtils';
-import { formatMainGameTurnPrompt } from '../utils/promptFormatters';
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { handleMapUpdates } from '../utils/mapUpdateHandlers';
 
@@ -342,7 +344,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           i.holderId !== PLAYER_HOLDER_ID &&
           i.holderId === currentFullState.currentMapNodeId
       );
-      const prompt = formatMainGameTurnPrompt(
+      const prompt = buildMainGameTurnPrompt(
         currentFullState.currentScene,
         action,
         currentFullState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID),

--- a/hooks/useRealityShift.ts
+++ b/hooks/useRealityShift.ts
@@ -13,7 +13,7 @@ import {
   ThemeMemory
 } from '../types';
 import { getThemesFromPacks } from '../themes';
-import { summarizeThemeAdventure_Service } from '../services/storyteller/api';
+import { summarizeThemeAdventure_Service } from '../services/storyteller';
 import { selectNextThemeName } from '../utils/gameLogicUtils';
 import { getInitialGameStates } from '../utils/initialStates';
 


### PR DESCRIPTION
## Summary
- refactor hooks to import main storyteller utilities from centralized index

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c89c9be48324b1e2684c0c6e702b