### PR TITLE
Refactor map context formatting

### DIFF
--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -151,7 +151,7 @@ export const buildMainGameTurnPrompt = (
     const targetNode = allNodesForCurrentTheme.find(n => n.id === edge.targetNodeId);
     return sourceNode && targetNode;
   });
-  const mapContext = formatMapContextForPrompt(
+  const mapContextParts = formatMapContextForPrompt(
     fullMapData,
     currentMapNodeDetails?.id || null,
     currentTheme,
@@ -201,7 +201,11 @@ ${placesContext}
 ${charactersContext}
 
 ### Current Map Context (including your location, possible exits, nearby paths, and other nearby locations):
-${mapContext}
+${mapContextParts.location}
+${mapContextParts.exits}
+${mapContextParts.pathsFromCurrent}
+${mapContextParts.pathsFromParent}
+${mapContextParts.nearby}
 
 ${detailedEntityContext}
 

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -303,7 +303,7 @@ export const formatMainGameTurnPrompt = (
     const targetNode = allNodesForCurrentTheme.find(n => n.id === edge.targetNodeId);
     return sourceNode && targetNode;
   });
-  const mapContext = formatMapContextForPrompt(
+  const mapContextParts = formatMapContextForPrompt(
     fullMapData,
     currentMapNodeDetails?.id || null,
     currentTheme,
@@ -354,7 +354,11 @@ ${placesContext}
 ${charactersContext}
 
 ### Current Map Context (including your location, possible exits, nearby paths, and other nearby locations):
-${mapContext}
+${mapContextParts.location}
+${mapContextParts.exits}
+${mapContextParts.pathsFromCurrent}
+${mapContextParts.pathsFromParent}
+${mapContextParts.nearby}
 
 ${detailedEntityContext}
 


### PR DESCRIPTION
## Summary
- return a `FormattedMapContext` object from `formatMapContextForPrompt`
- embed map context pieces in prompts through `mapContextParts`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849d40c1a888324910ac6f471431b0c