### PR TITLE
Fix prompts export and linter errors

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -289,7 +289,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
         if (!isTransitioningFromShift || draftState.globalTurnNumber === 0) {
           draftState.globalTurnNumber = 1;
         }
-      } catch (e: unknown) {
+      } catch (e) {
         console.error('Error loading initial game:', e);
         if (isServerOrClientError(e)) {
           draftState = structuredCloneGameState(baseStateSnapshotForInitialTurn);
@@ -494,7 +494,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
 
       draftState.turnsSinceLastShift += 1;
       draftState.globalTurnNumber += 1;
-    } catch (e: unknown) {
+    } catch (e) {
       console.error('Error retrying last main AI request:', e);
       const errMsg = e instanceof Error ? e.message : String(e);
       setError(`Retry failed: ${errMsg}.`);

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -402,7 +402,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         );
 
         await processAiResponse(parsedData, currentThemeObj, draftState, { baseStateSnapshot, scoreChangeFromAction, playerActionText: action });
-      } catch (e: unknown) {
+      } catch (e) {
         encounteredError = true;
         console.error('Error executing player action:', e);
         if (isServerOrClientError(e)) {

--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -8,6 +8,7 @@ export * from './api';
 export * from '../dialogueService';
 export * from "./systemPrompt";
 export * from './responseParser';
+export * from './promptBuilder';
 export * from '../mapUpdateService';
 export * from '../modelDispatcher';
 export * from '../geminiClient';


### PR DESCRIPTION
## Summary
- export prompt builder utilities from `services/storyteller`
- adjust error handling blocks to satisfy ESLint

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849df89e6e48324acf75aaffb458686