### PR TITLE
Add cartographer AI service

### DIFF
--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -1,0 +1,56 @@
+/**
+ * @file api.ts
+ * @description Wrapper utilities for communicating with the cartographer AI.
+ */
+import { GenerateContentResponse } from '@google/genai';
+import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME } from '../../constants';
+import { dispatchAIRequest } from '../modelDispatcher';
+import { addProgressSymbol } from '../../utils/loadingProgress';
+import { SYSTEM_INSTRUCTION } from './systemPrompt';
+import {
+  MapData,
+  MapNode,
+  MapEdge,
+  AIMapUpdatePayload,
+  MinimalModelCallRecord,
+} from '../../types';
+
+export interface MapUpdateServiceResult {
+  updatedMapData: MapData | null;
+  /** All nodes created as part of this update (both from MapAI and service-generated). */
+  newlyAddedNodes: MapNode[];
+  /** All edges created as part of this update (both from MapAI and service-generated). */
+  newlyAddedEdges: MapEdge[];
+  debugInfo: {
+    prompt: string;
+    rawResponse?: string;
+    parsedPayload?: AIMapUpdatePayload;
+    validationError?: string;
+    minimalModelCalls?: MinimalModelCallRecord[];
+    connectorChainsDebugInfo?: {
+      prompt: string;
+      rawResponse?: string;
+      parsedPayload?: AIMapUpdatePayload;
+      validationError?: string;
+    } | null;
+  } | null;
+}
+
+/**
+ * Executes a single cartographer AI call and returns the raw response.
+ */
+export const executeCartographerUpdate = async (
+  prompt: string,
+  systemInstruction: string = SYSTEM_INSTRUCTION,
+): Promise<GenerateContentResponse> => {
+  addProgressSymbol('▓▓');
+  return dispatchAIRequest(
+    [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+    prompt,
+    systemInstruction,
+    {
+      responseMimeType: 'application/json',
+      temperature: 0.75,
+    },
+  );
+};

--- a/services/cartographer/index.ts
+++ b/services/cartographer/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @file services/cartographer/index.ts
+ * @description Re-exports utilities for interacting with the cartographer AI.
+ */
+export * from './api';
+export * from './promptBuilder';
+export * from './responseParser';
+export * from './systemPrompt';

--- a/services/cartographer/promptBuilder.ts
+++ b/services/cartographer/promptBuilder.ts
@@ -1,0 +1,21 @@
+/**
+ * @file promptBuilder.ts
+ * @description Utilities for constructing prompts for the cartographer AI.
+ */
+import { AdventureTheme, MapData } from '../../types';
+
+/**
+ * Builds a simple map update prompt using the provided context.
+ */
+export const buildCartographerPrompt = (
+  theme: AdventureTheme,
+  mapData: MapData,
+  narrativeContext: string,
+): string => {
+  const mapNodes = mapData.nodes
+    .filter(n => n.themeName === theme.name)
+    .map(n => `- "${n.placeName}" (${n.data.nodeType})`)
+    .join('\n');
+
+  return `Narrative Context:\n${narrativeContext}\n\nKnown Map Nodes for theme "${theme.name}":\n${mapNodes}\n\nProvide JSON updates as per the SYSTEM_INSTRUCTION.`;
+};

--- a/services/cartographer/responseParser.ts
+++ b/services/cartographer/responseParser.ts
@@ -1,0 +1,18 @@
+/**
+ * @file responseParser.ts
+ * @description Parsing helpers for cartographer AI responses.
+ */
+import { AIMapUpdatePayload } from '../../types';
+import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
+import { isValidAIMapUpdatePayload } from '../../utils/mapUpdateValidationUtils';
+
+/**
+ * Attempts to parse the AI response text into an AIMapUpdatePayload.
+ */
+export const parseCartographerResponse = (
+  responseText: string,
+): AIMapUpdatePayload | null => {
+  const jsonStr = extractJsonFromFence(responseText);
+  const parsed = safeParseJson<AIMapUpdatePayload>(jsonStr);
+  return isValidAIMapUpdatePayload(parsed) ? parsed : null;
+};

--- a/services/cartographer/systemPrompt.ts
+++ b/services/cartographer/systemPrompt.ts
@@ -1,0 +1,5 @@
+/**
+ * @file systemPrompt.ts
+ * @description Exposes the system instruction for the cartographer AI.
+ */
+export { MAP_UPDATE_SYSTEM_INSTRUCTION as SYSTEM_INSTRUCTION } from '../../prompts/mapPrompts';


### PR DESCRIPTION
## Summary
- create cartographer service module
- expose cartographer system prompt
- implement simple API wrapper, prompt builder and response parser

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849e5f7160c83249f39327af0da2174