### PR TITLE
Extract map update prompt builder

### DIFF
--- a/services/cartographer/promptBuilder.ts
+++ b/services/cartographer/promptBuilder.ts
@@ -19,3 +19,33 @@ export const buildCartographerPrompt = (
 
   return `Narrative Context:\n${narrativeContext}\n\nKnown Map Nodes for theme "${theme.name}":\n${mapNodes}\n\nProvide JSON updates as per the SYSTEM_INSTRUCTION.`;
 };
+
+/**
+ * Builds the complex map update prompt used by the map update service.
+ */
+export const buildMapUpdatePrompt = (
+  sceneDesc: string,
+  logMsg: string,
+  localPlace: string,
+  mapHint: string,
+  currentTheme: AdventureTheme,
+  previousMapNodeContext: string,
+  existingMapContext: string,
+  allKnownMainPlaces: string,
+): string => `
+Narrative Context for Map Update:
+- Current Theme: "${currentTheme.name}"
+- System Modifier for Theme: ${currentTheme.systemInstructionModifier}
+- Player's Current Location Description (localPlace): "${localPlace}"
+- ${previousMapNodeContext}
+- Scene Description: "${sceneDesc}"
+- Log Message (outcome of last action): "${logMsg}"
+- Map Hint from Storyteller: "${mapHint}"
+- All Known Main Locations for this Theme (these are expected to be main map nodes): ${allKnownMainPlaces}.
+- Your task is to analyze this narrative context and suggest additions, updates, or removals to the map data.
+
+${existingMapContext}
+---
+Based on the Narrative Context and existing map context, provide a JSON response adhering to the MAP_UPDATE_SYSTEM_INSTRUCTION.
+
+`;

--- a/services/mapUpdateService.ts
+++ b/services/mapUpdateService.ts
@@ -25,6 +25,7 @@ import {
   MAX_RETRIES
 } from '../constants';
 import { SYSTEM_INSTRUCTION as MAP_UPDATE_SYSTEM_INSTRUCTION } from './cartographer/systemPrompt';
+import { buildMapUpdatePrompt } from './cartographer/promptBuilder';
 import { dispatchAIRequest } from './modelDispatcher';
 import { isApiConfigured } from './apiClient';
 import { isValidAIMapUpdatePayload } from '../utils/mapUpdateValidationUtils';
@@ -441,23 +442,16 @@ ${currentThemeEdgesFromMapData.length > 0 ? currentThemeEdgesFromMapData.map(e =
     : "No main places are pre-defined for this theme.";
 
 
-  const basePrompt = `
-Narrative Context for Map Update:
-- Current Theme: "${currentTheme.name}"
-- System Modifier for Theme: ${currentTheme.systemInstructionModifier}
-- Player's Current Location Description (localPlace): "${localPlace}"
-- ${previousMapNodeContext}
-- Scene Description: "${sceneDesc}"
-- Log Message (outcome of last action): "${logMsg}"
-- Map Hint from Storyteller: "${mapHint}"
-- All Known Main Locations for this Theme (these are expected to be main map nodes): ${allKnownMainPlacesString}.
-- Your task is to analyze this narrative context and suggest additions, updates, or removals to the map data.
-
-${existingMapContext}
----
-Based on the Narrative Context and existing map context, provide a JSON response adhering to the MAP_UPDATE_SYSTEM_INSTRUCTION.
-
-`;
+  const basePrompt = buildMapUpdatePrompt(
+    sceneDesc,
+    logMsg,
+    localPlace,
+    mapHint,
+    currentTheme,
+    previousMapNodeContext,
+    existingMapContext,
+    allKnownMainPlacesString,
+  );
   let prompt = basePrompt;
   const debugInfo: MapUpdateServiceResult['debugInfo'] = { prompt: basePrompt, minimalModelCalls };
   let validParsedPayload: AIMapUpdatePayload | null = null;


### PR DESCRIPTION
## Summary
- centralize prompt construction for map updates
- use `buildMapUpdatePrompt` in the map update service

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849e8eb9bc08324bbdb2b74d55ee6f4