### PR TITLE
Fix map update service imports

### DIFF
--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -14,7 +14,7 @@ import {
   ValidNewCharacterPayload,
   ValidCharacterUpdatePayload
 } from '../types';
-import { updateMapFromAIData_Service, MapUpdateServiceResult } from '../services/cartographer/api';
+import { updateMapFromAIData_Service, MapUpdateServiceResult } from '../services/cartographer';
 import { fetchFullPlaceDetailsForNewMapNode_Service } from '../services/corrections';
 import { selectBestMatchingMapNode, attemptMatchAndSetNode } from './mapNodeMatcher';
 import { buildCharacterChangeRecords, applyAllCharacterChanges } from './gameLogicUtils';


### PR DESCRIPTION
## Summary
- reference cartographer index for map update helpers

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ecdc344c8324abde7bebee1a9f89