### PR TITLE
Introduce modular dialogue service

### DIFF
--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -1,0 +1,180 @@
+/**
+ * @file api.ts
+ * @description Wrapper functions for dialogue-related AI interactions.
+ */
+import { GenerateContentResponse } from '@google/genai';
+import {
+  DialogueAIResponse,
+  DialogueHistoryEntry,
+  DialogueSummaryContext,
+  DialogueSummaryResponse,
+  Item,
+  Character,
+  MapNode,
+  DialogueMemorySummaryContext,
+  AdventureTheme,
+} from '../../types';
+import { GEMINI_MODEL_NAME, MAX_RETRIES } from '../../constants';
+import { DIALOGUE_SYSTEM_INSTRUCTION, DIALOGUE_SUMMARY_SYSTEM_INSTRUCTION } from './systemPrompt';
+import { ai } from '../geminiClient';
+import { recordModelCall } from '../../utils/modelUsageTracker';
+import { callMinimalCorrectionAI } from '../corrections/base';
+import { isApiConfigured } from '../apiClient';
+import { buildDialogueTurnPrompt, buildDialogueSummaryPrompt, buildDialogueMemorySummaryPrompts } from './promptBuilder';
+import { parseDialogueAIResponse, parseDialogueSummaryResponse } from './responseParser';
+
+interface GeminiRequestConfig {
+  systemInstruction: string;
+  responseMimeType: string;
+  temperature: number;
+  thinkingConfig?: { thinkingBudget: number };
+}
+
+/**
+ * Executes a Gemini API call for dialogue related prompts.
+ * Allows optional disabling of model "thinking" for faster responses.
+ */
+const callDialogueGeminiAPI = async (
+  prompt: string,
+  systemInstruction: string,
+  disableThinking: boolean = false,
+): Promise<GenerateContentResponse> => {
+  const config: GeminiRequestConfig = {
+    systemInstruction,
+    responseMimeType: 'application/json',
+    temperature: 0.8,
+  };
+  if (disableThinking) {
+    config.thinkingConfig = { thinkingBudget: 0 };
+  }
+  recordModelCall(GEMINI_MODEL_NAME);
+  return ai!.models.generateContent({
+    model: GEMINI_MODEL_NAME,
+    contents: prompt,
+    config,
+  });
+};
+
+/**
+ * Fetches the next dialogue turn from the AI based on the current game state.
+ */
+export const fetchDialogueTurn = async (
+  currentTheme: AdventureTheme,
+  currentQuest: string | null,
+  currentObjective: string | null,
+  currentScene: string,
+  localTime: string | null,
+  localEnvironment: string | null,
+  localPlace: string | null,
+  knownMainMapNodesInTheme: MapNode[],
+  knownCharactersInTheme: Character[],
+  inventory: Item[],
+  playerGender: string,
+  dialogueHistory: DialogueHistoryEntry[],
+  playerLastUtterance: string,
+  dialogueParticipants: string[],
+): Promise<DialogueAIResponse | null> => {
+  if (!isApiConfigured()) {
+    console.error('API Key not configured for Dialogue Service.');
+    return Promise.reject(new Error('API Key not configured.'));
+  }
+
+  const prompt = buildDialogueTurnPrompt(
+    currentTheme,
+    currentQuest,
+    currentObjective,
+    currentScene,
+    localTime,
+    localEnvironment,
+    localPlace,
+    knownMainMapNodesInTheme,
+    knownCharactersInTheme,
+    inventory,
+    playerGender,
+    dialogueHistory,
+    playerLastUtterance,
+    dialogueParticipants,
+  );
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      console.log(`Fetching dialogue turn (Participants: ${dialogueParticipants.join(', ')}, Attempt ${attempt}/${MAX_RETRIES})`);
+      const response = await callDialogueGeminiAPI(prompt, DIALOGUE_SYSTEM_INSTRUCTION, true);
+      const parsed = parseDialogueAIResponse(response.text ?? '');
+      if (parsed) return parsed;
+      console.warn(`Attempt ${attempt} failed to yield valid JSON for dialogue turn. Retrying if attempts remain.`);
+    } catch (error) {
+      console.error(`Error fetching dialogue turn (Attempt ${attempt}/${MAX_RETRIES}):`, error);
+      if (attempt === MAX_RETRIES) throw error;
+    }
+  }
+  throw new Error('Failed to fetch dialogue turn after maximum retries.');
+};
+
+/**
+ * Summarizes a completed dialogue to derive game state updates.
+ */
+export const summarizeDialogueForUpdates = async (
+  summaryContext: DialogueSummaryContext,
+): Promise<DialogueSummaryResponse | null> => {
+  if (!isApiConfigured()) {
+    console.error('API Key not configured for Dialogue Summary Service.');
+    return Promise.reject(new Error('API Key not configured.'));
+  }
+
+  if (!summaryContext.currentThemeObject) {
+    console.error('DialogueSummaryContext missing currentThemeObject. Cannot summarize dialogue.');
+    return Promise.reject(new Error('DialogueSummaryContext missing currentThemeObject.'));
+  }
+
+  const prompt = buildDialogueSummaryPrompt(summaryContext);
+
+  for (let attempt = 1; attempt <= MAX_RETRIES + 2; attempt++) {
+    try {
+      console.log(`Summarizing dialogue with ${summaryContext.dialogueParticipants.join(', ')}, Attempt ${attempt}/${MAX_RETRIES + 2})`);
+      const response = await callDialogueGeminiAPI(prompt, DIALOGUE_SUMMARY_SYSTEM_INSTRUCTION, false);
+      const parsed = parseDialogueSummaryResponse(response.text ?? '');
+      if (parsed) return parsed;
+      console.warn(`Attempt ${attempt} failed to yield valid JSON for dialogue summary. Retrying if attempts remain.`);
+    } catch (error) {
+      console.error(`Error summarizing dialogue (Attempt ${attempt}/${MAX_RETRIES + 2}):`, error);
+      if (attempt === MAX_RETRIES + 2) throw error;
+    }
+  }
+  return { logMessage: 'The conversation concluded without notable changes.' };
+};
+
+/**
+ * Generates a detailed narrative summary of a dialogue for character memory.
+ */
+export const summarizeDialogueForMemory = async (
+  context: DialogueMemorySummaryContext,
+): Promise<string | null> => {
+  if (!isApiConfigured()) {
+    console.error('API Key not configured for Dialogue Memory Summary Service.');
+    return null;
+  }
+  if (!context.currentThemeObject) {
+    console.error('DialogueMemorySummaryContext missing currentThemeObject. Cannot summarize memory.');
+    return null;
+  }
+
+  const { systemInstructionPart, userPromptPart } = buildDialogueMemorySummaryPrompts(context);
+
+  for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+    try {
+      console.log(`Generating memory summary for dialogue with ${context.dialogueParticipants.join(', ')}, Attempt ${attempt}/${MAX_RETRIES + 1})`);
+      const memoryText = await callMinimalCorrectionAI(userPromptPart, systemInstructionPart);
+      if (memoryText && memoryText.length > 0) {
+        console.log(`summarizeDialogueForMemory: ${context.dialogueParticipants.join(', ')} will remember ${memoryText}`);
+        return memoryText;
+      }
+      console.warn(`Attempt ${attempt} for memory summary yielded empty text after trim: '${memoryText}'`);
+      if (attempt === MAX_RETRIES + 1) return null;
+    } catch (error) {
+      console.error(`Error generating memory summary (Attempt ${attempt}/${MAX_RETRIES + 1}):`, error);
+      if (attempt === MAX_RETRIES + 1) return null;
+    }
+  }
+  return null;
+};

--- a/services/dialogue/index.ts
+++ b/services/dialogue/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @file services/dialogue/index.ts
+ * @description Re-exports utilities for interacting with the dialogue AI.
+ */
+export * from './api';
+export * from './promptBuilder';
+export * from './responseParser';
+export * from './systemPrompt';

--- a/services/dialogue/promptBuilder.ts
+++ b/services/dialogue/promptBuilder.ts
@@ -1,0 +1,198 @@
+/**
+ * @file promptBuilder.ts
+ * @description Helper functions for constructing dialogue-related prompts.
+ */
+import {
+  AdventureTheme,
+  DialogueHistoryEntry,
+  Item,
+  Character,
+  MapNode,
+  DialogueSummaryContext,
+  DialogueMemorySummaryContext,
+} from '../../types';
+import { MAX_DIALOGUE_SUMMARIES_IN_PROMPT } from '../../constants';
+import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
+
+/**
+ * Builds the prompt used to fetch the next dialogue turn.
+ */
+export const buildDialogueTurnPrompt = (
+  currentTheme: AdventureTheme,
+  currentQuest: string | null,
+  currentObjective: string | null,
+  currentScene: string,
+  localTime: string | null,
+  localEnvironment: string | null,
+  localPlace: string | null,
+  knownMainMapNodesInTheme: MapNode[],
+  knownCharactersInTheme: Character[],
+  inventory: Item[],
+  playerGender: string,
+  dialogueHistory: DialogueHistoryEntry[],
+  playerLastUtterance: string,
+  dialogueParticipants: string[],
+): string => {
+  let historyToUseInPrompt = [...dialogueHistory];
+  if (
+    historyToUseInPrompt.length > 0 &&
+    historyToUseInPrompt[historyToUseInPrompt.length - 1].speaker.toLowerCase() === 'player' &&
+    historyToUseInPrompt[historyToUseInPrompt.length - 1].line === playerLastUtterance
+  ) {
+    historyToUseInPrompt = historyToUseInPrompt.slice(0, -1);
+  }
+
+  const historyString = historyToUseInPrompt
+    .map(entry => `${entry.speaker}: "${entry.line}"`)
+    .join('\n');
+
+  const inventoryString =
+    inventory.map(item => `${item.name} (Type: ${item.type}, Active: ${!!item.isActive})`).join(', ') ||
+    'Empty';
+  const knownPlacesString = formatKnownPlacesForPrompt(knownMainMapNodesInTheme, true);
+
+  let characterContextString = 'Known Characters: ';
+  if (knownCharactersInTheme.length > 0) {
+    characterContextString +=
+      knownCharactersInTheme
+        .map(c => {
+          let charStr = `"${c.name}" (Description: ${c.description.substring(0, 70)}...; Presence: ${c.presenceStatus}`;
+          if (c.presenceStatus === 'nearby' || c.presenceStatus === 'companion') {
+            charStr += ` at ${c.preciseLocation || 'around'}`;
+          } else {
+            charStr += `, last seen: ${c.lastKnownLocation || 'Unknown'}`;
+          }
+          charStr += ')';
+          return charStr;
+        })
+        .join('; ') + '.';
+  } else {
+    characterContextString += 'None specifically known.';
+  }
+
+  let pastDialogueSummariesContext = '';
+  dialogueParticipants.forEach(participantName => {
+    const participantChar = knownCharactersInTheme.find(char => char.name === participantName);
+    if (participantChar && participantChar.dialogueSummaries && participantChar.dialogueSummaries.length > 0) {
+      pastDialogueSummariesContext += `\nRecent Past Conversations involving ${participantName}:\n`;
+      const summariesToShow = participantChar.dialogueSummaries.slice(-MAX_DIALOGUE_SUMMARIES_IN_PROMPT);
+      summariesToShow.forEach(summary => {
+        pastDialogueSummariesContext += `- Summary: "${summary.summaryText}" (Participants: ${summary.participants.join(', ')}; Time: ${summary.timestamp}; Location: ${summary.location})\n`;
+      });
+    }
+  });
+
+  return `
+Context for Dialogue Turn:
+- Current Theme: "${currentTheme.name}"
+- System Instruction Modifier for Theme: "${currentTheme.systemInstructionModifier}"
+- Current Main Quest: "${currentQuest || 'Not set'}"
+- Current Objective: "${currentObjective || 'Not set'}"
+- Scene Description (for environmental context): "${currentScene}"
+- Local Time: "${localTime || 'Unknown'}", Environment: "${localEnvironment || 'Undetermined'}", Place: "${localPlace || 'Undetermined'}"
+- Player's Character Gender: ${playerGender}
+- Player's Inventory: ${inventoryString}
+- Known Locations: ${knownPlacesString}
+- ${characterContextString}
+- Current Dialogue Participants: ${dialogueParticipants.join(', ')}
+${pastDialogueSummariesContext.trim() ? pastDialogueSummariesContext : '\n- No specific past dialogue summaries available for current participants.'}
+- Dialogue History (most recent last):
+${historyString}
+- Player's Last Utterance/Choice: "${playerLastUtterance}"
+
+Based on this context, provide the next part of the dialogue according to the DIALOGUE_SYSTEM_INSTRUCTION.
+The NPC(s) should respond to the player's last utterance, taking into account any relevant past conversation summaries.
+Provide new dialogue options, ensuring the last one is a way to end the dialogue.
+`;
+};
+
+/**
+ * Builds the prompt used for summarizing a completed dialogue.
+ */
+export const buildDialogueSummaryPrompt = (
+  summaryContext: DialogueSummaryContext,
+): string => {
+  const dialogueLogString = summaryContext.dialogueLog.map(entry => `${entry.speaker}: "${entry.line}"`).join('\n');
+  const inventoryString = summaryContext.inventory.map(item => `${item.name} (Type: ${item.type})`).join(', ') || 'Empty';
+  const knownPlacesString = formatKnownPlacesForPrompt(
+    summaryContext.mapDataForTheme.nodes.filter(n => n.data.nodeType !== 'feature'),
+    true,
+  );
+
+  let knownCharactersString = 'Known Characters: ';
+  if (summaryContext.knownCharactersInTheme.length > 0) {
+    knownCharactersString +=
+      summaryContext.knownCharactersInTheme
+        .map(c => {
+          let charStr = `"${c.name}" (Description: ${c.description.substring(0, 70)}...; Presence: ${c.presenceStatus}`;
+          if (c.presenceStatus === 'nearby' || c.presenceStatus === 'companion') {
+            charStr += ` at ${c.preciseLocation || 'around'}`;
+          } else {
+            charStr += `, last seen: ${c.lastKnownLocation || 'Unknown'}`;
+          }
+          charStr += ')';
+          return charStr;
+        })
+        .join('; ') + '.';
+  } else {
+    knownCharactersString += 'None specifically known.';
+  }
+
+  return `
+Context for Dialogue Summary:
+- Current Theme: "${summaryContext.currentThemeObject!.name}"
+- System Instruction Modifier for Theme: "${summaryContext.currentThemeObject!.systemInstructionModifier}"
+- Current Main Quest (before dialogue): "${summaryContext.mainQuest || 'Not set'}"
+- Current Objective (before dialogue): "${summaryContext.currentObjective || 'Not set'}"
+- Scene Description (when dialogue started): "${summaryContext.currentScene}"
+- Local Time: "${summaryContext.localTime || 'Unknown'}", Environment: "${summaryContext.localEnvironment || 'Undetermined'}", Place: "${summaryContext.localPlace || 'Undetermined'}"
+- Player's Character Gender: "${summaryContext.playerGender}"
+- Player's Inventory (before dialogue): ${inventoryString}
+- Known Locations (before dialogue): ${knownPlacesString}
+- ${knownCharactersString}
+- Dialogue Participants: ${summaryContext.dialogueParticipants.join(', ')}
+
+Full Dialogue Transcript:
+${dialogueLogString}
+
+Based *only* on the Dialogue Transcript and the provided context, determine what concrete game state changes (items, characters, quest/objective updates, log message, map updates) resulted *directly* from this dialogue.
+The "logMessage" field in your response should be a concise summary suitable for the main game log.
+If the dialogue revealed a new alias for an existing character, use "charactersUpdated" with "addAlias".
+If the dialogue changed some character's general whereabouts, use "newLastKnownLocation" in "charactersUpdated".
+If the dialogue revealed new map information (new locations, changed accessibility, etc.), or if Player's own location changed over the course of the dialogue, then set "mapUpdated": true.
+`;
+};
+
+/**
+ * Builds the system and user prompt parts for a dialogue memory summary.
+ */
+export const buildDialogueMemorySummaryPrompts = (
+  context: DialogueMemorySummaryContext,
+): { systemInstructionPart: string; userPromptPart: string } => {
+  const dialogueLogString = context.dialogueLog.map(entry => `  ${entry.speaker}: ${entry.line}`).join('\n');
+
+  const systemInstructionPart = `You are an AI assistant creating a detailed memory of a conversation. This memory will be stored by the game characters who participated.
+Your task is to write a concise yet detailed summary of the conversation.
+The summary should be between 500 and 1500 characters. It should be written from the point of view of the Conversation Participants other than the Player.
+The summary should ALWAYS mention all names and the "Player" explicitly without pronouns.
+It should capture:
+- Key topics discussed.
+- Important information revealed or exchanged by any participant.
+- Significant decisions made or outcomes reached.
+- The overall emotional tone or atmosphere of the conversation.
+- Any impressions or key takeaways the characters might have.
+
+Output ONLY the summary text. Do NOT use JSON or formatting. Do NOT include any preamble like "Here is the summary:".`;
+
+  const userPromptPart = `Generate a memory summary for the following conversation:
+ - Conversation Participants: ${context.dialogueParticipants.join(', ')}
+ - Theme: "${context.currentThemeObject!.name}" (System Modifier: ${context.currentThemeObject!.systemInstructionModifier})
+- Scene at start of conversation: "${context.currentScene}"
+- Context: Time: "${context.localTime || 'Unknown'}", Environment: "${context.localEnvironment || 'Undetermined'}", Place: "${context.localPlace || 'Undetermined'}"
+- Full Dialogue Transcript:
+${dialogueLogString}
+
+Output ONLY the summary text. Do NOT use JSON or formatting. Do NOT include any preamble like "Here is the summary:".`;
+
+  return { systemInstructionPart, userPromptPart };
+};

--- a/services/dialogue/responseParser.ts
+++ b/services/dialogue/responseParser.ts
@@ -1,0 +1,51 @@
+/**
+ * @file responseParser.ts
+ * @description Helpers for parsing dialogue-related AI responses.
+ */
+import { DialogueAIResponse, DialogueSummaryResponse } from '../../types';
+import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
+
+export const parseDialogueAIResponse = (
+  responseText: string,
+): DialogueAIResponse | null => {
+  const jsonStr = extractJsonFromFence(responseText);
+  const parsed = safeParseJson<Partial<DialogueAIResponse>>(jsonStr);
+  try {
+    if (!parsed) throw new Error('JSON parse failed');
+    if (
+      !parsed ||
+      !Array.isArray(parsed.npcResponses) ||
+      !parsed.npcResponses.every(r => r && typeof r.speaker === 'string' && typeof r.line === 'string') ||
+      !Array.isArray(parsed.playerOptions) ||
+      !parsed.playerOptions.every(o => typeof o === 'string') ||
+      (parsed.dialogueEnds !== undefined && typeof parsed.dialogueEnds !== 'boolean') ||
+      (parsed.updatedParticipants !== undefined && (!Array.isArray(parsed.updatedParticipants) || !parsed.updatedParticipants.every(p => typeof p === 'string')))
+    ) {
+      console.warn('Parsed dialogue JSON does not match DialogueAIResponse structure:', parsed);
+      return null;
+    }
+    if (parsed.playerOptions.length === 0) {
+      parsed.playerOptions = ['End Conversation.'];
+    }
+    return parsed as DialogueAIResponse;
+  } catch (e) {
+    console.warn('Failed to parse dialogue JSON response from AI:', e);
+    console.debug('Original dialogue response text:', responseText);
+    return null;
+  }
+};
+
+export const parseDialogueSummaryResponse = (
+  responseText: string,
+): DialogueSummaryResponse | null => {
+  const jsonStr = extractJsonFromFence(responseText);
+  const parsed = safeParseJson<DialogueSummaryResponse>(jsonStr);
+  try {
+    if (!parsed) throw new Error('JSON parse failed');
+    return parsed;
+  } catch (e) {
+    console.warn('Failed to parse dialogue summary JSON response from AI:', e);
+    console.debug('Original dialogue summary response text:', responseText);
+    return null;
+  }
+};

--- a/services/dialogue/systemPrompt.ts
+++ b/services/dialogue/systemPrompt.ts
@@ -1,0 +1,86 @@
+/**
+ * @file systemPrompt.ts
+ * @description System instructions for dialogue-related AI calls.
+ */
+
+import { ITEMS_GUIDE, LOCAL_CONDITIONS_GUIDE } from '../../prompts/helperPrompts';
+import { VALID_PRESENCE_STATUS_VALUES_STRING, ALIAS_INSTRUCTION } from '../../constants';
+
+export const DIALOGUE_SYSTEM_INSTRUCTION = `You are an AI assistant guiding a dialogue turn in a text-based adventure game. The player is in conversation with one or more characters. Your role is to:
+1. Generate responses for the NPC(s) involved in the dialogue.
+2. Provide from 4 to 8 first-person dialogue options for the player. The last option MUST be a way for the player to end the dialogue (e.g., "I should get going.", "That's all I needed to know.", "Let's talk another time.").
+3. Optionally, indicate if the dialogue is ending from the NPC's side or if the list of participants changes.
+4. Optionally add or remove participants of the dialogue, based on context.
+
+Respond ONLY in JSON format with the following structure:
+{
+  "npcResponses": [
+    { "speaker": "CharacterName1", "line": "What CharacterName1 says this turn." }, /* REQUIRED. */
+    { "speaker": "CharacterName2", "line": "What CharacterName2 says this turn,if they speak." }, /* Optional. */
+    ...
+    /* Include one entry for each NPC who may speaks this turn. It can be one or multiple NPCs. Speaker MUST be one of the current dialogue participants. Lines must be non-empty. */
+  ],
+  "playerOptions": [
+    "Player's first dialogue choice (phrased as if player is speaking, non-empty).",
+    "Player's second dialogue choice.",
+    /* ... up to 7 total options ... */
+    "An AI-generated phrase for the player to end the dialogue (e.g., "Thanks, I'll be on my way.", "Enough! I don't want to talk to you."). This MUST be the last option."
+  ],
+  "dialogueEnds"?: boolean, /* Optional. Set to true if the NPC(s) clearly signal the end of the conversation, or if the conversation obviously reached its logical end. */
+  "updatedParticipants"?: ["CharacterName1", "NewCharacterJoining", ...] /* Optional. Cannot be empty. Provide the new full list of participants if someone joins or leaves the conversation. If omitted, participants remain the same. DO NOT add Player's Character to the list. */
+}
+
+Instructions:
+- NPC responses should be in character, relevant to the ongoing dialogue.
+- Player options should be natural, first-person phrases. Ensure variety and meaningful choices.
+- The LAST player option must always be a contextually appropriate way for the player to signal they wish to end the conversation.
+- If the Player's latest response is a polite hint that the conversation is over, provide the final NPC responses and set "dialogueEnds" true.
+- If "updatedParticipants" is provided, the dialogue continues with the new set of characters.
+- Maintain thematic consistency based on the theme name and modifier provided in the prompt.
+- Consider the player's gender subtly if it makes sense for character interactions, but don't make it overt.
+`;
+
+export const DIALOGUE_SUMMARY_SYSTEM_INSTRUCTION = `You are an AI assistant tasked with analyzing a completed dialogue transcript from a text-based adventure game. Your goal is to extract concrete game state changes that occurred *as a direct result of the dialogue itself*.
+
+Respond ONLY in JSON format with the following structure:
+{
+  "sceneDescription": "Detailed, engaging description, considering Current Theme Guidance, active items, known Places/Characters, Local Time, Local Environment, Local Place, Player's Character Gender.",
+  "logMessage": "A concise summary message for the main game log, describing the key outcomes or information gained from the dialogue",
+  "options": ["Action 1", "Action 2", "Action 3", "Action 4" /* ALWAYS provide FOUR distinct "options". Tailor them to the full context. */ ],
+  "itemChange"?: [ /* ItemChange objects if items were gained, lost, put elsewhere, given/taken, or updated *directly through the dialogue*. Follow standard ItemChange structure. For 'update', 'gain', or 'put', the 'item' field is an Item object. */ ],
+  "charactersAdded"?: [ /* { "name", "description", "aliases" (${ALIAS_INSTRUCTION}), "presenceStatus": ${VALID_PRESENCE_STATUS_VALUES_STRING}, "lastKnownLocation": "...", "preciseLocation": "..." } if new characters were *introduced or became significant*. */ ],
+  "charactersUpdated"?: [ /* { "name", "newDescription", "newAliases" (${ALIAS_INSTRUCTION}), "addAlias"?: string, "newPresenceStatus": ${VALID_PRESENCE_STATUS_VALUES_STRING}, "newLastKnownLocation": "...", "newPreciseLocation": "..." } if dialogue provided new information about existing characters or their presence state. */ ],
+  "mainQuest"?: "New quest string if the dialogue changed it.",
+  "currentObjective"?: "New objective string if dialogue changed it.",
+  "objectiveAchieved"?: boolean, /* Set to true if the dialogue directly resulted in completing the current objective and resulted in a new objective. */
+  "localTime"?: "New concise string if time changed due to dialogue (e.g. significant passage of time discussed).",
+  "localEnvironment"?: "New brief sentence if environment/weather changed due to dialogue (e.g. magical effect during conversation).",
+  "localPlace"?: "New concise string if player's specific location changed due to dialogue (e.g. journey completed during talk, arrival confirmed).",
+  "mapUpdated"?: boolean, /* Optional. Set to true if this dialogue's outcome (e.g., revealing a new map node/location via logMessage, changing a map node's status) warrants an update to the game map. You DO NOT output specific map node/edge changes. */
+  "currentMapNodeId"?: string /* Optional. If dialogue implies player is at a specific Map Node (Location/Feature), provide its 'placeName' or ID. Omit if no strong suggestion. */,
+  "mapHint"?: string /* Optional hint (up to 500 chars) describing distant quest-related and objective-related locations, their surroundings, and travel directions from the player's current position. */
+}
+
+- For "charactersAdded" and "charactersUpdated", ensure all relevant fields including "presenceStatus", "lastKnownLocation", and "preciseLocation" are considered and provided if the dialogue yields such information. Default "presenceStatus" to 'distant' or 'unknown' if not specified but character is introduced.
+- "preciseLocation" is for the in-scene details. "lastKnownLocation" is for general whereabouts, and can be a known Map Node name or a descriptive string.
+- "lastKnownLocation" (on Character object, updated via "charactersUpdated") tracks general whereabouts when "presenceStatus" is 'distant' or 'unknown'.
+- "preciseLocation" (on Character object, updated via "charactersUpdated") details location/activity in current scene if "presenceStatus" is 'nearby' or 'companion'.
+
+Items:
+If the dialogue resulted in taking, giving, picking up, leaving behind, obtaining or consuming any Items, changing their properties or amounts, moving them elsewhere, or transferring them between characters, use "itemChange" actions "gain", "lose", "put", "give"/"take", or "update".
+${ITEMS_GUIDE}
+These fields MUST be provided if the Player's Inventory clearly changed during the dialogue..
+
+Local Time, Environment & Place:
+If the dialogue resulted in a change to the local time, environment, or player's specific place, update "localTime", "localEnvironment", and "localPlace" accordingly.
+${LOCAL_CONDITIONS_GUIDE}
+These fields MUST be provided if the dialogue caused a change, for example, Player moved to a new place, time passed, or weather changed; otherwise, they can be omitted if no change occurred. If provided, they must follow the specified format.
+
+Instructions:
+- Analyze the Dialogue Log carefully. Identify any explicit agreements, revelations, exchanges, or decisions made.
+- "charactersAdded"/"charactersUpdated": Only add/update if the dialogue provided new, concrete information for description, aliases, presence status, or locations.
+- If the dialogue implies a new location was revealed or an existing one changed, set "mapUpdated": true and include details in the "logMessage". The map service will handle actual map changes.
+- If distant quest-related locations were mentioned, summarize their relative position and travel directions in "mapHint" so the Map AI can ensure they exist on the map.
+- "logMessage": This should be a brief, informative message suitable for the main game log, summarizing the dialogue's impact.
+- "mainQuest"/"currentObjective"/"objectiveAchieved": Only change these if the dialogue undeniably led to a quest/objective update or completion.
+`;


### PR DESCRIPTION
## Summary
- add `services/dialogue/` folder mirroring other service modules
- include API wrapper, prompt builders, response parsers and system prompts
- re-export dialogue utilities from new index file

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849f4440f888324b46625cf2872a81f