### PR TITLE
Refactor dialogue API helper names

### DIFF
--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -58,7 +58,7 @@ const callDialogueGeminiAPI = async (
 /**
  * Fetches the next dialogue turn from the AI based on the current game state.
  */
-export const fetchDialogueTurn = async (
+export const executeDialogueTurn = async (
   currentTheme: AdventureTheme,
   currentQuest: string | null,
   currentObjective: string | null,
@@ -114,7 +114,7 @@ export const fetchDialogueTurn = async (
 /**
  * Summarizes a completed dialogue to derive game state updates.
  */
-export const summarizeDialogueForUpdates = async (
+export const executeDialogueSummary = async (
   summaryContext: DialogueSummaryContext,
 ): Promise<DialogueSummaryResponse | null> => {
   if (!isApiConfigured()) {
@@ -147,7 +147,7 @@ export const summarizeDialogueForUpdates = async (
 /**
  * Generates a detailed narrative summary of a dialogue for character memory.
  */
-export const summarizeDialogueForMemory = async (
+export const executeMemorySummary = async (
   context: DialogueMemorySummaryContext,
 ): Promise<string | null> => {
   if (!isApiConfigured()) {


### PR DESCRIPTION
## Summary
- rename dialogue helper methods for clarity

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849f78547b08324bb04566ac628bbb6