### PR TITLE
Refactor dialogue builders

### DIFF
--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -79,7 +79,7 @@ export const executeDialogueTurn = async (
     return Promise.reject(new Error('API Key not configured.'));
   }
 
-  const prompt = buildDialogueTurnPrompt(
+  const prompt = buildDialogueTurnPrompt({
     currentTheme,
     currentQuest,
     currentObjective,
@@ -94,7 +94,7 @@ export const executeDialogueTurn = async (
     dialogueHistory,
     playerLastUtterance,
     dialogueParticipants,
-  );
+  });
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {

--- a/services/dialogue/promptBuilder.ts
+++ b/services/dialogue/promptBuilder.ts
@@ -3,13 +3,9 @@
  * @description Helper functions for constructing dialogue-related prompts.
  */
 import {
-  AdventureTheme,
-  DialogueHistoryEntry,
-  Item,
-  Character,
-  MapNode,
   DialogueSummaryContext,
   DialogueMemorySummaryContext,
+  DialogueTurnContext,
 } from '../../types';
 import { MAX_DIALOGUE_SUMMARIES_IN_PROMPT } from '../../constants';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
@@ -18,21 +14,24 @@ import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
  * Builds the prompt used to fetch the next dialogue turn.
  */
 export const buildDialogueTurnPrompt = (
-  currentTheme: AdventureTheme,
-  currentQuest: string | null,
-  currentObjective: string | null,
-  currentScene: string,
-  localTime: string | null,
-  localEnvironment: string | null,
-  localPlace: string | null,
-  knownMainMapNodesInTheme: MapNode[],
-  knownCharactersInTheme: Character[],
-  inventory: Item[],
-  playerGender: string,
-  dialogueHistory: DialogueHistoryEntry[],
-  playerLastUtterance: string,
-  dialogueParticipants: string[],
+  context: DialogueTurnContext,
 ): string => {
+  const {
+    currentTheme,
+    currentQuest,
+    currentObjective,
+    currentScene,
+    localTime,
+    localEnvironment,
+    localPlace,
+    knownMainMapNodesInTheme,
+    knownCharactersInTheme,
+    inventory,
+    playerGender,
+    dialogueHistory,
+    playerLastUtterance,
+    dialogueParticipants,
+  } = context;
   let historyToUseInPrompt = [...dialogueHistory];
   if (
     historyToUseInPrompt.length > 0 &&

--- a/types.ts
+++ b/types.ts
@@ -117,10 +117,28 @@ export interface DialogueSetupPayload {
 }
 
 export interface DialogueAIResponse { // AI response for a single turn *during* dialogue
-  npcResponses: DialogueTurnResponsePart[]; 
-  playerOptions: string[]; 
-  dialogueEnds?: boolean; 
-  updatedParticipants?: string[]; 
+  npcResponses: DialogueTurnResponsePart[];
+  playerOptions: string[];
+  dialogueEnds?: boolean;
+  updatedParticipants?: string[];
+}
+
+// Context object for building a dialogue turn prompt
+export interface DialogueTurnContext {
+  currentTheme: AdventureTheme;
+  currentQuest: string | null;
+  currentObjective: string | null;
+  currentScene: string;
+  localTime: string | null;
+  localEnvironment: string | null;
+  localPlace: string | null;
+  knownMainMapNodesInTheme: MapNode[];
+  knownCharactersInTheme: Character[];
+  inventory: Item[];
+  playerGender: string;
+  dialogueHistory: DialogueHistoryEntry[];
+  playerLastUtterance: string;
+  dialogueParticipants: string[];
 }
 
 export interface DialogueSummaryContext {


### PR DESCRIPTION
## Summary
- add DialogueTurnContext type
- refactor prompt builder to use context object
- use new builders from dialogueService and API modules

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849f8cd5c2c832482372f8f0f255d76