### PR TITLE
Implement dialogue response parsers

### DIFF
--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -21,7 +21,10 @@ import { recordModelCall } from '../../utils/modelUsageTracker';
 import { callMinimalCorrectionAI } from '../corrections/base';
 import { isApiConfigured } from '../apiClient';
 import { buildDialogueTurnPrompt, buildDialogueSummaryPrompt, buildDialogueMemorySummaryPrompts } from './promptBuilder';
-import { parseDialogueAIResponse, parseDialogueSummaryResponse } from './responseParser';
+import {
+  parseDialogueTurnResponse,
+  parseDialogueSummaryResponse,
+} from './responseParser';
 
 interface GeminiRequestConfig {
   systemInstruction: string;
@@ -100,7 +103,7 @@ export const executeDialogueTurn = async (
     try {
       console.log(`Fetching dialogue turn (Participants: ${dialogueParticipants.join(', ')}, Attempt ${attempt}/${MAX_RETRIES})`);
       const response = await callDialogueGeminiAPI(prompt, DIALOGUE_SYSTEM_INSTRUCTION, true);
-      const parsed = parseDialogueAIResponse(response.text ?? '');
+      const parsed = parseDialogueTurnResponse(response.text ?? '');
       if (parsed) return parsed;
       console.warn(`Attempt ${attempt} failed to yield valid JSON for dialogue turn. Retrying if attempts remain.`);
     } catch (error) {

--- a/services/dialogue/responseParser.ts
+++ b/services/dialogue/responseParser.ts
@@ -35,6 +35,36 @@ export const parseDialogueAIResponse = (
   }
 };
 
+export const parseDialogueTurnResponse = (
+  responseText: string,
+): DialogueAIResponse | null => {
+  const jsonStr = extractJsonFromFence(responseText);
+  const parsed = safeParseJson<Partial<DialogueAIResponse>>(jsonStr);
+  try {
+    if (!parsed) throw new Error('JSON parse failed');
+    if (
+      !parsed ||
+      !Array.isArray(parsed.npcResponses) ||
+      !parsed.npcResponses.every(r => r && typeof r.speaker === 'string' && typeof r.line === 'string') ||
+      !Array.isArray(parsed.playerOptions) ||
+      !parsed.playerOptions.every(o => typeof o === 'string') ||
+      (parsed.dialogueEnds !== undefined && typeof parsed.dialogueEnds !== 'boolean') ||
+      (parsed.updatedParticipants !== undefined && (!Array.isArray(parsed.updatedParticipants) || !parsed.updatedParticipants.every(p => typeof p === 'string')))
+    ) {
+      console.warn('Parsed dialogue JSON does not match DialogueAIResponse structure:', parsed);
+      return null;
+    }
+    if (parsed.playerOptions.length === 0) {
+      parsed.playerOptions = ['End Conversation.'];
+    }
+    return parsed as DialogueAIResponse;
+  } catch (e) {
+    console.warn('Failed to parse dialogue JSON response from AI:', e);
+    console.debug('Original dialogue response text:', responseText);
+    return null;
+  }
+};
+
 export const parseDialogueSummaryResponse = (
   responseText: string,
 ): DialogueSummaryResponse | null => {


### PR DESCRIPTION
## Summary
- implement `parseDialogueTurnResponse` for dialog API JSON
- expose the new parser in dialogue API
- keep helpers for parsing dialogue summary

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849fd8308b083248bfd9d5c4fafd2a2