### PR TITLE
Streamline Storyteller exports

### DIFF
--- a/services/storyteller/index.ts
+++ b/services/storyteller/index.ts
@@ -5,12 +5,7 @@
  */
 
 export * from './api';
-export * from '../dialogueService';
-export * from "./systemPrompt";
-export * from './responseParser';
 export * from './promptBuilder';
-export * from '../cartographer/api';
-export * from '../modelDispatcher';
-export * from '../geminiClient';
-export * from '../apiClient';
+export * from './responseParser';
+export * from './systemPrompt';
 


### PR DESCRIPTION
## Summary
- keep `services/storyteller/index.ts` focused on its own modules

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ff4282a88324b6f4dd633fb9fd00