### PR TITLE
Implement ModelDispatchOptions and update dispatch usage

### DIFF
--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -71,17 +71,20 @@ export interface MapUpdateServiceResult {
  * Sends a prompt and system instruction to the auxiliary AI model and returns
  * the raw response.
  */
-const callMapUpdateAI = async (prompt: string, systemInstruction: string): Promise<GenerateContentResponse> => {
+const callMapUpdateAI = async (
+  prompt: string,
+  systemInstruction: string
+): Promise<GenerateContentResponse> => {
   addProgressSymbol('▓▓');
-  return dispatchAIRequest(
-    [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+  const { response } = await dispatchAIRequest({
+    modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
     prompt,
     systemInstruction,
-    {
-      responseMimeType: "application/json",
-      temperature: 0.75,
-    }
-  );
+    responseMimeType: 'application/json',
+    temperature: 0.75,
+    label: 'MapUpdate',
+  });
+  return response;
 };
 
 /**

--- a/services/corrections/base.ts
+++ b/services/corrections/base.ts
@@ -3,7 +3,7 @@
  * @description Shared utilities for calling the AI correction models.
  */
 import { AUXILIARY_MODEL_NAME, MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME } from '../../constants';
-import { dispatchAIRequest, dispatchAIRequestWithModelInfo } from '../modelDispatcher';
+import { dispatchAIRequest } from '../modelDispatcher';
 import { MinimalModelCallRecord } from '../../types';
 import { isApiConfigured } from '../apiClient';
 import { isServerOrClientError } from '../../utils/aiErrorUtils';
@@ -28,15 +28,14 @@ export const callCorrectionAI = async <T = unknown>(
 ): Promise<T | null> => {
   addProgressSymbol('●');
   try {
-    const response = await dispatchAIRequest(
-      [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+    const { response } = await dispatchAIRequest({
+      modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
       prompt,
       systemInstruction,
-      {
-        responseMimeType: 'application/json',
-        temperature: CORRECTION_TEMPERATURE,
-      }
-    );
+      responseMimeType: 'application/json',
+      temperature: CORRECTION_TEMPERATURE,
+      label: 'CorrectionAI',
+    });
     const jsonStr = extractJsonFromFence(response.text ?? '');
     const parsed = safeParseJson<T>(jsonStr);
     if (parsed) return parsed;
@@ -66,13 +65,14 @@ export const callMinimalCorrectionAI = async (
   }
 
   try {
-    const { response } = await dispatchAIRequestWithModelInfo(
-      [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+    const { response } = await dispatchAIRequest({
+      modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
       prompt,
       systemInstruction,
-      { temperature: CORRECTION_TEMPERATURE },
-      debugLog
-    );
+      temperature: CORRECTION_TEMPERATURE,
+      label: 'MinimalCorrection',
+      debugLog,
+    });
     return response.text?.trim() ?? null;
   } catch (error) {
     console.error(

--- a/services/corrections/map.ts
+++ b/services/corrections/map.ts
@@ -611,12 +611,14 @@ Return ONLY a JSON object strictly matching this structure:
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       debugInfo.prompt = prompt;
-      const response = await dispatchAIRequest(
-        [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+      const { response } = await dispatchAIRequest({
+        modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
-        systemInstr,
-        { responseMimeType: 'application/json', temperature: CORRECTION_TEMPERATURE }
-      );
+        systemInstruction: systemInstr,
+        responseMimeType: 'application/json',
+        temperature: CORRECTION_TEMPERATURE,
+        label: 'ConnectorChains',
+      });
       debugInfo.rawResponse = response.text ?? '';
       const jsonStr = extractJsonFromFence(response.text ?? '');
       const parsed: unknown = safeParseJson(jsonStr);

--- a/services/modelDispatcher.ts
+++ b/services/modelDispatcher.ts
@@ -6,112 +6,95 @@
 import { GenerateContentResponse } from '@google/genai';
 import { ai } from './geminiClient';
 import { isApiConfigured } from './apiClient';
-import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
+import {
+  isServerOrClientError,
+  extractStatusFromError,
+} from '../utils/aiErrorUtils';
 import { MinimalModelCallRecord } from '../types';
 import { recordModelCall } from '../utils/modelUsageTracker';
+import { MINIMAL_MODEL_NAME } from '../constants';
 
 /** Determines if a model supports separate system instructions. */
 const supportsSystemInstruction = (model: string): boolean => !model.startsWith('gemma-');
 
+export interface ModelDispatchOptions {
+  modelNames: string[];
+  prompt: string;
+  systemInstruction?: string;
+  temperature?: number;
+  responseMimeType?: string;
+  thinkingBudget?: number;
+  responseSchema?: object;
+  label?: string;
+  debugLog?: MinimalModelCallRecord[];
+}
+
 /**
- * Sends an AI request, trying each model in order until one succeeds.
- * Falls back to the next model only when a client or server error is returned.
- *
- * @param modelNames - Array of model names to try in order.
- * @param prompt - The user prompt to send.
- * @param systemInstruction - Optional system instruction to include.
- * @param config - Additional generateContent configuration.
- * @returns The GenerateContentResponse from the first successful model.
+ * Sends an AI request, trying each model in order until one succeeds. Falls
+ * back to the next model only when a client or server error (typically 4xx)
+ * is encountered.
  */
 export const dispatchAIRequest = async (
-  modelNames: string[],
-  prompt: string,
-  systemInstruction?: string,
-  config: Record<string, unknown> = {}
-): Promise<GenerateContentResponse> => {
-  if (!isApiConfigured() || !ai) {
-    return Promise.reject(new Error('API Key not configured.'));
-  }
-
-  let lastError: unknown = null;
-  for (const model of modelNames) {
-    try {
-      const modelSupportsSystem = supportsSystemInstruction(model);
-      const contents = modelSupportsSystem
-        ? prompt
-        : `${systemInstruction ? systemInstruction + '\n\n' : ''}${prompt}`;
-      const cfg = { ...config };
-      if (modelSupportsSystem && systemInstruction) {
-        cfg.systemInstruction = systemInstruction;
-      }
-
-      recordModelCall(model);
-      const response = await ai.models.generateContent({
-        model,
-        contents,
-        config: cfg,
-      });
-      return response;
-    } catch (err) {
-      lastError = err;
-      if (!isServerOrClientError(err)) {
-        throw err;
-      }
-      console.warn(
-        `dispatchAIRequest: Model ${model} failed with status ${extractStatusFromError(err)}. Trying next model if available.`
-      );
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
-};
-
-export const dispatchAIRequestWithModelInfo = async (
-  modelNames: string[],
-  prompt: string,
-  systemInstruction?: string,
-  config: Record<string, unknown> = {},
-  debugLog?: MinimalModelCallRecord[]
+  options: ModelDispatchOptions
 ): Promise<{ response: GenerateContentResponse; modelUsed: string }> => {
   if (!isApiConfigured() || !ai) {
     return Promise.reject(new Error('API Key not configured.'));
   }
 
   let lastError: unknown = null;
-  for (const model of modelNames) {
+  for (const model of options.modelNames) {
     try {
       const modelSupportsSystem = supportsSystemInstruction(model);
       const contents = modelSupportsSystem
-        ? prompt
-        : `${systemInstruction ? systemInstruction + '\n\n' : ''}${prompt}`;
-      const cfg = { ...config };
-      if (modelSupportsSystem && systemInstruction) {
-        cfg.systemInstruction = systemInstruction;
-      }
-      recordModelCall(model);
+        ? options.prompt
+        : `${options.systemInstruction ? options.systemInstruction + '\n\n' : ''}${options.prompt}`;
 
+      const cfg: Record<string, unknown> = {};
+      if (options.temperature !== undefined) cfg.temperature = options.temperature;
+      if (options.responseMimeType) cfg.responseMimeType = options.responseMimeType;
+      if (options.thinkingBudget !== undefined) {
+        cfg.thinkingConfig = { thinkingBudget: options.thinkingBudget };
+      }
+      if (modelSupportsSystem && options.systemInstruction) {
+        cfg.systemInstruction = options.systemInstruction;
+      }
+      if (options.responseSchema && model !== MINIMAL_MODEL_NAME) {
+        cfg.responseSchema = options.responseSchema;
+      }
+
+      recordModelCall(model);
       const response = await ai.models.generateContent({
         model,
         contents,
         config: cfg,
       });
-      if (debugLog) {
-        debugLog.push({
-          prompt,
-          systemInstruction: systemInstruction || '',
+
+      if (options.label) {
+        console.log(
+          `[${options.label}] tokens: total ${response.usageMetadata?.totalTokenCount ?? 'N/A'}, prompt ${response.usageMetadata?.promptTokenCount ?? 'N/A'}, thoughts ${response.usageMetadata?.thoughtsTokenCount ?? 'N/A'}`
+        );
+      }
+
+      if (options.debugLog) {
+        options.debugLog.push({
+          prompt: options.prompt,
+          systemInstruction: options.systemInstruction || '',
           modelUsed: model,
           responseText: response.text ?? '',
         });
       }
+
       return { response, modelUsed: model };
     } catch (err) {
-      if (debugLog) {
-        debugLog.push({
-          prompt,
-          systemInstruction: systemInstruction || '',
+      if (options.debugLog) {
+        options.debugLog.push({
+          prompt: options.prompt,
+          systemInstruction: options.systemInstruction || '',
           modelUsed: model,
           responseText: `ERROR: ${err instanceof Error ? err.message : String(err)}`,
         });
       }
+
       lastError = err;
       if (!isServerOrClientError(err)) {
         throw err;

--- a/services/storyteller/api.ts
+++ b/services/storyteller/api.ts
@@ -102,14 +102,12 @@ Do not include any preamble. Just provide the summary text itself.
   for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) { // Extra retry for summarization
     try {
       console.log(`Summarizing adventure for theme "${themeToSummarize.name}" (Attempt ${attempt}/${MAX_RETRIES +1})`);
-      const response = await dispatchAIRequest(
-          [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
-          summarizationPrompt,
-          undefined,
-          {
-              temperature: 0.8,
-          }
-      );
+      const { response } = await dispatchAIRequest({
+          modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+          prompt: summarizationPrompt,
+          temperature: 0.8,
+          label: 'Summarize',
+      });
       const text = (response.text ?? '').trim();
       if (text && text.length > 0) {
         return text;


### PR DESCRIPTION
## Summary
- add `ModelDispatchOptions` interface
- update `dispatchAIRequest` to use options object, handle schema/labels, and return model used
- remove `dispatchAIRequestWithModelInfo`
- adjust correction, cartographer and storyteller services to new API

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ab4f38cb48324966cd8a8a65d2b15