### PR TITLE
Use unified dispatch labels

### DIFF
--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -82,7 +82,7 @@ const callMapUpdateAI = async (
     systemInstruction,
     responseMimeType: 'application/json',
     temperature: 0.75,
-    label: 'MapUpdate',
+    label: 'Cartographer',
   });
   return response;
 };

--- a/services/corrections/base.ts
+++ b/services/corrections/base.ts
@@ -34,7 +34,7 @@ export const callCorrectionAI = async <T = unknown>(
       systemInstruction,
       responseMimeType: 'application/json',
       temperature: CORRECTION_TEMPERATURE,
-      label: 'CorrectionAI',
+      label: 'Corrections',
     });
     const jsonStr = extractJsonFromFence(response.text ?? '');
     const parsed = safeParseJson<T>(jsonStr);
@@ -70,7 +70,7 @@ export const callMinimalCorrectionAI = async (
       prompt,
       systemInstruction,
       temperature: CORRECTION_TEMPERATURE,
-      label: 'MinimalCorrection',
+      label: 'Corrections',
       debugLog,
     });
     return response.text?.trim() ?? null;

--- a/services/corrections/map.ts
+++ b/services/corrections/map.ts
@@ -617,7 +617,7 @@ Return ONLY a JSON object strictly matching this structure:
         systemInstruction: systemInstr,
         responseMimeType: 'application/json',
         temperature: CORRECTION_TEMPERATURE,
-        label: 'ConnectorChains',
+        label: 'Corrections',
       });
       debugInfo.rawResponse = response.text ?? '';
       const jsonStr = extractJsonFromFence(response.text ?? '');


### PR DESCRIPTION
## Summary
- log dispatchAIRequest calls with unified `Cartographer` and `Corrections` labels
- update map connector correction to use the same label

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ab967d4dc832485ef749c8b777466