### PR TITLE
Improve AI dispatch docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,9 @@ This layer abstracts external interactions and complex data processing.
         *   `systemPrompt.ts` holds `MAP_UPDATE_SYSTEM_INSTRUCTION`.
         *   `index.ts` re-exports these utilities.
     *   `services/modelDispatcher.ts`: Provides AI model fallback when dispatching requests.
+        *   `dispatchAIRequest(modelNames, prompt, systemInstruction?, config?)` tries each model in order until one succeeds.  It returns the `GenerateContentResponse` from the first working model.
+        *   `dispatchAIRequestWithModelInfo` accepts the same parameters plus a `debugLog` array to capture which model was used and the raw response text for troubleshooting.
+        *   Callers such as `storyteller/api.ts` log `response.usageMetadata` token counts (total, thoughts, prompt) when using this interface to help diagnose high token usage.
 *   **Data Processing & Validation:**
     *   `services/storyteller/responseParser.ts`: Parses the storyteller AI's JSON, validates, and attempts corrections.
     *   `services/dialogue/responseParser.ts`: Parses dialogue AI JSON for turns and summaries.

--- a/services/cartographer/AGENTS.md
+++ b/services/cartographer/AGENTS.md
@@ -1,0 +1,9 @@
+The **cartographer** service is responsible for updating the map. It calls the auxiliary model with map context to produce an `AIMapUpdatePayload` that describes nodes and edges to add, update or remove.
+
+* `api.ts` – orchestrates map update calls and applies the returned payload to the game's `MapData` structure.
+* `promptBuilder.ts` – builds the prompt given to the map model.
+* `responseParser.ts` – parses and validates the AI response before it is merged into the game state.
+* `systemPrompt.ts` – contains the detailed instructions that define the payload format and valid values.
+* `index.ts` – re-exports these helpers.
+
+Edits here should maintain strict validation rules so invalid map structures do not propagate to the rest of the game.

--- a/services/corrections/AGENTS.md
+++ b/services/corrections/AGENTS.md
@@ -1,0 +1,9 @@
+The **corrections** helpers attempt to fix malformed AI responses. They are used when JSON fails validation or when map nodes require additional information.
+
+* `base.ts` – shared helpers for calling the correction models. Provides `callCorrectionAI` and `callMinimalCorrectionAI` wrappers that rely on `dispatchAIRequest`.
+* `character.ts`, `item.ts`, `name.ts` – small utilities that request corrected data for specific entity types.
+* `map.ts` – sophisticated routines that repair or refine `AIMapUpdatePayload` results.
+* `dialogue.ts` – fixes issues with conversation summaries and turn outputs.
+* `index.ts` – exports all correction helpers together.
+
+Use these utilities to keep the game running smoothly when the main models return inconsistent data.

--- a/services/dialogue/AGENTS.md
+++ b/services/dialogue/AGENTS.md
@@ -1,0 +1,9 @@
+The **dialogue** service handles conversational interactions with NPCs. It generates responses based on current map context and dialogue history.
+
+* `api.ts` – functions for performing dialogue turns, summarising conversations and obtaining memory summaries. All model calls route through `dispatchAIRequest`.
+* `promptBuilder.ts` – constructs the dialogue prompt using player input and recent exchanges.
+* `responseParser.ts` – validates the AI's JSON output and extracts conversation choices or summaries.
+* `systemPrompt.ts` – the base instruction string guiding dialogue style and structure.
+* `index.ts` – convenience exports for the modules above.
+
+Maintain compatibility between dialogue prompts and the parser whenever adjustments are made.

--- a/services/storyteller/AGENTS.md
+++ b/services/storyteller/AGENTS.md
@@ -1,0 +1,9 @@
+The **storyteller** service encapsulates all communication with the main narrative model. It exposes helper modules that build prompts, parse responses and store the system instruction used for each request.
+
+* `api.ts` – high level functions such as `executeAIMainTurn` and theme summarisation. These send fully formatted prompts to `dispatchAIRequest` and log usage metadata so token counts can be monitored.
+* `promptBuilder.ts` – constructs the large prompts for new games and turns using utilities from `utils/promptFormatters`.
+* `responseParser.ts` – validates the JSON returned by the model and converts it into game state structures.
+* `systemPrompt.ts` – holds the base instruction string given to the model.
+* `index.ts` – re-exports the modules above for convenient importing.
+
+When modifying this service keep the prompt format and returned interfaces aligned with code in `useGameLogic` and the AI prompts.


### PR DESCRIPTION
## Summary
- outline new dispatchAIRequest interface in ARCHITECTURE.md
- document usage of storyteller, cartographer, dialogue and corrections services

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684abc0883d08324b9c490873508666b