### PR TITLE
Improve map view performance

### DIFF
--- a/hooks/useMapInteractions.ts
+++ b/hooks/useMapInteractions.ts
@@ -3,7 +3,7 @@
  * @description Hook providing pan and zoom handlers for the map display.
  */
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { VIEWBOX_WIDTH_INITIAL, VIEWBOX_HEIGHT_INITIAL } from '../utils/mapConstants';
 import { getSVGCoordinates } from '../utils/svgUtils';
 
@@ -26,57 +26,84 @@ export const useMapInteractions = (
   onViewBoxChange?: (viewBox: string) => void
 ): UseMapInteractionsResult => {
   const [viewBox, setViewBox] = useState(initialViewBox);
+  const viewBoxRef = useRef(initialViewBox);
+  const rafId = useRef<number | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
   const updateViewBox = (box: string) => {
     setViewBox(box);
     if (onViewBoxChange) onViewBoxChange(box);
   };
-  const svgRef = useRef<SVGSVGElement | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [lastScreenDragPoint, setLastScreenDragPoint] = useState<{ x: number; y: number } | null>(null);
-  const [lastPinchDistance, setLastPinchDistance] = useState<number | null>(null);
+
+  const flushViewBoxAttr = useCallback(() => {
+    if (svgRef.current) svgRef.current.setAttribute('viewBox', viewBoxRef.current);
+    rafId.current = null;
+  }, []);
+
+  const setViewBoxAttr = useCallback(
+    (box: string) => {
+      viewBoxRef.current = box;
+      if (rafId.current === null) {
+        rafId.current = requestAnimationFrame(flushViewBoxAttr);
+      }
+    },
+    [flushViewBoxAttr]
+  );
+
+  const isDragging = useRef(false);
+  const lastScreenDragPoint = useRef<{ x: number; y: number } | null>(null);
+  const lastPinchDistance = useRef<number | null>(null);
 
   useEffect(() => {
     setViewBox(prev => (prev === initialViewBox ? prev : initialViewBox));
-  }, [initialViewBox]);
+    setViewBoxAttr(initialViewBox);
+  }, [initialViewBox, setViewBoxAttr]);
+
+  useEffect(() => {
+    return () => {
+      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+    };
+  }, []);
 
   /** Starts drag panning. */
   const handleMouseDown = (e: React.MouseEvent<SVGSVGElement>) => {
     if ((e.target as SVGElement).closest('.map-node')) return;
-    setIsDragging(true);
-    setLastScreenDragPoint({ x: e.clientX, y: e.clientY });
+    isDragging.current = true;
+    lastScreenDragPoint.current = { x: e.clientX, y: e.clientY };
     if (svgRef.current) svgRef.current.style.cursor = 'grabbing';
   };
 
   /** Pans the map on mouse move. */
   const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
-    if (!isDragging || !lastScreenDragPoint || !svgRef.current) return;
+    if (!isDragging.current || !lastScreenDragPoint.current || !svgRef.current) return;
 
     const svgEl = svgRef.current;
     const prevSVGPoint = getSVGCoordinates(
       svgEl,
-      lastScreenDragPoint.x,
-      lastScreenDragPoint.y
+      lastScreenDragPoint.current.x,
+      lastScreenDragPoint.current.y
     );
     const currentSVGPoint = getSVGCoordinates(svgEl, e.clientX, e.clientY);
 
     const deltaViewBoxX = prevSVGPoint.x - currentSVGPoint.x;
     const deltaViewBoxY = prevSVGPoint.y - currentSVGPoint.y;
 
-    const [vx, vy, vw, vh] = viewBox.split(' ').map(parseFloat);
-    updateViewBox(`${vx + deltaViewBoxX} ${vy + deltaViewBoxY} ${vw} ${vh}`);
-    setLastScreenDragPoint({ x: e.clientX, y: e.clientY });
+    const [vx, vy, vw, vh] = viewBoxRef.current.split(' ').map(parseFloat);
+    setViewBoxAttr(`${vx + deltaViewBoxX} ${vy + deltaViewBoxY} ${vw} ${vh}`);
+    lastScreenDragPoint.current = { x: e.clientX, y: e.clientY };
   };
 
   /** Stops drag panning. */
   const handleMouseUp = () => {
-    setIsDragging(false);
-    setLastScreenDragPoint(null);
+    isDragging.current = false;
+    lastScreenDragPoint.current = null;
     if (svgRef.current) svgRef.current.style.cursor = 'grab';
+    updateViewBox(viewBoxRef.current);
   };
 
   /** Ends drag if the mouse leaves the SVG. */
   const handleMouseLeave = () => {
-    if (isDragging) handleMouseUp();
+    if (isDragging.current) handleMouseUp();
   };
 
   /**
@@ -88,7 +115,7 @@ export const useMapInteractions = (
     if (e.cancelable) e.preventDefault();
     if (!svgRef.current) return;
 
-    const [vx, vy, vw, vh] = viewBox.split(' ').map(parseFloat);
+    const [vx, vy, vw, vh] = viewBoxRef.current.split(' ').map(parseFloat);
     const zoomFactor = 1.1;
     const newVw = e.deltaY < 0 ? vw / zoomFactor : vw * zoomFactor;
     const newVh = e.deltaY < 0 ? vh / zoomFactor : vh * zoomFactor;
@@ -104,7 +131,8 @@ export const useMapInteractions = (
     const newVx = svgPoint.x - (svgPoint.x - vx) * (newVw / vw);
     const newVy = svgPoint.y - (svgPoint.y - vy) * (newVh / vh);
 
-    updateViewBox(`${newVx} ${newVy} ${newVw} ${newVh}`);
+    setViewBoxAttr(`${newVx} ${newVy} ${newVw} ${newVh}`);
+    updateViewBox(viewBoxRef.current);
   };
 
   /** Returns the distance between two touch points. */
@@ -119,14 +147,14 @@ export const useMapInteractions = (
 
     if (e.touches.length === 1) {
       if ((e.target as SVGElement).closest('.map-node')) return;
-      setIsDragging(true);
-      setLastScreenDragPoint({ x: e.touches[0].clientX, y: e.touches[0].clientY });
-      setLastPinchDistance(null);
+      isDragging.current = true;
+      lastScreenDragPoint.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      lastPinchDistance.current = null;
       svgRef.current.style.cursor = 'grabbing';
     } else if (e.touches.length === 2) {
-      setIsDragging(false);
-      setLastPinchDistance(getTouchDistance(e.touches[0], e.touches[1]));
-      setLastScreenDragPoint(null);
+      isDragging.current = false;
+      lastPinchDistance.current = getTouchDistance(e.touches[0], e.touches[1]);
+      lastScreenDragPoint.current = null;
     }
   };
 
@@ -135,13 +163,13 @@ export const useMapInteractions = (
     if (!svgRef.current) return;
     if (e.cancelable) e.preventDefault();
 
-    if (e.touches.length === 1 && isDragging && lastScreenDragPoint) {
+    if (e.touches.length === 1 && isDragging.current && lastScreenDragPoint.current) {
       const touch = e.touches[0];
       const svgEl = svgRef.current;
       const prevSVGPoint = getSVGCoordinates(
         svgEl,
-        lastScreenDragPoint.x,
-        lastScreenDragPoint.y
+        lastScreenDragPoint.current.x,
+        lastScreenDragPoint.current.y
       );
       const currentSVGPoint = getSVGCoordinates(
         svgEl,
@@ -152,15 +180,15 @@ export const useMapInteractions = (
       const deltaViewBoxX = prevSVGPoint.x - currentSVGPoint.x;
       const deltaViewBoxY = prevSVGPoint.y - currentSVGPoint.y;
 
-      const [vx, vy, vw, vh] = viewBox.split(' ').map(parseFloat);
-      updateViewBox(`${vx + deltaViewBoxX} ${vy + deltaViewBoxY} ${vw} ${vh}`);
-      setLastScreenDragPoint({ x: touch.clientX, y: touch.clientY });
-    } else if (e.touches.length === 2 && lastPinchDistance !== null) {
+      const [vx, vy, vw, vh] = viewBoxRef.current.split(' ').map(parseFloat);
+      setViewBoxAttr(`${vx + deltaViewBoxX} ${vy + deltaViewBoxY} ${vw} ${vh}`);
+      lastScreenDragPoint.current = { x: touch.clientX, y: touch.clientY };
+    } else if (e.touches.length === 2 && lastPinchDistance.current !== null) {
       const currentDistance = getTouchDistance(e.touches[0], e.touches[1]);
-      if (currentDistance === 0 || lastPinchDistance === 0) return;
+      if (currentDistance === 0 || lastPinchDistance.current === 0) return;
 
-      const scaleFactor = currentDistance / lastPinchDistance;
-      const [vx, vy, vw, vh] = viewBox.split(' ').map(parseFloat);
+      const scaleFactor = currentDistance / lastPinchDistance.current;
+      const [vx, vy, vw, vh] = viewBoxRef.current.split(' ').map(parseFloat);
 
       let newVw = vw / scaleFactor;
       let newVh = vh / scaleFactor;
@@ -196,18 +224,19 @@ export const useMapInteractions = (
       const newVx = svgPinchCenter.x - (svgPinchCenter.x - vx) * (newVw / vw);
       const newVy = svgPinchCenter.y - (svgPinchCenter.y - vy) * (newVh / vh);
 
-      updateViewBox(`${newVx} ${newVy} ${newVw} ${newVh}`);
-      setLastPinchDistance(currentDistance);
+      setViewBoxAttr(`${newVx} ${newVy} ${newVw} ${newVh}`);
+      lastPinchDistance.current = currentDistance;
     }
   };
 
   /** Resets state on touch end. */
   const handleTouchEnd = (e: React.TouchEvent<SVGSVGElement>) => {
     if (svgRef.current) svgRef.current.style.cursor = 'grab';
-    if (e.touches.length < 2) setLastPinchDistance(null);
+    if (e.touches.length < 2) lastPinchDistance.current = null;
     if (e.touches.length < 1) {
-      setIsDragging(false);
-      setLastScreenDragPoint(null);
+      isDragging.current = false;
+      lastScreenDragPoint.current = null;
+      updateViewBox(viewBoxRef.current);
     }
   };
 


### PR DESCRIPTION
## Summary
- avoid re-rendering every drag tick by directly updating SVG `viewBox`
- commit the updated viewBox only when interaction ends
- throttle DOM updates with `requestAnimationFrame`
- store drag and pinch state in refs to avoid state churn

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ad4a56dcc83249021c22e25ff01c4