### PR TITLE
Add inventory service

### DIFF
--- a/services/inventory/AGENTS.md
+++ b/services/inventory/AGENTS.md
@@ -1,0 +1,9 @@
+The **inventory** service coordinates small item management requests to the AI. It mirrors the pattern of other services by exposing helper modules for prompt construction, response parsing and the base system instruction.
+
+* `api.ts` – wraps `dispatchAIRequest`, first trying `MINIMAL_MODEL_NAME` and falling back to a full model if needed.
+* `promptBuilder.ts` – composes prompts using provided `playerItemsHint`, `worldItemsHint`, `npcItemsHint` and pre-generated suggested item IDs.
+* `responseParser.ts` – validates and parses the AI's JSON output into `ItemChange[]`.
+* `systemPrompt.ts` – the instruction string describing the item change format.
+* `index.ts` – re-exports these helpers for convenient importing.
+
+Maintain compatibility between the prompt builder and parser when adjusting this service.

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -1,0 +1,31 @@
+/**
+ * @file api.ts
+ * @description Wrapper functions for inventory-related AI interactions.
+ */
+
+import { GenerateContentResponse } from '@google/genai';
+import { MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME } from '../../constants';
+import { SYSTEM_INSTRUCTION } from './systemPrompt';
+import { dispatchAIRequest } from '../modelDispatcher';
+import { isApiConfigured } from '../apiClient';
+
+/**
+ * Executes the inventory AI call using model fallback.
+ */
+export const executeInventoryRequest = async (
+  prompt: string,
+): Promise<GenerateContentResponse> => {
+  if (!isApiConfigured()) {
+    console.error('API Key not configured for Inventory Service.');
+    return Promise.reject(new Error('API Key not configured.'));
+  }
+  const { response } = await dispatchAIRequest({
+    modelNames: [MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME],
+    prompt,
+    systemInstruction: SYSTEM_INSTRUCTION,
+    responseMimeType: 'application/json',
+    temperature: 0.7,
+    label: 'Inventory',
+  });
+  return response;
+};

--- a/services/inventory/index.ts
+++ b/services/inventory/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @file services/inventory/index.ts
+ * @description Re-exports inventory service utilities.
+ */
+
+export * from './api';
+export * from './promptBuilder';
+export * from './responseParser';
+export * from './systemPrompt';

--- a/services/inventory/promptBuilder.ts
+++ b/services/inventory/promptBuilder.ts
@@ -1,0 +1,14 @@
+/**
+ * @file promptBuilder.ts
+ * @description Helper for constructing prompts for the inventory service.
+ */
+
+/**
+ * Builds the prompt for requesting inventory changes.
+ */
+export const buildInventoryPrompt = (
+  playerItemsHint: string,
+  worldItemsHint: string,
+  npcItemsHint: string,
+  suggestedItemIds: string[],
+): string => `Player Items Hint:\n${playerItemsHint}\n\nWorld Items Hint:\n${worldItemsHint}\n\nNPC Items Hint:\n${npcItemsHint}\n\nSuggested Item IDs: ${suggestedItemIds.join(', ')}\n\nProvide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;

--- a/services/inventory/responseParser.ts
+++ b/services/inventory/responseParser.ts
@@ -1,0 +1,52 @@
+/**
+ * @file responseParser.ts
+ * @description Parses inventory AI responses.
+ */
+
+import { ItemChange, GiveItemPayload } from '../../types';
+import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
+import { isValidItem, isValidItemReference } from '../parsers/validation';
+
+/**
+ * Parses the AI response text into an array of ItemChange objects.
+ */
+export const parseInventoryResponse = (responseText: string): ItemChange[] | null => {
+  const jsonStr = extractJsonFromFence(responseText);
+  const parsed = safeParseJson<unknown>(jsonStr);
+  if (!Array.isArray(parsed)) {
+    console.warn('Inventory response was not an array:', parsed);
+    return null;
+  }
+  const valid: ItemChange[] = [];
+  for (const raw of parsed) {
+    if (!raw || typeof raw !== 'object') continue;
+    const change = raw as ItemChange;
+    if (typeof change.action !== 'string') continue;
+    const action = change.action;
+    let ok = false;
+    switch (action) {
+      case 'gain':
+      case 'put':
+        ok = isValidItem(change.item, 'gain');
+        break;
+      case 'update':
+        ok = isValidItem(change.item, 'update');
+        break;
+      case 'lose':
+        ok = isValidItemReference(change.item);
+        break;
+      case 'give':
+      case 'take':
+        ok = !!(
+          change.item &&
+          typeof change.item === 'object' &&
+          typeof (change.item as GiveItemPayload).id === 'string' &&
+          typeof (change.item as GiveItemPayload).fromId === 'string' &&
+          typeof (change.item as GiveItemPayload).toId === 'string'
+        );
+        break;
+    }
+    if (ok) valid.push(change);
+  }
+  return valid;
+};

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -1,0 +1,12 @@
+/**
+ * @file systemPrompt.ts
+ * @description System instruction for the inventory AI helper.
+ */
+
+import { ITEMS_GUIDE } from '../../prompts/helperPrompts';
+
+export const SYSTEM_INSTRUCTION = `
+You assist a text adventure engine with concise inventory updates.
+Respond ONLY with a JSON array of ItemChange objects describing the modifications.
+${ITEMS_GUIDE}
+`;


### PR DESCRIPTION
## Summary
- add `inventory` service skeleton
- provide prompt builder using player, world and NPC hints
- wrap model dispatch for inventory helpers
- parse inventory JSON responses
- document service responsibilities

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aff5258a08324ba30b8cfa3149ae4