### PR TITLE
Add item hint fields and validation

### DIFF
--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -6,6 +6,7 @@ import {
   Item,
   ItemReference,
   KnownUse,
+  NewItemSuggestion,
   ValidCharacterUpdatePayload,
   ValidNewCharacterPayload,
   DialogueSetupPayload,
@@ -113,6 +114,16 @@ export function isValidItemReference(obj: unknown): obj is ItemReference {
   return (
     typeof maybe.id === 'string' && maybe.id.trim() !== '' &&
     typeof maybe.name === 'string' && maybe.name.trim() !== ''
+  );
+}
+
+export function isValidNewItemSuggestion(obj: unknown): obj is NewItemSuggestion {
+  if (!obj || typeof obj !== 'object') return false;
+  const maybe = obj as Partial<NewItemSuggestion>;
+  return (
+    typeof maybe.name === 'string' && maybe.name.trim() !== '' &&
+    typeof maybe.description === 'string' && maybe.description.trim() !== '' &&
+    typeof maybe.type === 'string' && VALID_ITEM_TYPES.includes(maybe.type)
   );
 }
 

--- a/services/storyteller/responseParser.ts
+++ b/services/storyteller/responseParser.ts
@@ -11,7 +11,8 @@ import {
     isValidItemReference,
     isValidCharacterUpdate,
     isValidNewCharacterPayload,
-    isDialogueSetupPayloadStructurallyValid
+    isDialogueSetupPayloadStructurallyValid,
+    isValidNewItemSuggestion
 } from '../parsers/validation';
 import {
     fetchCorrectedItemAction_Service,
@@ -78,7 +79,11 @@ function validateBasicStructure(
         (data.dialogueSetup === undefined || typeof data.dialogueSetup === 'object') &&
         (data.mapUpdated === undefined || typeof data.mapUpdated === 'boolean') &&
         (data.currentMapNodeId === undefined || data.currentMapNodeId === null || typeof data.currentMapNodeId === 'string') &&
-        (data.mapHint === undefined || typeof data.mapHint === 'string');
+        (data.mapHint === undefined || typeof data.mapHint === 'string') &&
+        (data.playerItemsHint === undefined || typeof data.playerItemsHint === 'string') &&
+        (data.worldItemsHint === undefined || typeof data.worldItemsHint === 'string') &&
+        (data.npcItemsHint === undefined || typeof data.npcItemsHint === 'string') &&
+        (data.newItems === undefined || Array.isArray(data.newItems));
 
     if (!baseFieldsValid) {
         console.warn('parseAIResponse: Basic field validation failed (pre-dialogue specifics and array checks).', parsedData);
@@ -654,6 +659,10 @@ export async function parseAIResponse(
         validated.localPlace = validated.localPlace?.trim() || 'Undetermined Location';
         if (validated.mapHint !== undefined) {
             validated.mapHint = validated.mapHint.trim();
+        }
+
+        if (Array.isArray(validated.newItems)) {
+            validated.newItems = validated.newItems.filter(isValidNewItemSuggestion);
         }
 
         delete (validated as Record<string, unknown>).placesAdded;

--- a/types.ts
+++ b/types.ts
@@ -64,6 +64,12 @@ export interface GiveItemPayload {
   toName?: string;
 }
 
+export interface NewItemSuggestion {
+  name: string;
+  type: ItemType;
+  description: string;
+}
+
 export interface ItemChange {
   // For "gain" or "update", 'item' is an Item object.
   // For "lose", 'item' provides at least an id and name (if available).
@@ -200,6 +206,10 @@ export interface DialogueSummaryResponse {
   mapUpdated?: boolean; // This flag signals the map service to run
   currentMapNodeId?: string | undefined; // Suggestion for current location node ID
   mapHint?: string; // Optional hint about distant quest-related locations for MapAI
+  playerItemsHint?: string;
+  worldItemsHint?: string;
+  npcItemsHint?: string;
+  newItems?: NewItemSuggestion[];
 }
 // --- End Dialogue Mode Types ---
 
@@ -237,6 +247,10 @@ export interface GameStateFromAI {
   mapUpdated?: boolean; // This flag signals the map service to run
   currentMapNodeId?: string | undefined; // Suggestion for current location node ID
   mapHint?: string; // Optional hint about distant quest-related locations for MapAI
+  playerItemsHint?: string;
+  worldItemsHint?: string;
+  npcItemsHint?: string;
+  newItems?: NewItemSuggestion[];
   // placesAdded and placesUpdated are removed from storyteller responsibility
 }
 


### PR DESCRIPTION
## Summary
- define `NewItemSuggestion` type
- extend `DialogueSummaryResponse` and `GameStateFromAI` with optional item hint fields
- validate new fields when parsing storyteller responses
- filter suggested items using a new validator

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b00ef4b188324ae0b9922f782d20f