### PR TITLE
Refactor item guide for inventory hints

### DIFF
--- a/prompts/helperPrompts.ts
+++ b/prompts/helperPrompts.ts
@@ -6,126 +6,104 @@
 
 import { VALID_ITEM_TYPES_STRING } from '../constants'; // Import needed constant
 
-export const ITEMS_GUIDE = `- "itemChange" is ALWAYS an array. If no items change this turn, send an empty array: "itemChange": [].
-Valid actions are 'gain', 'lose', 'update', 'put', 'give', and 'take'.
-CRITICALLY IMPORTANT: Use 'put' or 'gain' only when revealing or creating a **NEW** item at a specific location, specific NPC inventory, or in Player's inventory.
-CRITICALLY IMPORTANT: Use 'give' or 'take' when transferring an **EXISTING** item from one holder to another, or dropping/picking up the item at the current location.
-CRITICALLY IMPORTANT: Use 'lose' ONLY when the item is **IRREVERSIBLY** consumed, destroyed, or otherwise removed from play.
-Structure for individual ItemChange objects within the array:
-- Example for gaining a new item:
-  { "action": "gain",
-    item: {
-      "name": "Old Lantern", /* REQUIRED: Full name of the item. */
-      "type": "equipment", /* REQUIRED. MUST be one of ${VALID_ITEM_TYPES_STRING} */
-      "description": "A dusty old lantern that still flickers faintly.", /* REQUIRED: Short description of the item. */
-      "activeDescription"?: "The lantern is lit and casts a warm glow.", /* Optional: Description when the item is active. REQUIRED for toggle-able items.*/
-      "isActive"?: false, /* Optional: true if the item is currently active (e.g., a lit lantern, powered equipment). Defaults to false if not provided. */
-      "isJunk"?: false, /* Optional: true if the item is largely unimportant or has served its ONLY purpose (e.g., a used quest item, common debris). Defaults to false if not provided. IMPORTANT: "status effects" can never be marked as junk. */
-      "knownUses"?: /* Optional: Array of KnownUse objects describing how the item can be used. If not provided, the item has no known uses yet.
-        [
-          { 
-            "actionName": "Light the Lantern", /* REQUIRED: User-facing text for the action button. */
-            "promptEffect": "Light the lantern to illuminate the area.", /* REQUIRED: Non-empty text sent to the game AI when this action is chosen, e.g., "Player lights the lantern, illuminating the area." */
-            "description": "Use this to light your way in dark places.", /* REQUIRED: A small hint or detail for the player, shown as a tooltip, e.g., "Use this to light your way in dark places." */
-            "appliesWhenActive"?: true, /* Optional: If true, this use is shown when item.isActive is true. Defaults to false if not provided. */
-            "appliesWhenInactive"?: false /* Optional: If true, this use is shown when item.isActive is false or undefined. Defaults to false if not provided. */
-          }
-        ]
-    }
+export const ITEMS_GUIDE = `Generate inventory hints using these fields:
+- "playerItemsHint": short summary of gains, losses or state changes for the Player.
+- "worldItemsHint": short summary of items dropped or discovered in the environment.
+- "npcItemsHint": short summary of items held or used by NPCs.
+- "newItems": array of brand new items introduced this turn, or [] if none.
+
+Each object in "newItems" should include:
+  {
+    "name": "Item Name",
+    "type": "one of ${VALID_ITEM_TYPES_STRING}",
+    "description": "Short description",
+    "activeDescription"?: "When active",
+    "isActive"?: false,
+    "isJunk"?: false,
+    "knownUses"?: [
+      {
+        "actionName": "Action text",
+        "promptEffect": "Prompt sent to the AI",
+        "description": "Player hint",
+        "appliesWhenActive"?: false,
+        "appliesWhenInactive"?: false
+      }
+    ]
   }
+
+Examples illustrating the hint style:
+- Example for gaining a new item:
+  playerItemsHint: "Picked up Old Lantern."
+  newItems: [{
+    "name": "Old Lantern",
+    "type": "equipment",
+    "description": "A dusty old lantern that still flickers faintly.",
+    "activeDescription": "The lantern is lit and casts a warm glow.",
+    "isActive": false,
+    "isJunk": false,
+    "knownUses": [
+      {
+        "actionName": "Light the Lantern",
+        "promptEffect": "Light the lantern to illuminate the area.",
+        "description": "Use this to light your way in dark places.",
+        "appliesWhenActive": true,
+        "appliesWhenInactive": false
+      }
+    ]
+  }]
 
 - Example for putting a new item into another inventory or location:
-  { "action": "put",
-    item: {
-      "name": "Rusty Key",
-      "type": "key",
-      "description": "Opens an old door.",
-      "holderId": "char_guard_4f3a" /* ID of the character or map node to hold the item */
-    }
-  }
+  npcItemsHint: "Guard now carries Rusty Key."
+  newItems: [{
+    "name": "Rusty Key",
+    "type": "key",
+    "description": "Opens an old door.",
+    "holderId": "char_guard_4f3a"
+  }]
 
-- Example for losing, destroying, completely removing the item from the world:
-  { "action": "lose",
-    item:{
-      "id": "item_old_lantern_flickering_7fr4", /* REQUIRED: Unique identifier for the item being lost. Choose from the provided Player inventory. */
-      "name": "Old Lantern (flickering)" /* REQUIRED: Full name of the item being lost, including any notes in brackets. Choose from the provided Player inventory. */
-    }
-  }
+- Example for losing, destroying, completely removing the item:
+  playerItemsHint: "Lost Old Lantern (flickering)."
 
-- Example for giving an existing item from one holder to another, or for placing it in the current location:
-  { "action": "give",
-    item: {
-      "id": "item_iron_sword_ab12",
-      "name": "Iron Sword",
-      "fromId": "player",
-      "toId": "char_guard_4f3a"
-    }
-  }
+- Example for giving an existing item from one holder to another:
+  npcItemsHint: "Gave Iron Sword to Guard."
 
-- "take" is an alias for "give". It has the same structure and is used when the player takes an existing item from somewhere or someone. Example:
-  { "action": "take",
-    item: {
-      "id": "item_coin_pouch_8f2c",
-      "name": "Coin Pouch",
-      "fromId": "npc_bandit_8f2c",
-      "toId": "player"
-    }
-  }
+- "take" is an alias for "give". Example:
+  playerItemsHint: "Took Coin Pouch from Bandit."
 
-- Example for simple update (only changing "isActive", other properties like type/description are inherited from the existing "Old Torch"): 
-  { "action": "update",
-      item: {
-        "id": "item_plasma_torch_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
-        "name": "Plasma Torch", /* REQUIRED: Full name of the item to update.  Choose from the provided context. */  
-        "isActive": true /* REQUIRED: true if the item is now active (e.g., a lit torch), false if it is inactive (e.g., an unlit torch). Defaults to false if not provided. */
+- Example for simple update (only changing "isActive"):
+  playerItemsHint: "Plasma Torch is now active."
+
+- Example for transformation or crafting:
+  playerItemsHint: "Scrap Metal transformed into Makeshift Shiv."
+  newItems: [{
+    "name": "Makeshift Shiv",
+    "type": "weapon",
+    "description": "A sharp piece of metal.",
+    "isJunk": false,
+    "knownUses": [
+      {
+        "actionName": "Cut",
+        "promptEffect": "Cut something.",
+        "description": "Use this to cut things.",
+        "appliesWhenActive": false,
+        "appliesWhenInactive": false
       }
-  }
+    ]
+  }]
 
-- Example for transformation or crafting (providing all details for the new item): 
-  { "action": "update",
-    "item": {
-      "id": "item_scrap_metal_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
-      "name": "Scrap Metal", /* REQUIRED: Full name of the item to update. Choose from the provided context. */
-      "newName": "Makeshift Shiv", /* REQUIRED: New name for the transformed item, e.g., "Makeshift Shiv" */
-      "type": "weapon", /* REQUIRED: New type for the transformed item, e.g., "weapon". MUST be one of ${VALID_ITEM_TYPES_STRING} */
-      "description": "A sharp piece of metal.", /* REQUIRED: New description for the transformed item, e.g., "A sharp piece of metal." */
-      "isJunk"?: false /* Optional: Set to true if the item becomes junk, false if it becomes important again. Defaults to false if not provided. IMPORTANT: "status effects" can never be marked as junk. */
-      "knownUses"?: [
-        { 
-          "actionName": "Cut", /* REQUIRED: User-facing text for the action button. */
-          "promptEffect": "Cut something.", /* REQUIRED: Non-empty text sent to the game AI when this action is chosen, e.g., "Player lights the lantern, illuminating the area." */
-          "description": "Use this to cut things.", /* REQUIRED: A small hint or detail for the player, shown as a tooltip, e.g., "Use this to light your way in dark places." */
-          "appliesWhenActive"?: false, /* Optional: If true, this use is shown when item.isActive is true. Defaults to false if not provided. */
-          "appliesWhenInactive"?: false /* Optional: If true, this use is shown when item.isActive is false or undefined. Defaults to false if not provided. */
-        }
-      ]
-    }
-  }
-
-- Example for adding a known use (type/description etc. inherited): 
-  { "action": "update",
-    "item": {
-      "id": "item_mystic_orb_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
-      "name": "Mystic Orb", /* REQUIRED: Full name of the item to update. Choose from the provided context. */
-      "addKnownUse": { /* REQUIRED: New known use to add to the item. */
-        "actionName": "Peer into the Orb", /* REQUIRED: User-facing text for the action button. */
-        "promptEffect": "Peer into the Mystic Orb, trying to glimpse the future.", /* REQUIRED: Non-empty text sent to the game AI when this action is chosen. */
-        "description": "Try to see the beyond", /* REQUIRED: A small hint or detail for the player, shown as a tooltip. */
-        "AppliesWhenActive": true /* Optional: If true, this use is shown when item.isActive is true. Defaults to false if not provided. */
-      }
-    }
-  }
+- Example for adding a known use (type/description etc. inherited):
+  playerItemsHint: "Mystic Orb can now 'Peer into the Orb'."
 
   - ALWAYS appropriately handle spending single-use items and state toggles ("isActive": true/false).
   - Using some "single-use" items (food, water, medicine, etc) MUST add or remove appropriate "status effects".
-  - Use "update" to change the remaining number of uses for multi-use items in their name (in brackets) or in description.
+  - Mention remaining uses for multi-use items when they change.
 IMPORTANT: For items that CLEARLY can be enabled or disabled (e.g., light sources, powered equipment, wielded or worn items) provide at least the two knownUses to enable and disable them with appropriate names:
   - The knownUse to turn on, light, or otherwise enable the item should ALWAYS have "appliesWhenInactive": true (and typically "appliesWhenActive": false or undefined).
   - The knownUse to turn off, extinguish, or disable the item should ALWAYS have "appliesWhenActive": true (and typically "appliesWhenInactive": false or undefined).
 IMPORTANT: NEVER add "Inspect", "Use", "Drop", "Discard", "Enter", "Park" known uses - there are dedicated buttons for those in the game.
 
-If Player's Action is "Inspect: [item_name]": Provide details about the item in "logMessage". If new info/use is found, use "itemChange" "update" (e.g., with "addKnownUse").
-If Player's Action is "Attempt to use: [item_name]": Treat it as the most logical action. Describe the outcome in "logMessage". If specific function is revealed, consider "itemChange" "update" for "addKnownUse" in addition to main outcome.
+If Player's Action is "Inspect: [item_name]": Provide details about the item in "logMessage". If new info/use is found, mention it in "playerItemsHint".
+If Player's Action is "Attempt to use: [item_name]": Treat it as the most logical action. Describe the outcome in "logMessage". If specific function is revealed, mention it in "playerItemsHint".
 
 
 Valid item "type" values are: ${VALID_ITEM_TYPES_STRING}.
@@ -136,11 +114,11 @@ Valid item "type" values are: ${VALID_ITEM_TYPES_STRING}.
 - "key": Unlocks specific doors, chests, portals, or similar. Description should hint at its purpose, e.g., "Ornate Silver Key (for a large chest)". Can be 'lost' or 'updated' (e.g., to "Bent Key") after use.
 - "weapon": Melee and ranged weapons, distinct from "equipment" Items that can be explicitly used in a fight when wielded. Ranged weapon consume ammunition or charges.
 - "ammunition": For reloading specific ranged weapons, e.g., Arrows for Longbow, Rounds for firearms, Charges for energy weapons. Using weapon consumes ammo (handled by log/update).
-- "vehicle": Player's current transport (if isActive: true) or one they can enter if adjacent to it. Integral parts (mounted guns, cargo bays) are 'knownUses', NOT separate items unless detached. If player enters a vehicle, its 'isActive' state MUST be set to true using an 'itemChange' action 'update'. If player exits a vehicle, its 'isActive' state MUST be set to false using an 'itemChange' action 'update'.
+  - "vehicle": Player's current transport (if isActive: true) or one they can enter if adjacent to it. Integral parts (mounted guns, cargo bays) are 'knownUses', NOT separate items unless detached. If player enters a vehicle, note in "playerItemsHint" that it becomes active. If they exit, note that it becomes inactive. Include the vehicle in "newItems" only when first introduced.
 - "knowledge": Immaterial. Represents learned info, skills, spells, passwords. 'knownUses' define how to apply it. Can be 'lost' if used up or no longer relevant. E.g., "Spell: Fireball", "Recipe: Health Potion", "Clue: Thief Name".
 - "status effect": Temporary condition, positive or negative, generally gained and lost by eating, drinking, environmental exposure, impacts, and wounds. 'isActive: true' while affecting player. 'description' explains its effect, e.g., "Poisoned (move slower)", "Blessed (higher luck)", "Wounded (needs healing)". 'lost' when it expires.
 
-IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName", and the new "type" and "description" for the thematically appropriate item. Your "logMessage" must creatively explain this transformation. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand". The log message could be: "The strange metal device from another world shimmers and reshapes into a humming metal wand in your grasp!"
+IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Mention the transformation in "playerItemsHint" and include the resulting item in "newItems" with its new "name", "type" and "description". Your "logMessage" must creatively explain this transformation. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand". The log message could be: "The strange metal device from another world shimmers and reshapes into a humming metal wand in your grasp!"
 `;
 
 export const MAP_NODE_TYPE_GUIDE = `Map Node Types:


### PR DESCRIPTION
## Summary
- update `ITEMS_GUIDE` to describe `playerItemsHint`, `worldItemsHint`, `npcItemsHint` and `newItems`
- include hint-based examples and adjust vehicle and anachronism notes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b04687d7883248a931ca063965f67