### PR TITLE
Add InventoryAI integration

### DIFF
--- a/services/inventory/promptBuilder.ts
+++ b/services/inventory/promptBuilder.ts
@@ -6,9 +6,22 @@
 /**
  * Builds the prompt for requesting inventory changes.
  */
+import { Item } from '../../types';
+
 export const buildInventoryPrompt = (
   playerItemsHint: string,
   worldItemsHint: string,
   npcItemsHint: string,
-  suggestedItemIds: string[],
-): string => `Player Items Hint:\n${playerItemsHint}\n\nWorld Items Hint:\n${worldItemsHint}\n\nNPC Items Hint:\n${npcItemsHint}\n\nSuggested Item IDs: ${suggestedItemIds.join(', ')}\n\nProvide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;
+  suggestedItems: Item[],
+): string => {
+  const itemsList =
+    suggestedItems.length > 0
+      ? suggestedItems
+          .map(
+            (it) =>
+              `- ${it.id} | "${it.name}" | ${it.type} | ${it.description}`,
+          )
+          .join('\n')
+      : 'None.';
+  return `Player Items Hint:\n${playerItemsHint}\n\nWorld Items Hint:\n${worldItemsHint}\n\nNPC Items Hint:\n${npcItemsHint}\n\nSuggested Items:\n${itemsList}\n\nProvide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;
+};


### PR DESCRIPTION
## Summary
- include new `applyInventoryHints_Service` to process item hints
- support passing full item suggestions to InventoryAI prompt
- invoke InventoryAI after map updates in `usePlayerActions`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b09ebc4a08324a4005c6583ecb5aa