### PR TITLE
Add Inventory AI tab to Debug View

### DIFF
--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -21,6 +21,7 @@ type DebugTab =
   | "GameState"
   | "MainAI"
   | "MapLocationAI"
+  | "InventoryAI"
   | "Inventory"
   | "Characters"
   | "MapDataFull"
@@ -117,6 +118,7 @@ const DebugView: React.FC<DebugViewProps> = ({
     { name: "GameState", label: "Game State" },
     { name: "MainAI", label: "Main AI" },
     { name: "MapLocationAI", label: "Map & Location AI" },
+    { name: "InventoryAI", label: "Inventory AI" },
     { name: "Inventory", label: "Inventory" },
     { name: "Characters", label: "Characters" },
     { name: "MapDataFull", label: "Map Data (Full)" },
@@ -219,6 +221,23 @@ const DebugView: React.FC<DebugViewProps> = ({
               <p className="italic text-slate-400">No Map Update AI interaction debug packet captured for the last main AI turn.</p>
             )}
           </>
+        );
+      case "InventoryAI":
+        return debugPacket?.inventoryDebugInfo ? (
+          <>
+            {renderContent(
+              "Inventory AI Request Prompt",
+              debugPacket.inventoryDebugInfo.prompt,
+              false,
+            )}
+            {renderContent(
+              "Inventory AI Raw Response",
+              debugPacket.inventoryDebugInfo.rawResponse,
+              false,
+            )}
+          </>
+        ) : (
+          <p className="italic text-slate-400">No Inventory AI interaction debug packet captured.</p>
         );
       case "Inventory":
         return renderContent("Current Inventory", currentState?.inventory, true, "max-h-[70vh]");

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -251,7 +251,14 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
       } else {
         prompt = buildNewGameFirstTurnPrompt(themeObjToLoad, playerGenderProp);
       }
-      draftState.lastDebugPacket = { prompt, rawResponseText: null, parsedResponse: null, timestamp: new Date().toISOString() };
+      draftState.lastDebugPacket = {
+        prompt,
+        rawResponseText: null,
+        parsedResponse: null,
+        timestamp: new Date().toISOString(),
+        mapUpdateDebugInfo: null,
+        inventoryDebugInfo: null,
+      };
 
       try {
         const response = await executeAIMainTurn(prompt, themeObjToLoad.systemInstructionModifier);
@@ -442,6 +449,8 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
       rawResponseText: null,
       parsedResponse: null,
       timestamp: new Date().toISOString(),
+      mapUpdateDebugInfo: null,
+      inventoryDebugInfo: null,
     };
     draftState.lastDebugPacket = debugPacket;
 

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -149,6 +149,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         parsedResponse: aiData,
         timestamp: new Date().toISOString(),
         mapUpdateDebugInfo: null,
+        inventoryDebugInfo: null,
       };
 
       if (aiData.localTime !== undefined) {
@@ -288,6 +289,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         );
         if (invResult) {
           combinedItemChanges = combinedItemChanges.concat(invResult.itemChanges);
+          if (draftState.lastDebugPacket)
+            draftState.lastDebugPacket.inventoryDebugInfo = invResult.debugInfo;
         }
       }
 
@@ -389,6 +392,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         rawResponseText: null,
         parsedResponse: null,
         timestamp: new Date().toISOString(),
+        mapUpdateDebugInfo: null,
+        inventoryDebugInfo: null,
       };
       draftState.lastDebugPacket = debugPacket;
       if (isFreeForm) draftState.score -= FREE_FORM_ACTION_COST;

--- a/types.ts
+++ b/types.ts
@@ -420,6 +420,10 @@ export interface DebugPacket {
       validationError?: string;
     } | null;
   } | null;
+  inventoryDebugInfo?: {
+    prompt: string;
+    rawResponse?: string;
+  } | null;
 }
 
 


### PR DESCRIPTION
## Summary
- extend `DebugPacket` with `inventoryDebugInfo`
- record Inventory service debug info in `usePlayerActions`
- initialise new field in game state helpers
- show new Inventory AI tab in `DebugView`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b0df785088324921746e89d557d1b