### PR TITLE
Update inventory AI instructions

### DIFF
--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -8,10 +8,9 @@ import { MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME } from '../../constants';
 import { SYSTEM_INSTRUCTION } from './systemPrompt';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { isApiConfigured } from '../apiClient';
-import { ItemChange, Item, NewItemSuggestion } from '../../types';
+import { ItemChange, NewItemSuggestion } from '../../types';
 import { buildInventoryPrompt } from './promptBuilder';
 import { parseInventoryResponse } from './responseParser';
-import { buildItemId } from '../../utils/entityUtils';
 
 /**
  * Executes the inventory AI call using model fallback.
@@ -52,15 +51,7 @@ export const applyInventoryHints_Service = async (
     return { itemChanges: [], debugInfo: null };
   }
 
-  const suggestedItems: Item[] = newItems.map((ni) => ({
-    id: buildItemId(ni.name),
-    name: ni.name,
-    type: ni.type,
-    description: ni.description,
-    holderId: 'unknown',
-  }));
-
-  const prompt = buildInventoryPrompt(pHint, wHint, nHint, suggestedItems);
+  const prompt = buildInventoryPrompt(pHint, wHint, nHint, newItems);
   const response = await executeInventoryRequest(prompt);
   const parsed = parseInventoryResponse(response.text ?? '') || [];
   return { itemChanges: parsed, debugInfo: { prompt, rawResponse: response.text ?? '' } };

--- a/services/inventory/promptBuilder.ts
+++ b/services/inventory/promptBuilder.ts
@@ -6,22 +6,14 @@
 /**
  * Builds the prompt for requesting inventory changes.
  */
-import { Item } from '../../types';
+import { NewItemSuggestion } from '../../types';
 
 export const buildInventoryPrompt = (
   playerItemsHint: string,
   worldItemsHint: string,
   npcItemsHint: string,
-  suggestedItems: Item[],
+  newItems: NewItemSuggestion[],
 ): string => {
-  const itemsList =
-    suggestedItems.length > 0
-      ? suggestedItems
-          .map(
-            (it) =>
-              `- ${it.id} | "${it.name}" | ${it.type} | ${it.description}`,
-          )
-          .join('\n')
-      : 'None.';
-  return `Player Items Hint:\n${playerItemsHint}\n\nWorld Items Hint:\n${worldItemsHint}\n\nNPC Items Hint:\n${npcItemsHint}\n\nSuggested Items:\n${itemsList}\n\nProvide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;
+  const newItemsJson = newItems.length > 0 ? `\`\`\`json\n${JSON.stringify(newItems, null, 2)}\n\`\`\`` : '[]';
+  return `Player Items Hint:\n${playerItemsHint}\n\nWorld Items Hint:\n${worldItemsHint}\n\nNPC Items Hint:\n${npcItemsHint}\n\nnewItems from Storyteller or Dialogue:\n${newItemsJson}\n\nProvide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;
 };

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -3,10 +3,11 @@
  * @description System instruction for the inventory AI helper.
  */
 
-import { ITEMS_GUIDE } from '../../prompts/helperPrompts';
+import { VALID_ITEM_TYPES_STRING } from '../../constants';
 
 export const SYSTEM_INSTRUCTION = `
-You assist a text adventure engine with concise inventory updates.
-Respond ONLY with a JSON array of ItemChange objects describing the modifications.
-${ITEMS_GUIDE}
-`;
+You are an AI assistant that converts item hints into explicit inventory actions for a text adventure game.
+Analyze the hints and optional new items JSON provided in the prompt.
+Respond ONLY with a JSON array of ItemChange objects. Each object requires an "action" ("gain", "lose", "update", "put", "give", or "take") and an "item" payload.
+For "gain" and "update" actions, the item payload must contain fields like "name", "type" (${VALID_ITEM_TYPES_STRING}), and "description" describing the resulting item state.
+Do not include any explanations or formatting outside of the JSON array.`;


### PR DESCRIPTION
## Summary
- revise Inventory AI system prompt to build full `ItemChange` objects
- include raw `newItems` JSON in inventory prompt
- streamline Inventory API to pass raw suggestions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b1232674483248839adf5981e2147