### PR TITLE
Complete inventory prompt

### DIFF
--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -43,6 +43,11 @@ export const applyInventoryHints_Service = async (
   worldItemsHint: string | undefined,
   npcItemsHint: string | undefined,
   newItems: NewItemSuggestion[],
+  playerLastAction: string,
+  playerInventory: string,
+  locationInventory: string,
+  companionsInventory: string,
+  nearbyNpcsInventory: string,
 ): Promise<InventoryUpdateResult | null> => {
   const pHint = playerItemsHint?.trim() || '';
   const wHint = worldItemsHint?.trim() || '';
@@ -51,7 +56,17 @@ export const applyInventoryHints_Service = async (
     return { itemChanges: [], debugInfo: null };
   }
 
-  const prompt = buildInventoryPrompt(pHint, wHint, nHint, newItems);
+  const prompt = buildInventoryPrompt(
+    playerLastAction,
+    pHint,
+    wHint,
+    nHint,
+    newItems,
+    playerInventory,
+    locationInventory,
+    companionsInventory,
+    nearbyNpcsInventory,
+  );
   const response = await executeInventoryRequest(prompt);
   const parsed = parseInventoryResponse(response.text ?? '') || [];
   return { itemChanges: parsed, debugInfo: { prompt, rawResponse: response.text ?? '' } };

--- a/services/inventory/promptBuilder.ts
+++ b/services/inventory/promptBuilder.ts
@@ -9,23 +9,31 @@
 import { NewItemSuggestion } from '../../types';
 
 export const buildInventoryPrompt = (
+  playerLastAction: string,
   playerItemsHint: string,
   worldItemsHint: string,
   npcItemsHint: string,
   newItems: NewItemSuggestion[],
+  playerInventory: string,
+  locationInventory: string,
+  companionsInventory: string,
+  nearbyNpcsInventory: string,
 ): string => {
-  const newItemsJson = newItems.length > 0 ? `\`\`\`json\n${JSON.stringify(newItems, null, 2)}\n\`\`\`` : '[]';
+  const newItemsJson =
+    newItems.length > 0
+      ? `\`\`\`json\n${JSON.stringify(newItems, null, 2)}\n\`\`\``
+      : '[]';
   return `
-  - Player's Last Action: TODO
+  - Player's Last Action: ${playerLastAction}
   - Player Items Hint: "${playerItemsHint}";
   - World Items Hint: "${worldItemsHint}";
   - NPC Items Hint: "${npcItemsHint}".
-  
-  ${newItemsJson? `New Items from Storyteller AI or Dialogue AI:\n${newItemsJson}\n` : ''}
-  Current Player's Inventory: TODO
-  Current Location Inventory: TODO
-  Companions Inventory: TODO
-  Nearby NPCs Inventory: TODO
+
+  ${newItemsJson ? `New Items from Storyteller AI or Dialogue AI:\n${newItemsJson}\n` : ''}
+  Current Player's Inventory:\n${playerInventory}
+  Current Location Inventory:\n${locationInventory}
+  Companions Inventory:\n${companionsInventory}
+  Nearby NPCs Inventory:\n${nearbyNpcsInventory}
 
   Provide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;
 };


### PR DESCRIPTION
## Summary
- expand `buildInventoryPrompt` with action and inventory context
- supply full inventory details in `applyInventoryHints_Service`
- gather inventories when applying AI responses

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b2faaa47c8324be4af3f7a3242ed8