### PR TITLE
Fix item update validation

### DIFF
--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -79,8 +79,8 @@ Instructions for "update":
     -   If "type" is provided, it must be from ${VALID_ITEM_TYPES_STRING} and CANNOT be 'junk'. If the item becomes junk, set 'isJunk: true'.
 2.  **Transformation (Using "newName"):** If the malformed payload contains a "newName" OR the context clearly indicates a transformation:
     -   The corrected payload MUST include the "newName" field.
-    -   The corrected payload MUST also include "type" and "description" that describe the *new, transformed item*.
-    -   "type" MUST be from ${VALID_ITEM_TYPES_STRING} and CANNOT be 'junk'. If the new item is junk, set 'isJunk: true'.
+    -   Optionally include "type" and "description" if they change; otherwise they will be inherited.
+    -   If "type" is provided, it must be from ${VALID_ITEM_TYPES_STRING} and CANNOT be 'junk'. If the new item is junk, set 'isJunk: true'.
 3.  **Known Uses:**
     -   "knownUses" replaces all existing known uses if provided.
     -   "addKnownUse" adds or updates a single known use.

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -78,14 +78,14 @@ Structure for individual ItemChange objects within the array:
       }
   }
 
-- Example for transformation or crafting (providing all details for the new item): 
+- Example for transformation or crafting (new item details can be partial and will inherit missing fields):
   { "action": "update",
     "item": {
       "id": "item_scrap_metal_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
       "name": "Scrap Metal", /* REQUIRED: Full name of the item to update. Choose from the provided context. */
       "newName": "Makeshift Shiv", /* REQUIRED: New name for the transformed item, e.g., "Makeshift Shiv" */
-      "type": "weapon", /* REQUIRED: New type for the transformed item, e.g., "weapon". MUST be one of ${VALID_ITEM_TYPES_STRING} */
-      "description": "A sharp piece of metal.", /* REQUIRED: New description for the transformed item, e.g., "A sharp piece of metal." */
+      "type": "weapon", /* Optional: New type for the transformed item if it changes. MUST be one of ${VALID_ITEM_TYPES_STRING} */
+      "description": "A sharp piece of metal.", /* Optional: New description for the transformed item if it changes. */
       "isJunk"?: false /* Optional: Set to true if the item becomes junk, false if it becomes important again. Defaults to false if not provided. IMPORTANT: "status effects" can never be marked as junk. */
       "knownUses"?: [
         { 
@@ -137,6 +137,6 @@ Valid item "type" values are: ${VALID_ITEM_TYPES_STRING}.
 - "knowledge": Immaterial. Represents learned info, skills, spells, passwords. 'knownUses' define how to apply it. Can be 'lost' if used up or no longer relevant. E.g., "Spell: Fireball", "Recipe: Health Potion", "Clue: Thief Name".
 - "status effect": Temporary condition, positive or negative, generally gained and lost by eating, drinking, environmental exposure, impacts, and wounds. 'isActive: true' while affecting player. 'description' explains its effect, e.g., "Poisoned (move slower)", "Blessed (higher luck)", "Wounded (needs healing)". 'lost' when it expires.
 
-IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName", and the new "type" and "description" for the thematically appropriate item. Your "logMessage" must creatively explain this transformation. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand". The log message could be: "The strange metal device from another world shimmers and reshapes into a humming metal wand in your grasp!"
+IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName" and optionally the new "type" and "description" if they change. Your "logMessage" must creatively explain this transformation. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand". The log message could be: "The strange metal device from another world shimmers and reshapes into a humming metal wand in your grasp!"
 
 Do not include any explanations or formatting outside of the JSON array.`;

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -56,14 +56,7 @@ export function isValidItem(item: unknown, context?: 'gain' | 'update'): item is
         console.warn("isValidItem (context: update, with newName): 'newName' is invalid.", item);
         return false;
     }
-    if (typeof obj.type !== 'string' || !VALID_ITEM_TYPES.includes(obj.type)) {
-        console.warn("isValidItem (context: update, with newName): 'type' is missing or invalid for transformed item.", item);
-        return false;
-    }
-    if (typeof obj.description !== 'string' || obj.description.trim() === '') {
-        console.warn("isValidItem (context: update, with newName): 'description' is missing or invalid for transformed item.", item);
-        return false;
-    }
+    // 'type' and 'description' can be omitted and inherited from the existing item.
   }
 
 

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -66,8 +66,8 @@ Current Objective: "${theme.initialCurrentObjective}" (adjust for variety)
 
 Player's Current Inventory (brought from previous reality or last visit):\n - ${inventoryPrompt}
 IMPORTANT:
-- EXAMINE the player's Current Inventory for any items that are CLEARLY ANACHRONISTIC for the theme "${theme.name}".
-- If anachronistic items are found, TRANSFORM them into thematically appropriate equivalents using an "itemChange" "update" action with "newName", "type", and "description". Creatively explain this transformation in the "logMessage". Refer to ITEMS_GUIDE for anachronistic item handling.
+  - EXAMINE the player's Current Inventory for any items that are CLEARLY ANACHRONISTIC for the theme "${theme.name}".
+  - If anachronistic items are found, TRANSFORM them into thematically appropriate equivalents using an "itemChange" "update" action with "newName" and optionally updated "type" and "description". Creatively explain this transformation in the "logMessage". Refer to ITEMS_GUIDE for anachronistic item handling.
 - If no items are anachronistic, no transformation is needed.
 
 Generate the scene description for a disoriented arrival, and provide appropriate initial action options for the player to orient themselves.
@@ -104,8 +104,8 @@ Current Objective: "${themeMemory.currentObjective}"
 Player's Current Inventory (brought from previous reality or last visit):\n - ${inventoryPrompt}
 IMPORTANT:
 - EXAMINE the player's Current Inventory for any items that are CLEARLY ANACHRONISTIC for the theme "${theme.name}".
-- If anachronistic items are found, TRANSFORM them into thematically appropriate equivalents using an "itemChange" "update" action with "newName", "type", and "description". Creatively explain this transformation in the "logMessage". Refer to ITEMS_GUIDE for anachronistic item handling.
-- CRITICALLY IMPORTANT: ALWAYS transform some items into important quest items you must have already had in this reality, based on Main Quest, Current Objective, or the Adventure Summary even if they are NOT anachronistic, using an "itemChange" "update" action with "newName", "type", "description". Creatively explain this transformation in the "logMessage".
+  - If anachronistic items are found, TRANSFORM them into thematically appropriate equivalents using an "itemChange" "update" action with "newName" and optionally updated "type" and "description". Creatively explain this transformation in the "logMessage". Refer to ITEMS_GUIDE for anachronistic item handling.
+  - CRITICALLY IMPORTANT: ALWAYS transform some items into important quest items you must have already had in this reality, based on Main Quest, Current Objective, or the Adventure Summary even if they are NOT anachronistic, using an "itemChange" "update" action with "newName" and optional "type" and "description". Creatively explain this transformation in the "logMessage".
 
 Known Locations: ${placesContext}
 Known Characters (including presence): ${charactersContext}


### PR DESCRIPTION
## Summary
- loosen validation for item updates so `type` and `description` can be omitted
- clarify in inventory prompts that transformed items inherit missing fields
- adjust correction prompts and storyteller instructions for optional fields

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b3db01eb08324b6ce83c150fe1c3f