### PR TITLE
Include current location ID in inventory prompt

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -310,6 +310,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           playerActionText || '',
           formatInventoryForPrompt(baseInventoryForPlayer),
           formatInventoryForPrompt(locationInventory),
+          baseStateSnapshot.currentMapNodeId || null,
           formatCharInventoryList(companionChars),
           formatCharInventoryList(nearbyChars)
         );

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -46,6 +46,7 @@ export const applyInventoryHints_Service = async (
   playerLastAction: string,
   playerInventory: string,
   locationInventory: string,
+  currentNodeId: string | null,
   companionsInventory: string,
   nearbyNpcsInventory: string,
 ): Promise<InventoryUpdateResult | null> => {
@@ -64,6 +65,7 @@ export const applyInventoryHints_Service = async (
     newItems,
     playerInventory,
     locationInventory,
+    currentNodeId,
     companionsInventory,
     nearbyNpcsInventory,
   );

--- a/services/inventory/promptBuilder.ts
+++ b/services/inventory/promptBuilder.ts
@@ -16,6 +16,7 @@ export const buildInventoryPrompt = (
   newItems: NewItemSuggestion[],
   playerInventory: string,
   locationInventory: string,
+  currentNodeId: string | null,
   companionsInventory: string,
   nearbyNpcsInventory: string,
 ): string => {
@@ -31,7 +32,7 @@ export const buildInventoryPrompt = (
 
   ${newItemsJson ? `New Items from Storyteller AI or Dialogue AI:\n${newItemsJson}\n` : ''}
   ${playerInventory ? `Current Player's Inventory:\n${playerInventory}\n` : ''}
-  ${locationInventory ? `Current Location Inventory:\n${locationInventory}\n` : ''}
+  ${locationInventory ? `Current Location Inventory - ID: ${currentNodeId || 'unknown'}\n${locationInventory}\n` : ''}
   ${companionsInventory ? `Companions Inventory:\n${companionsInventory}\n` : ''}
   ${nearbyNpcsInventory ? `Nearby NPCs Inventory:\n${nearbyNpcsInventory}\n` : ''}
 


### PR DESCRIPTION
## Summary
- pass location id to inventory service prompt builder
- append location id when listing location inventory

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b46bf43c883249714e136146fb0fa