### PR TITLE
Fix game title font on desktop

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -445,7 +445,7 @@ const App: React.FC = () => {
     <>
       <div className="min-h-screen bg-slate-900 text-slate-200 p-4 md:p-8 flex flex-col items-center">
         <header className="w-full max-w-screen-xl mb-6 text-center">
-          <h1 className="text-4xl md:text-5xl font-bold text-sky-400 tracking-wider" style={{ fontFamily: "'Cinzel Decorative', cursive" }}>
+          <h1 className="text-4xl md:text-5xl font-bold text-sky-400 tracking-wider title-font">
             Whispers in the Dark
           </h1>
           {hasGameBeenInitialized && (

--- a/components/TitleMenu.tsx
+++ b/components/TitleMenu.tsx
@@ -45,7 +45,7 @@ const TitleMenu: React.FC<TitleMenuProps> = ({
         )}
         <div className="flex flex-col items-center justify-center h-full w-full p-4 text-center">
           <header className="mb-10 md:mb-12">
-            <h1 id="title-menu-heading" className="text-4xl sm:text-5xl md:text-6xl font-bold text-sky-400 tracking-wider" style={{ fontFamily: "'Cinzel Decorative', cursive" }}>
+            <h1 id="title-menu-heading" className="text-4xl sm:text-5xl md:text-6xl font-bold text-sky-400 tracking-wider title-font">
               Whispers in the Dark
             </h1>
             <p className="text-slate-400 text-lg md:text-xl mt-2">An Adventure in Shifting Realities</p>

--- a/index.css
+++ b/index.css
@@ -1,7 +1,13 @@
 /* Main stylesheet for Whispers in the Dark */
+@import url('https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&display=swap');
 
 body {
   font-family: "Georgia", serif; /* Thematic font */
+}
+
+/* Font used for the main game title */
+.title-font {
+  font-family: 'Cinzel Decorative', cursive;
 }
 /* Custom scrollbar for a more thematic feel */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- load *Cinzel Decorative* from Google Fonts via `@import`
- add `title-font` utility class
- use the class for the title in `TitleMenu` and main app header

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f3b366fc4832497603b96e499a3ed