### PR TITLE
Move info panel to title menu and tweak toolbar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import SettingsDisplay from './components/SettingsDisplay';
 import ConfirmationDialog from './components/ConfirmationDialog';
 import InfoDisplay from './components/InfoDisplay';
 import MainToolbar from './components/MainToolbar';
+import ModelUsageIndicators from './components/ModelUsageIndicators';
 import TitleMenu from './components/TitleMenu';
 import DialogueDisplay from './components/DialogueDisplay';
 import DebugView from './components/DebugView';
@@ -478,7 +479,6 @@ const App: React.FC = () => {
                 isLoading={isLoading || !!dialogueState}
                 currentThemeName={currentTheme?.name || null}
                 currentSceneExists={!!currentScene}
-                onOpenInfo={() => setIsInfoVisible(true)}
                 onOpenVisualizer={() => setIsVisualizerVisible(true)}
                 onOpenKnowledgeBase={() => setIsKnowledgeBaseVisible(true)}
                 onOpenHistory={() => setIsHistoryVisible(true)}
@@ -487,6 +487,12 @@ const App: React.FC = () => {
                 onManualRealityShift={() => setShiftConfirmOpen(true)}
                 turnsSinceLastShift={turnsSinceLastShift}
               />
+            )}
+            {hasGameBeenInitialized && (
+              <div className="flex items-center my-2">
+                <ModelUsageIndicators />
+                <div className="flex-grow border-t border-slate-600 ml-2" />
+              </div>
             )}
 
             {isLoading && !dialogueState && !isDialogueExiting && hasGameBeenInitialized && (
@@ -640,6 +646,7 @@ const App: React.FC = () => {
         onSaveGame={hasGameBeenInitialized ? handleSaveGameFromMenu : undefined}
         onLoadGame={handleLoadGameFromMenu}
         onOpenSettings={openSettingsFromMenu}
+        onOpenInfo={() => setIsInfoVisible(true)}
         isGameActive={hasGameBeenInitialized}
       />
       <CustomGameSetupScreen

--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -4,10 +4,9 @@
  * @description Top-level toolbar with action buttons.
  */
 import React from 'react';
-import ModelUsageIndicators from './ModelUsageIndicators';
 import {
   CoinIcon,
-  VisualizeIcon, BookOpenIcon, MenuIcon, InfoIcon, RealityShiftIcon, ScrollIcon, MapIcon // Added MapIcon
+  VisualizeIcon, BookOpenIcon, MenuIcon, RealityShiftIcon, ScrollIcon, MapIcon // Added MapIcon
 } from './icons.tsx';
 
 interface MainToolbarProps {
@@ -15,7 +14,6 @@ interface MainToolbarProps {
   isLoading: boolean;
   currentThemeName: string | null;
   currentSceneExists: boolean;
-  onOpenInfo: () => void;
   onOpenVisualizer: () => void;
   onOpenKnowledgeBase: () => void;
   onOpenHistory: () => void;
@@ -33,7 +31,6 @@ const MainToolbar: React.FC<MainToolbarProps> = ({
   isLoading,
   currentThemeName,
   currentSceneExists,
-  onOpenInfo,
   onOpenVisualizer,
   onOpenKnowledgeBase,
   onOpenHistory,
@@ -66,25 +63,11 @@ const MainToolbar: React.FC<MainToolbarProps> = ({
             <span className="text-indigo-400 font-semibold text-lg">{turnsSinceLastShift}</span>
           </div>
         )}
-        <div className="p-2 border border-slate-500 rounded-md shadow-md">
-          <ModelUsageIndicators />
-        </div>
       </div>
 
 
       {/* Icon Buttons */}
       <div className="flex space-x-2">
-        <button
-          onClick={onOpenInfo}
-          disabled={isLoading}
-          className="p-2 bg-cyan-700 hover:bg-cyan-600 text-white rounded-md shadow-md
-                    disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed
-                    transition-colors duration-150"
-          title="Open Game Info & Guide"
-          aria-label="Open Game Info & Guide"
-        >
-          <InfoIcon />
-        </button>
         <button
           onClick={onOpenVisualizer}
           disabled={isLoading || !currentThemeName || !currentSceneExists}

--- a/components/SceneDisplay.tsx
+++ b/components/SceneDisplay.tsx
@@ -40,17 +40,20 @@ const SceneDisplay: React.FC<SceneDisplayProps> = ({
     [inventory, mapData, allCharacters, currentThemeName]
   );
 
+  const enableMobileTap =
+    typeof window !== 'undefined' && window.matchMedia('(hover: none)').matches;
+
   const highlightedDescription = useMemo(() => {
     return description.split('\n').map((para, index) => (
       <p key={index} className="mb-4 leading-relaxed text-lg text-slate-300">
-        {highlightEntitiesInText(para, entitiesForHighlighting)}
+        {highlightEntitiesInText(para, entitiesForHighlighting, enableMobileTap)}
       </p>
     ));
-  }, [description, entitiesForHighlighting]);
+  }, [description, entitiesForHighlighting, enableMobileTap]);
 
   const highlightedLastActionLog = useMemo(() => {
-    return highlightEntitiesInText(lastActionLog, entitiesForHighlighting);
-  }, [lastActionLog, entitiesForHighlighting]);
+    return highlightEntitiesInText(lastActionLog, entitiesForHighlighting, enableMobileTap);
+  }, [lastActionLog, entitiesForHighlighting, enableMobileTap]);
 
   return (
     <div className="bg-slate-800 p-6 rounded-lg shadow-lg border border-slate-700 min-h-[200px]">

--- a/components/TitleMenu.tsx
+++ b/components/TitleMenu.tsx
@@ -14,6 +14,7 @@ interface TitleMenuProps {
   onSaveGame?: () => void;
   onLoadGame: () => void;
   onOpenSettings: () => void;
+  onOpenInfo: () => void;
   isGameActive: boolean;
 }
 
@@ -28,6 +29,7 @@ const TitleMenu: React.FC<TitleMenuProps> = ({
   onSaveGame,
   onLoadGame,
   onOpenSettings,
+  onOpenInfo,
   isGameActive,
 }) => {
 
@@ -92,6 +94,14 @@ const TitleMenu: React.FC<TitleMenuProps> = ({
               aria-label="Open Settings"
             >
               Settings
+            </button>
+            <button
+              onClick={onOpenInfo}
+              className="w-full px-6 py-2.5 sm:py-3 bg-cyan-700 hover:bg-cyan-600 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
+                         transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-cyan-400 focus:outline-none"
+              aria-label="About & Game Guide"
+            >
+              About
             </button>
             {isGameActive && (
               <button

--- a/index.css
+++ b/index.css
@@ -447,6 +447,20 @@ body {
   transition: opacity 0.1s ease-in-out; /* Smooth appear/disappear if needed */
 }
 
+.highlight-tooltip {
+  position: fixed;
+  background-color: rgba(31, 41, 55, 0.95);
+  color: #e5e7eb;
+  border: 1px solid #60a5fa;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  z-index: 80;
+  white-space: pre-wrap;
+}
+
 
 .map-controls-container {
   display: flex;

--- a/utils/highlightHelper.tsx
+++ b/utils/highlightHelper.tsx
@@ -5,6 +5,26 @@
  */
 import React from 'react';
 import { Item, Character, MapNode } from '../types';
+
+const showMobileTooltip = (text: string, rect: DOMRect) => {
+  const existing = document.querySelector('.highlight-tooltip');
+  if (existing) existing.remove();
+
+  const div = document.createElement('div');
+  div.className = 'highlight-tooltip';
+  div.textContent = text;
+  document.body.appendChild(div);
+
+  const offset = 8;
+  const left = rect.left + rect.width / 2 - div.offsetWidth / 2 + window.scrollX;
+  const top = rect.bottom + offset + window.scrollY;
+  div.style.left = `${Math.max(4, Math.min(left, window.innerWidth - div.offsetWidth - 4))}px`;
+  div.style.top = `${top}px`;
+
+  const remove = () => div.remove();
+  div.addEventListener('click', remove);
+  setTimeout(remove, 2500);
+};
 // Item and Character types are fine. Place-like entities will be mapped to HighlightableEntity.
 // No direct type change needed here as long as the calling components map MapNode data to HighlightableEntity structure.
 
@@ -30,7 +50,8 @@ const getEntityHighlightClass = (type: HighlightableEntity['type']): string => {
 
 export const highlightEntitiesInText = (
   text: string | null | undefined,
-  entities: HighlightableEntity[]
+  entities: HighlightableEntity[],
+  enableMobileTap: boolean = false
 ): React.ReactNode[] => {
   if (!text) return [text || '']; 
 
@@ -94,8 +115,15 @@ export const highlightEntitiesInText = (
           key={`${matchedTermInfo.entityData.name}-${matchedTermInfo.term}-${match.index}`}
           className={getEntityHighlightClass(matchedTermInfo.entityData.type)}
           title={matchedTermInfo.entityData.description || matchedTermInfo.entityData.name}
+          onClick={enableMobileTap ? (e => {
+            if (window.matchMedia('(hover: none)').matches) {
+              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+              const text = e.currentTarget.getAttribute('title') || '';
+              showMobileTooltip(text, rect);
+            }
+          }) : undefined}
         >
-          {matchedString} 
+          {matchedString}
         </span>
       );
     } else {


### PR DESCRIPTION
## Summary
- add mobile tooltip handling for highlighted text
- place model usage line below the toolbar
- remove Info button from toolbar
- move About button to the title menu
- fix highlight logic so PC still shows tooltips

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ff165a8d483249643eb7e62b68aa8