### PR TITLE
Improve inventory hints with map context

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -575,6 +575,8 @@ const App: React.FC = () => {
             items={itemsHere}
             onTakeItem={handleTakeLocationItem}
             disabled={isLoading || !!dialogueState || effectiveIsTitleMenuOpen || isCustomGameSetupVisible || isManualShiftThemeSelectionVisible }
+            currentNodeId={currentMapNodeId}
+            mapNodes={mapData.nodes}
           />
           <InventoryDisplay
             items={inventory}

--- a/components/LocationItemsDisplay.tsx
+++ b/components/LocationItemsDisplay.tsx
@@ -7,9 +7,11 @@ interface LocationItemsDisplayProps {
   items: Item[];
   onTakeItem: (itemName: string) => void;
   disabled: boolean;
+  currentNodeId: string | null;
+  mapNodes: { id: string; placeName: string }[];
 }
 
-const LocationItemsDisplay: React.FC<LocationItemsDisplayProps> = ({ items, onTakeItem, disabled }) => {
+const LocationItemsDisplay: React.FC<LocationItemsDisplayProps> = ({ items, onTakeItem, disabled, currentNodeId, mapNodes }) => {
   if (items.length === 0) return null;
 
   return (
@@ -20,6 +22,8 @@ const LocationItemsDisplay: React.FC<LocationItemsDisplayProps> = ({ items, onTa
       <ul className="flex flex-wrap justify-center gap-4 list-none p-0">
         {items.map((item) => {
           const description = item.isActive && item.activeDescription ? item.activeDescription : item.description;
+          const atCurrent = item.holderId === currentNodeId;
+          const holderName = !atCurrent ? mapNodes.find(n => n.id === item.holderId)?.placeName : null;
           return (
             <li
               key={item.name}
@@ -32,7 +36,10 @@ const LocationItemsDisplay: React.FC<LocationItemsDisplayProps> = ({ items, onTa
               <div className="mb-1">
                 <span className="font-semibold text-lg text-slate-100">{item.name}</span>
               </div>
-              <p className="text-sm text-slate-300 mb-3 italic leading-tight flex-grow">{description}</p>
+              <p className="text-sm text-slate-300 mb-1 italic leading-tight flex-grow">{description}</p>
+              {!atCurrent && holderName && (
+                <p className="text-xs text-slate-400 mb-2">Reachable at {holderName}</p>
+              )}
               <div className="mt-auto">
                 <button
                   onClick={(event: React.MouseEvent<HTMLButtonElement>) => {

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -38,6 +38,8 @@ import {
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { handleMapUpdates } from '../utils/mapUpdateHandlers';
 import { formatInventoryForPrompt } from '../utils/promptFormatters/inventory';
+import { formatLimitedMapContextForPrompt } from '../utils/promptFormatters/map';
+import { getAdjacentNodeIds } from '../utils/mapGraphUtils';
 import { applyInventoryHints_Service } from '../services/inventory';
 
 export interface ProcessAiResponseOptions {
@@ -314,6 +316,10 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         if (themeContextForResponse) {
           const originalLoadingReason = loadingReason;
           setLoadingReason('inventory');
+          const limitedMapContext = formatLimitedMapContextForPrompt(
+            draftState.mapData,
+            draftState.currentMapNodeId
+          );
           const invResult = await applyInventoryHints_Service(
             'playerItemsHint' in aiData ? aiData.playerItemsHint : undefined,
             'worldItemsHint' in aiData ? aiData.worldItemsHint : undefined,
@@ -327,7 +333,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
             formatCharInventoryList(nearbyChars),
             'sceneDescription' in aiData ? aiData.sceneDescription : baseStateSnapshot.currentScene,
             aiData.logMessage,
-            themeContextForResponse
+            themeContextForResponse,
+            limitedMapContext
           );
           setLoadingReason(originalLoadingReason);
           if (invResult) {
@@ -643,14 +650,20 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       const currentLocationId = currentFullState.currentMapNodeId;
       if (!currentLocationId) return;
 
-      const itemToTake = currentFullState.inventory.find(
-        (item) => item.name === itemName && item.holderId === currentLocationId
+      const adjacentIds = getAdjacentNodeIds(
+        currentFullState.mapData,
+        currentLocationId
       );
+      const itemToTake = currentFullState.inventory.find(item => {
+        if (item.name !== itemName) return false;
+        if (item.holderId === currentLocationId) return true;
+        return adjacentIds.includes(item.holderId);
+      });
       if (!itemToTake) return;
 
       const draftState = structuredCloneGameState(currentFullState);
       draftState.inventory = draftState.inventory.map((item) =>
-        item.name === itemName && item.holderId === currentLocationId
+        item.name === itemName && item.holderId === itemToTake.holderId
           ? { ...item, holderId: PLAYER_HOLDER_ID }
           : item
       );

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -53,6 +53,7 @@ export const applyInventoryHints_Service = async (
   sceneDescription: string | undefined,
   logMessage: string | undefined,
   currentTheme: AdventureTheme,
+  limitedMapContext: string,
 ): Promise<InventoryUpdateResult | null> => {
   const pHint = playerItemsHint?.trim() || '';
   const wHint = worldItemsHint?.trim() || '';
@@ -72,6 +73,7 @@ export const applyInventoryHints_Service = async (
     currentNodeId,
     companionsInventory,
     nearbyNpcsInventory,
+    limitedMapContext,
   );
   const response = await executeInventoryRequest(prompt);
   let parsed = parseInventoryResponse(response.text ?? '');

--- a/services/inventory/promptBuilder.ts
+++ b/services/inventory/promptBuilder.ts
@@ -19,6 +19,7 @@ export const buildInventoryPrompt = (
   currentNodeId: string | null,
   companionsInventory: string,
   nearbyNpcsInventory: string,
+  limitedMapContext: string,
 ): string => {
   const newItemsJson =
     newItems.length > 0
@@ -35,6 +36,7 @@ export const buildInventoryPrompt = (
   ${locationInventory ? `Current Location Inventory - ID: ${currentNodeId || 'unknown'}\n${locationInventory}\n` : ''}
   ${companionsInventory ? `Companions Inventory:\n${companionsInventory}\n` : ''}
   ${nearbyNpcsInventory ? `Nearby NPCs Inventory:\n${nearbyNpcsInventory}\n` : ''}
+  ${limitedMapContext ? `Nearby Map Context:\n${limitedMapContext}\n` : ''}
 
   Provide the inventory update as JSON as described in the SYSTEM_INSTRUCTION.`;
 };

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -8,6 +8,8 @@ import { VALID_ITEM_TYPES_STRING } from '../../constants';
 export const SYSTEM_INSTRUCTION = `** SYSTEM INSTRUCTIONS: **
 You are an AI assistant that converts item hints into explicit inventory actions for a text adventure game.
 Analyze the hints and optional new items JSON provided in the prompt.
+The prompt provides limited map context listing nodes within two hops of the Player.
+Items described in the "World Items Hint" should be placed at their appropriate map node holderId from this context using the 'put' action, leaving them for the Player to pick up later unless explicitly taken.
 You MUST process all items in the New Items JSON, and define any operations on existing items in the Player's Inventory, Location Inventory, or NPCs' inventories, according to provided hints.
 Return ONLY the JSON array of itemChange objects, without any additional text or explanations.
 

--- a/utils/mapGraphUtils.ts
+++ b/utils/mapGraphUtils.ts
@@ -88,6 +88,26 @@ export const isDescendantIdOf = (
 };
 
 /**
+ * Returns IDs of nodes directly connected to the provided node via traversable edges.
+ */
+export const getAdjacentNodeIds = (
+  mapData: MapData,
+  nodeId: string,
+): string[] => {
+  const allowed: MapEdgeStatus[] = ['open', 'accessible', 'active'];
+  const ids = new Set<string>();
+  for (const edge of mapData.edges) {
+    if (!allowed.includes(edge.data.status ?? 'open')) continue;
+    if (edge.sourceNodeId === nodeId) {
+      ids.add(edge.targetNodeId);
+    } else if (edge.targetNodeId === nodeId && edge.data.status !== 'one_way') {
+      ids.add(edge.sourceNodeId);
+    }
+  }
+  return Array.from(ids);
+};
+
+/**
  * Determines if a non-rumored path exists between two nodes.
  * Traverses the map graph ignoring edges with status 'rumored' or 'removed'.
  *

--- a/utils/promptFormatters/map.ts
+++ b/utils/promptFormatters/map.ts
@@ -196,6 +196,30 @@ const getNearbyNodeIds = (
 };
 
 /**
+ * Formats limited map context for inventory prompts.
+ * Lists nodes within two hops including id, name, parent id and description.
+ */
+export const formatLimitedMapContextForPrompt = (
+  mapData: MapData,
+  currentMapNodeId: string | null,
+): string => {
+  if (!currentMapNodeId) return 'Current location unknown.';
+  const allNodes = mapData.nodes;
+  const allEdges = mapData.edges;
+  const nearbyIds = getNearbyNodeIds(currentMapNodeId, 2, allNodes, allEdges);
+  nearbyIds.add(currentMapNodeId);
+  const lines: string[] = [];
+  nearbyIds.forEach(id => {
+    const node = allNodes.find(n => n.id === id);
+    if (!node) return;
+    const parent = node.data.parentNodeId || 'Universe';
+    const desc = node.data.description || 'No description.';
+    lines.push(` - ${node.id} - "${node.placeName}" (parent: ${parent}), "${desc}"`);
+  });
+  return lines.join(';\n') + '.';
+};
+
+/**
  * Formats the current map context for the AI prompt.
  */
 export const formatMapContextForPrompt = (


### PR DESCRIPTION
## Summary
- add limited map context formatter
- extend inventory prompt and service to include map info
- place world items at map nodes via new system instructions
- display reachable items from adjacent nodes in UI
- allow taking items from adjacent locations

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ffde80fec832498dc8958218a1ee2