### PR TITLE
Add item details to limited map context

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -318,7 +318,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           setLoadingReason('inventory');
           const limitedMapContext = formatLimitedMapContextForPrompt(
             draftState.mapData,
-            draftState.currentMapNodeId
+            draftState.currentMapNodeId,
+            baseStateSnapshot.inventory
           );
           const invResult = await applyInventoryHints_Service(
             'playerItemsHint' in aiData ? aiData.playerItemsHint : undefined,

--- a/utils/promptFormatters/map.ts
+++ b/utils/promptFormatters/map.ts
@@ -4,7 +4,7 @@
  * @description Utilities for formatting map related context for AI prompts.
  */
 
-import { AdventureTheme, MapData, MapNode, MapEdge } from '../../types';
+import { AdventureTheme, MapData, MapNode, MapEdge, Item } from '../../types';
 import { NON_DISPLAYABLE_EDGE_STATUSES } from '../../constants';
 
 /**
@@ -197,11 +197,12 @@ const getNearbyNodeIds = (
 
 /**
  * Formats limited map context for inventory prompts.
- * Lists nodes within two hops including id, name, parent id and description.
+ * Lists nodes within two hops including id, name, parent id, description, and items at each node.
  */
 export const formatLimitedMapContextForPrompt = (
   mapData: MapData,
   currentMapNodeId: string | null,
+  inventory: Item[] = [],
 ): string => {
   if (!currentMapNodeId) return 'Current location unknown.';
   const allNodes = mapData.nodes;
@@ -214,7 +215,14 @@ export const formatLimitedMapContextForPrompt = (
     if (!node) return;
     const parent = node.data.parentNodeId || 'Universe';
     const desc = node.data.description || 'No description.';
-    lines.push(` - ${node.id} - "${node.placeName}" (parent: ${parent}), "${desc}"`);
+    const itemsAtNode = inventory.filter(item => item.holderId === id);
+    const itemsStr =
+      itemsAtNode.length > 0
+        ? ` Items: ${itemsAtNode.map(i => `"${i.name}"`).join(', ')}`
+        : '';
+    lines.push(
+      ` - ${node.id} - "${node.placeName}" (parent: ${parent}), "${desc}"${itemsStr}`,
+    );
   });
   return lines.join(';\n') + '.';
 };


### PR DESCRIPTION
## Summary
- extend `formatLimitedMapContextForPrompt` to include items at each nearby node
- update `usePlayerActions` call site

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850055ddcdc8324a0489190f528341b