### PR TITLE
Add pseudo thinking to inventory AI

### DIFF
--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -311,6 +311,23 @@ const DebugView: React.FC<DebugViewProps> = ({
               debugPacket.inventoryDebugInfo.rawResponse,
               false,
             )}
+            {debugPacket.inventoryDebugInfo.parsedItemChanges &&
+              renderContent(
+                "Inventory AI Parsed",
+                debugPacket.inventoryDebugInfo.parsedItemChanges,
+              )}
+            {debugPacket.inventoryDebugInfo.observations &&
+              renderContent(
+                "Inventory Observations",
+                debugPacket.inventoryDebugInfo.observations,
+                false,
+              )}
+            {debugPacket.inventoryDebugInfo.rationale &&
+              renderContent(
+                "Inventory Rationale",
+                debugPacket.inventoryDebugInfo.rationale,
+                false,
+              )}
           </>
         ) : (
           <p className="italic text-slate-400">No Inventory AI interaction debug packet captured.</p>

--- a/services/corrections/inventory.ts
+++ b/services/corrections/inventory.ts
@@ -61,7 +61,8 @@ Task: Provide ONLY the corrected JSON array of ItemChange objects.`;
   for (let attempt = 0; attempt <= MAX_RETRIES; ) {
     try {
       const corrected = await callCorrectionAI<ItemChange[]>(prompt, systemInstructionForFix);
-      const validated = corrected ? parseInventoryResponse(JSON.stringify(corrected)) : null;
+      const validatedPayload = corrected ? parseInventoryResponse(JSON.stringify(corrected)) : null;
+      const validated = validatedPayload ? validatedPayload.itemChanges : null;
       if (validated) return validated;
       console.warn(
         `fetchCorrectedItemChangeArray_Service (Attempt ${attempt + 1}/${MAX_RETRIES + 1}): corrected payload invalid.`,

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -10,7 +10,7 @@ import { dispatchAIRequest } from '../modelDispatcher';
 import { isApiConfigured } from '../apiClient';
 import { AdventureTheme, ItemChange, NewItemSuggestion } from '../../types';
 import { buildInventoryPrompt } from './promptBuilder';
-import { parseInventoryResponse } from './responseParser';
+import { parseInventoryResponse, InventoryAIPayload } from './responseParser';
 import { fetchCorrectedItemChangeArray_Service } from '../corrections';
 
 /**
@@ -36,7 +36,13 @@ export const executeInventoryRequest = async (
 
 export interface InventoryUpdateResult {
   itemChanges: ItemChange[];
-  debugInfo: { prompt: string; rawResponse?: string } | null;
+  debugInfo: {
+    prompt: string;
+    rawResponse?: string;
+    parsedItemChanges?: ItemChange[];
+    observations?: string;
+    rationale?: string;
+  } | null;
 }
 
 export const applyInventoryHints_Service = async (
@@ -75,7 +81,8 @@ export const applyInventoryHints_Service = async (
   );
   const response = await executeInventoryRequest(prompt);
   let parsed = parseInventoryResponse(response.text ?? '');
-  if (!parsed || (parsed.length === 0 && (response.text?.trim() || '') !== '[]')) {
+  if (!parsed ||
+      (parsed.itemChanges.length === 0 && (response.text?.trim() || '') !== '[]')) {
     const corrected = await fetchCorrectedItemChangeArray_Service(
       response.text ?? '',
       logMessage,
@@ -88,7 +95,17 @@ export const applyInventoryHints_Service = async (
       nearbyNpcsInventory,
       currentTheme,
     );
-    if (corrected) parsed = corrected;
+    if (corrected)
+      parsed = { itemChanges: corrected } as InventoryAIPayload;
   }
-  return { itemChanges: parsed || [], debugInfo: { prompt, rawResponse: response.text ?? '' } };
+  return {
+    itemChanges: parsed ? parsed.itemChanges : [],
+    debugInfo: {
+      prompt,
+      rawResponse: response.text ?? '',
+      parsedItemChanges: parsed ? parsed.itemChanges : undefined,
+      observations: parsed?.observations,
+      rationale: parsed?.rationale,
+    },
+  };
 };

--- a/services/inventory/responseParser.ts
+++ b/services/inventory/responseParser.ts
@@ -7,46 +7,71 @@ import { ItemChange, GiveItemPayload } from '../../types';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
 import { isValidItem, isValidItemReference } from '../parsers/validation';
 
+export interface InventoryAIPayload {
+  itemChanges: ItemChange[];
+  observations?: string;
+  rationale?: string;
+}
+
 /**
- * Parses the AI response text into an array of ItemChange objects.
+ * Parses the AI response text into an InventoryAIPayload structure.
  */
-export const parseInventoryResponse = (responseText: string): ItemChange[] | null => {
+export const parseInventoryResponse = (
+  responseText: string,
+): InventoryAIPayload | null => {
   const jsonStr = extractJsonFromFence(responseText);
   const parsed = safeParseJson<unknown>(jsonStr);
-  if (!Array.isArray(parsed)) {
-    console.warn('Inventory response was not an array:', parsed);
-    return null;
-  }
-  const valid: ItemChange[] = [];
-  for (const raw of parsed) {
-    if (!raw || typeof raw !== 'object') continue;
-    const change = raw as ItemChange;
-    if (typeof change.action !== 'string') continue;
-    const action = change.action;
-    let ok = false;
-    switch (action) {
-      case 'gain':
-      case 'put':
-        ok = isValidItem(change.item, 'gain');
-        break;
-      case 'update':
-        ok = isValidItem(change.item, 'update');
-        break;
-      case 'destroy':
-        ok = isValidItemReference(change.item);
-        break;
-      case 'give':
-      case 'take':
-        ok = !!(
-          change.item &&
-          typeof change.item === 'object' &&
-          typeof (change.item as GiveItemPayload).id === 'string' &&
-          typeof (change.item as GiveItemPayload).fromId === 'string' &&
-          typeof (change.item as GiveItemPayload).toId === 'string'
-        );
-        break;
+  if (!parsed) return null;
+
+  let payload: InventoryAIPayload | null = null;
+
+  const validateArray = (arr: unknown[]): ItemChange[] => {
+    const valid: ItemChange[] = [];
+    for (const raw of arr) {
+      if (!raw || typeof raw !== 'object') continue;
+      const change = raw as ItemChange;
+      if (typeof change.action !== 'string') continue;
+      const action = change.action;
+      let ok = false;
+      switch (action) {
+        case 'gain':
+        case 'put':
+          ok = isValidItem(change.item, 'gain');
+          break;
+        case 'update':
+          ok = isValidItem(change.item, 'update');
+          break;
+        case 'destroy':
+          ok = isValidItemReference(change.item);
+          break;
+        case 'give':
+        case 'take':
+          ok = !!(
+            change.item &&
+            typeof change.item === 'object' &&
+            typeof (change.item as GiveItemPayload).id === 'string' &&
+            typeof (change.item as GiveItemPayload).fromId === 'string' &&
+            typeof (change.item as GiveItemPayload).toId === 'string'
+          );
+          break;
+      }
+      if (ok) valid.push(change);
     }
-    if (ok) valid.push(change);
+    return valid;
+  };
+
+  if (Array.isArray(parsed)) {
+    // Simple array of ItemChange objects
+    payload = { itemChanges: validateArray(parsed) };
+  } else if (typeof parsed === 'object') {
+    const obj = parsed as Partial<InventoryAIPayload & { itemChanges: unknown }>;
+    const arr = Array.isArray(obj.itemChanges) ? obj.itemChanges : [];
+    payload = {
+      itemChanges: validateArray(arr),
+      observations: typeof obj.observations === 'string' ? obj.observations : undefined,
+      rationale: typeof obj.rationale === 'string' ? obj.rationale : undefined,
+    };
   }
-  return valid;
+
+  return payload;
 };

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -9,7 +9,10 @@ export const SYSTEM_INSTRUCTION = `** SYSTEM INSTRUCTIONS: **
 You are an AI assistant that converts item hints into explicit inventory actions for a text adventure game.
 Analyze the hints and optional new items JSON provided in the prompt.
 You MUST process all items in the New Items JSON, and define any operations on existing items in the Player's Inventory, Location Inventory, or NPCs' inventories, according to provided hints.
-Return ONLY the JSON array of itemChange objects, without any additional text or explanations.
+Respond ONLY with a JSON object containing these fields:
+{"observations": "string", /* REQUIRED. Contextually relevant observations about the items. Minimum 500 chars. */
+ "rationale": "string", /* REQUIRED. Explain the reasoning behind the inventory changes. */
+ "itemChanges": [] /* REQUIRED. Array of ItemChange objects as described below. */}
 
 "itemChange" is ALWAYS an array. If no items change this turn, send an empty array: "itemChange": [].
 Valid actions are 'gain', 'destroy', 'update', 'put', 'give', and 'take'.
@@ -139,4 +142,4 @@ Valid item "type" values are: ${VALID_ITEM_TYPES_STRING}.
 
 IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName" and optionally the new "type" and "description" if they change. Your "logMessage" must creatively explain this transformation. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand". The log message could be: "The strange metal device from another world shimmers and reshapes into a humming metal wand in your grasp!"
 
-Do not include any explanations or formatting outside of the JSON array.`;
+Do not include any explanations or formatting outside of the JSON object.`;

--- a/types.ts
+++ b/types.ts
@@ -415,6 +415,9 @@ export interface DebugPacket {
   inventoryDebugInfo?: {
     prompt: string;
     rawResponse?: string;
+    parsedItemChanges?: ItemChange[];
+    observations?: string;
+    rationale?: string;
   } | null;
   dialogueDebugInfo?: {
     turns: DialogueTurnDebugEntry[];


### PR DESCRIPTION
## Summary
- enhance inventory system prompt with observations and rationale fields
- parse inventory responses into a new `InventoryAIPayload`
- expose debug info about inventory reasoning
- surface inventory AI parsed output and reasoning in Debug View
- update correction helpers to use new parser

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68500a52c22483249c78c8ae824f4b76