### PR TITLE
Improve travel plan context with parent names

### DIFF
--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -174,7 +174,13 @@ export const buildMainGameTurnPrompt = (
   } else if (destinationNodeId) {
     const destNode = fullMapData.nodes.find(n => n.id === destinationNodeId);
     const placeName = destNode?.placeName || destinationNodeId;
-    travelPlanOrUnknown = `Player wants to reach ${placeName}, but does not know how to get there.`;
+    const destParentId = destNode?.data.parentNodeId;
+    const destParent =
+      destParentId && destParentId !== 'Universe'
+        ? fullMapData.nodes.find(n => n.id === destParentId)?.placeName || destParentId
+        : null;
+    const displayName = destParent ? `${placeName} in ${destParent}` : placeName;
+    travelPlanOrUnknown = `Player wants to reach ${displayName}, but does not know how to get there.`;
   }
 
   const detailedEntityContext = formatDetailedContextForMentionedEntities(

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -135,6 +135,12 @@ export const formatTravelPlanLine = (
   if (!path || path.length < 3) return null;
   const destination = mapData.nodes.find(n => n.id === destinationNodeId);
   const destName = destination?.placeName ?? destinationNodeId;
+  const destParentId = destination?.data.parentNodeId;
+  const destParentName =
+    destParentId && destParentId !== 'Universe'
+      ? mapData.nodes.find(n => n.id === destParentId)?.placeName ?? destParentId
+      : null;
+  const destDisplay = destParentName ? `${destName} in ${destParentName}` : destName;
   const destRumored = destination?.data.status === 'rumored';
   const firstEdge = path[1];
   const nextNodeStep = path[2];
@@ -153,8 +159,8 @@ export const formatTravelPlanLine = (
   const furtherRumored = furtherNode?.data.status === 'rumored';
 
   let line = destRumored
-    ? `Player wants to reach a rumored place - ${destName}.`
-    : `Player wants to travel to ${destName}.`;
+    ? `Player wants to reach a rumored place - ${destDisplay}.`
+    : `Player wants to travel to ${destDisplay}.`;
 
   if (firstEdge.id.startsWith('hierarchy:')) {
     const [from, to] = firstEdge.id.split(':')[1].split('->');


### PR DESCRIPTION
## Summary
- mention parent location in travel plans
- mention parent location when route to destination unknown

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685037676f708324b45c11648aa12120