### PR TITLE
Trim old narrator thoughts

### DIFF
--- a/services/dialogue/promptBuilder.ts
+++ b/services/dialogue/promptBuilder.ts
@@ -41,7 +41,19 @@ export const buildDialogueTurnPrompt = (
     historyToUseInPrompt = historyToUseInPrompt.slice(0, -1);
   }
 
-  const historyString = historyToUseInPrompt
+  // Trim Narrator THOUGHTS from all but the most recent NPC responses
+  const trimmedHistory = historyToUseInPrompt.map(entry => ({ ...entry }));
+  let foundLastPlayer = false;
+  for (let i = trimmedHistory.length - 1; i >= 0; i--) {
+    const entry = trimmedHistory[i];
+    if (entry.speaker.toLowerCase() === 'player') {
+      foundLastPlayer = true;
+    } else if (foundLastPlayer && 'thought' in entry) {
+      delete entry.thought;
+    }
+  }
+
+  const historyString = trimmedHistory
     .map(entry => {
       const thought = entry.thought ? `Narrator THOUGHTS: "${entry.thought}"\n` : '';
       return `${thought}${entry.speaker}: "${entry.line}"`;


### PR DESCRIPTION
## Summary
- trim older narrator THOUGHTS when building dialogue prompts

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68503a4251b48324891dd7c14c432075