### PR TITLE
Fix about screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -692,6 +692,11 @@ const App: React.FC = () => {
         isCustomGameMode={isCustomGameMode}
       />
 
+      <InfoDisplay
+        isVisible={isInfoVisible}
+        onClose={() => setIsInfoVisible(false)}
+      />
+
 
       {hasGameBeenInitialized && currentTheme && (
         <>
@@ -735,10 +740,6 @@ const App: React.FC = () => {
            onViewBoxChange={handleMapViewBoxChange}
             isVisible={isMapVisible}
             onClose={() => setIsMapVisible(false)}
-          />
-          <InfoDisplay
-            isVisible={isInfoVisible}
-            onClose={() => setIsInfoVisible(false)}
           />
           <ConfirmationDialog
             isOpen={newGameFromMenuConfirmOpen}


### PR DESCRIPTION
## Summary
- show the InfoDisplay modal regardless of game state

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685051c5a1a48324925de777d5e2c73b