### PR TITLE
Refactor JSON parsing helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ ID suffix is 4 character alphanumeric: ${Math.random().toString(36).substring(2,
 ## Code and Prompts synchronization:
  - When making changes to the data structures and code, always make sure the AI prompts used by the game are in agreement with the changes you make.
  - Try to centralize common enums and constants in one place, and import them as necessary.
- - Use the defined common enums to define type properties that can take a limited set of values.
+- Use the defined common enums to define type properties that can take a limited set of values.
+- Reuse JSON helpers from `utils/jsonUtils.ts` (`extractJsonFromFence`, `safeParseJson`, `coerceNullToUndefined`) instead of hand-written parsing logic.
 
 ## Unified visual style rules:
  - Close modal frame button grey, hover: red.

--- a/services/cartographer/AGENTS.md
+++ b/services/cartographer/AGENTS.md
@@ -8,6 +8,7 @@ The **cartographer** service is responsible for updating the map. It calls the a
 
 Edits here should maintain strict validation rules so invalid map structures do not propagate to the rest of the game.
 Both null and undefined optional fields in AI responses should be sanitized to undefined and treated as undefined down the line.
+- Parsing helpers in `utils/jsonUtils.ts` should be used to handle map AI JSON responses.
 
 ### Gemini API call guidelines
 

--- a/services/corrections/AGENTS.md
+++ b/services/corrections/AGENTS.md
@@ -8,6 +8,7 @@ The **corrections** helpers attempt to fix malformed AI responses. They are used
 
 Use these utilities to keep the game running smoothly when the main models return inconsistent data.
 Both null and undefined optional fields in AI responses should be sanitized to undefined and treated as undefined down the line.
+- The shared helpers in `utils/jsonUtils.ts` simplify fence stripping and JSON parsing; use them in correction routines.
 
 ### Gemini API call guidelines
 

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -35,7 +35,7 @@ export const fetchCorrectedItemPayload_Service = async (
 
   let originalItemNameFromMalformed = 'Not specified or unparseable from malformed payload';
   try {
-    const malformedObj: Record<string, unknown> = JSON.parse(malformedPayloadString) as Record<string, unknown>;
+    const malformedObj = safeParseJson<Record<string, unknown>>(malformedPayloadString);
     if (malformedObj && typeof malformedObj.name === 'string') {
       originalItemNameFromMalformed = `"${malformedObj.name}"`;
     }
@@ -167,7 +167,7 @@ export const fetchCorrectedItemAction_Service = async (
 
   // Basic check before engaging the AI
   try {
-    const parsed = JSON.parse(malformedItemChangeString) as Record<string, unknown>;
+    const parsed = safeParseJson<Record<string, unknown>>(malformedItemChangeString);
     if (parsed && typeof parsed === 'object') {
       const rawAction = parsed['action'];
       if (typeof rawAction === 'string' && ['gain', 'destroy', 'update', 'put', 'give', 'take'].includes(rawAction)) {

--- a/services/corrections/placeDetails.ts
+++ b/services/corrections/placeDetails.ts
@@ -109,9 +109,9 @@ export const fetchCorrectedPlaceDetails_Service = async (
 
   let originalPlaceNameFromMalformed = 'Not specified or unparseable';
   try {
-    const malformedObj: Record<string, unknown> = JSON.parse(
+    const malformedObj = safeParseJson<Record<string, unknown>>(
       malformedMapNodePayloadString,
-    ) as Record<string, unknown>;
+    );
     if (malformedObj && typeof malformedObj.name === 'string') {
       originalPlaceNameFromMalformed = `"${malformedObj.name}"`;
     } else if (

--- a/services/dialogue/AGENTS.md
+++ b/services/dialogue/AGENTS.md
@@ -8,6 +8,7 @@ The **dialogue** service handles conversational interactions with NPCs. It gener
 
 Maintain compatibility between dialogue prompts and the parser whenever adjustments are made.
 Both null and undefined optional fields in AI responses should be sanitized to undefined and treated as undefined down the line.
+- Use the utilities in `utils/jsonUtils.ts` for stripping code fences and safely parsing AI responses.
 
 ### Gemini API call guidelines
 

--- a/services/dialogue/responseParser.ts
+++ b/services/dialogue/responseParser.ts
@@ -3,7 +3,7 @@
  * @description Helpers for parsing dialogue-related AI responses.
  */
 import { DialogueAIResponse, DialogueSummaryResponse } from '../../types';
-import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
+import { extractJsonFromFence, safeParseJson, coerceNullToUndefined } from '../../utils/jsonUtils';
 import { isValidNewItemSuggestion } from '../parsers/validation';
 
 export const parseDialogueAIResponse = (
@@ -96,9 +96,7 @@ export const parseDialogueSummaryResponse = (
   try {
     if (!parsed) throw new Error('JSON parse failed');
 
-    const sanitized = Object.fromEntries(
-      Object.entries(parsed).map(([k, v]) => [k, v === null ? undefined : v]),
-    ) as Partial<DialogueSummaryResponse>;
+    const sanitized: Partial<DialogueSummaryResponse> = coerceNullToUndefined(parsed);
 
     const validated: DialogueSummaryResponse = {
       ...sanitized,

--- a/services/inventory/AGENTS.md
+++ b/services/inventory/AGENTS.md
@@ -8,6 +8,7 @@ The **inventory** service coordinates small item management requests to the AI. 
 
 Maintain compatibility between the prompt builder and parser when adjusting this service.
 Both null and undefined optional fields in AI responses should be sanitized to undefined and treated as undefined down the line.
+- Prefer the helpers in `utils/jsonUtils.ts` when parsing or sanitizing AI JSON.
 
 ### Gemini API call guidelines
 

--- a/services/saveLoadService.ts
+++ b/services/saveLoadService.ts
@@ -28,6 +28,7 @@ import { getDefaultMapLayoutConfig } from "../hooks/useMapUpdates";
 import { DEFAULT_VIEWBOX } from '../utils/mapConstants';
 import { findThemeByName } from "./themeUtils";
 import { buildCharacterId, buildItemId } from '../utils/entityUtils';
+import { safeParseJson } from '../utils/jsonUtils';
 
 
 // --- Validation Helpers for SavedGameDataShape (V3) ---
@@ -609,7 +610,11 @@ export const loadGameStateFromFile = async (file: File): Promise<FullGameState |
     reader.onload = (event) => {
       try {
         if (event.target && typeof event.target.result === 'string') {
-          const parsedData: unknown = JSON.parse(event.target.result);
+          const parsedData: unknown = safeParseJson(event.target.result);
+          if (parsedData === null) {
+            resolve(null);
+            return;
+          }
           const processed = normalizeLoadedSaveData(parsedData as Record<string, unknown>, 'file');
           if (processed) {
             resolve(expandSavedDataToFullState(processed));

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -13,6 +13,7 @@ import {
   expandSavedDataToFullState,
   normalizeLoadedSaveData,
 } from './saveLoadService';
+import { safeParseJson } from '../utils/jsonUtils';
 
 /** Saves the current game state to localStorage. */
 export const saveGameStateToLocalStorage = (gameState: FullGameState): boolean => {
@@ -40,7 +41,11 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
     const savedDataString = localStorage.getItem(LOCAL_STORAGE_SAVE_KEY);
     if (!savedDataString) return null;
 
-    const parsedData: unknown = JSON.parse(savedDataString);
+    const parsedData: unknown = safeParseJson(savedDataString);
+    if (parsedData === null) {
+      console.warn('Saved data found in localStorage could not be parsed as JSON.');
+      return null;
+    }
     if (typeof parsedData !== 'object' || parsedData === null) {
       console.warn('Saved data found in localStorage is not an object.');
       return null;

--- a/services/storyteller/AGENTS.md
+++ b/services/storyteller/AGENTS.md
@@ -8,6 +8,7 @@ The **storyteller** service encapsulates all communication with the main narrati
 
 When modifying this service keep the prompt format and returned interfaces aligned with code in `useGameLogic` and the AI prompts.
 Both null and undefined optional fields in AI responses should be sanitized to undefined and treated as undefined down the line.
+- Use `extractJsonFromFence`, `safeParseJson` and `coerceNullToUndefined` from `utils/jsonUtils.ts` when parsing model output.
 
 ### Gemini API call guidelines
 

--- a/utils/jsonUtils.ts
+++ b/utils/jsonUtils.ts
@@ -30,5 +30,17 @@ export function safeParseJson<T>(jsonStr: string): T | null {
   }
 }
 
+/**
+ * Returns a shallow copy of the input object where any `null` values are
+ * converted to `undefined`. Useful for sanitizing optional fields in AI
+ * responses so they can be handled uniformly.
+ */
+export function coerceNullToUndefined<T extends Record<string, unknown>>(obj: T): T {
+  const sanitized = Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k, v === null ? undefined : v]),
+  );
+  return sanitized as T;
+}
+
 // Backwards compatibility for old imports
 export const sanitizeJsonString = extractJsonFromFence;


### PR DESCRIPTION
## Summary
- document shared JSON helpers in AGENTS docs
- replace manual JSON parsing with `safeParseJson` across services
- adjust storyteller parser to use the helper
- fallback to shared helper when loading from local storage or file

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508dd7699083249a702a5cc105a6f2