### PR TITLE
Fix Gemini fallback trigger on Imagen 400

### DIFF
--- a/components/ImageVisualizer.tsx
+++ b/components/ImageVisualizer.tsx
@@ -129,7 +129,14 @@ const ImageVisualizer: React.FC<ImageVisualizerProps> = ({
       console.error("Error generating image:", err);
       const errorMessage = err instanceof Error ? err.message : "Unknown error during image generation.";
 
-      if (errorMessage.includes("Imagen API is only accessible to billed users")) {
+      // The Imagen API may respond with HTTP 400 when the request is not allowed
+      // for the current project. Treat it similarly to the explicit billing
+      // error so the Gemini fallback is attempted.
+      const isStatus400 =
+        typeof err === 'object' && err !== null && 'status' in err &&
+        Number((err as { status?: number | string }).status) === 400;
+
+      if (errorMessage.includes("Imagen API is only accessible to billed users") || isStatus400) {
         try {
           const fallbackResp = await ai.models.generateContentStream({
             model: 'gemini-2.0-flash-preview-image-generation',


### PR DESCRIPTION
## Summary
- detect 400 errors from Imagen
- run Gemini fallback image generation when 400 occurs

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685094f7e7348324836404668d2d8449