### PR TITLE
Fix hook export style

### DIFF
--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -5,7 +5,7 @@
 
 import React, { useMemo, useState, useRef } from 'react';
 import { MapNode, MapEdge } from '../../types';
-import useMapInteractions from '../../hooks/useMapInteractions';
+import { useMapInteractions } from '../../hooks/useMapInteractions';
 import {
   NODE_RADIUS,
   EDGE_HOVER_WIDTH,

--- a/hooks/useMapInteractions.ts
+++ b/hooks/useMapInteractions.ts
@@ -224,5 +224,3 @@ export const useMapInteractions = (
     handleTouchEnd,
   };
 };
-
-export default useMapInteractions;


### PR DESCRIPTION
## Summary
- use named export for `useMapInteractions` to match the other hooks
- update imports of `useMapInteractions`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a698f39c832494d61a8c5ed341bf