### PR TITLE
Consolidate model usage setup

### DIFF
--- a/hooks/useModelUsage.ts
+++ b/hooks/useModelUsage.ts
@@ -18,44 +18,31 @@ export interface ModelUsageInfo {
   limit: number;
 }
 
+const buildUsageMap = (): Record<string, ModelUsageInfo> => ({
+  [GEMINI_MODEL_NAME]: {
+    model: GEMINI_MODEL_NAME,
+    count: getModelUsageCount(GEMINI_MODEL_NAME),
+    limit: GEMINI_RATE_LIMIT_PER_MINUTE,
+  },
+  [AUXILIARY_MODEL_NAME]: {
+    model: AUXILIARY_MODEL_NAME,
+    count: getModelUsageCount(AUXILIARY_MODEL_NAME),
+    limit: AUXILIARY_RATE_LIMIT_PER_MINUTE,
+  },
+  [MINIMAL_MODEL_NAME]: {
+    model: MINIMAL_MODEL_NAME,
+    count: getModelUsageCount(MINIMAL_MODEL_NAME),
+    limit: MINIMAL_RATE_LIMIT_PER_MINUTE,
+  },
+});
+
 export const useModelUsage = () => {
-  const [usage, setUsage] = useState<Record<string, ModelUsageInfo>>(() => ({
-    [GEMINI_MODEL_NAME]: {
-      model: GEMINI_MODEL_NAME,
-      count: getModelUsageCount(GEMINI_MODEL_NAME),
-      limit: GEMINI_RATE_LIMIT_PER_MINUTE,
-    },
-    [AUXILIARY_MODEL_NAME]: {
-      model: AUXILIARY_MODEL_NAME,
-      count: getModelUsageCount(AUXILIARY_MODEL_NAME),
-      limit: AUXILIARY_RATE_LIMIT_PER_MINUTE,
-    },
-    [MINIMAL_MODEL_NAME]: {
-      model: MINIMAL_MODEL_NAME,
-      count: getModelUsageCount(MINIMAL_MODEL_NAME),
-      limit: MINIMAL_RATE_LIMIT_PER_MINUTE,
-    },
-  }));
+  const [usage, setUsage] = useState<Record<string, ModelUsageInfo>>(() =>
+    buildUsageMap(),
+  );
 
   useEffect(() => {
-    const update = () =>
-      setUsage({
-        [GEMINI_MODEL_NAME]: {
-          model: GEMINI_MODEL_NAME,
-          count: getModelUsageCount(GEMINI_MODEL_NAME),
-          limit: GEMINI_RATE_LIMIT_PER_MINUTE,
-        },
-        [AUXILIARY_MODEL_NAME]: {
-          model: AUXILIARY_MODEL_NAME,
-          count: getModelUsageCount(AUXILIARY_MODEL_NAME),
-          limit: AUXILIARY_RATE_LIMIT_PER_MINUTE,
-        },
-        [MINIMAL_MODEL_NAME]: {
-          model: MINIMAL_MODEL_NAME,
-          count: getModelUsageCount(MINIMAL_MODEL_NAME),
-          limit: MINIMAL_RATE_LIMIT_PER_MINUTE,
-        },
-      });
+    const update = () => setUsage(buildUsageMap());
 
     const unsub = subscribeToModelUsage(update);
     const intervalId = setInterval(update, 1000);


### PR DESCRIPTION
## Summary
- create `buildUsageMap` helper to construct usage state
- use the helper in the `useModelUsage` hook

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685144a520608324be2f51a87c9f750d