### PR TITLE
Refactor dialogue parsing helpers

### DIFF
--- a/services/dialogue/responseParser.ts
+++ b/services/dialogue/responseParser.ts
@@ -4,9 +4,9 @@
  */
 import { DialogueAIResponse, DialogueSummaryResponse } from '../../types';
 import { extractJsonFromFence, safeParseJson, coerceNullToUndefined } from '../../utils/jsonUtils';
-import { isValidNewItemSuggestion } from '../parsers/validation';
+import { trimDialogueHints } from '../../utils/dialogueParsing';
 
-export const parseDialogueAIResponse = (
+const parseDialogueResponse = (
   responseText: string,
   thoughts?: string[],
 ): DialogueAIResponse | null => {
@@ -47,45 +47,18 @@ export const parseDialogueAIResponse = (
   }
 };
 
+export const parseDialogueAIResponse = (
+  responseText: string,
+  thoughts?: string[],
+): DialogueAIResponse | null => {
+  return parseDialogueResponse(responseText, thoughts);
+};
+
 export const parseDialogueTurnResponse = (
   responseText: string,
   thoughts?: string[],
 ): DialogueAIResponse | null => {
-  const jsonStr = extractJsonFromFence(responseText);
-  const parsed = safeParseJson<Partial<DialogueAIResponse>>(jsonStr);
-  try {
-    if (!parsed) throw new Error('JSON parse failed');
-    if (
-      !parsed ||
-      !Array.isArray(parsed.npcResponses) ||
-      !parsed.npcResponses.every(
-        r => r && typeof r.speaker === 'string' && typeof r.line === 'string',
-      ) ||
-      !Array.isArray(parsed.playerOptions) ||
-      !parsed.playerOptions.every(o => typeof o === 'string') ||
-      (parsed.dialogueEnds !== undefined && typeof parsed.dialogueEnds !== 'boolean') ||
-      (parsed.updatedParticipants !== undefined && (!Array.isArray(parsed.updatedParticipants) || !parsed.updatedParticipants.every(p => typeof p === 'string')))
-    ) {
-      console.warn('Parsed dialogue JSON does not match DialogueAIResponse structure:', parsed);
-      return null;
-    }
-    if (parsed.playerOptions.length === 0) {
-      parsed.playerOptions = ['End Conversation.'];
-    }
-    const validated = parsed as DialogueAIResponse;
-    if (thoughts && thoughts.length > 0) {
-      validated.npcResponses.forEach((r, idx) => {
-        if (thoughts[idx]) {
-          r.thought = thoughts[idx];
-        }
-      });
-    }
-    return validated;
-  } catch (e) {
-    console.warn('Failed to parse dialogue JSON response from AI:', e);
-    console.debug('Original dialogue response text:', responseText);
-    return null;
-  }
+  return parseDialogueResponse(responseText, thoughts);
 };
 
 export const parseDialogueSummaryResponse = (
@@ -103,22 +76,7 @@ export const parseDialogueSummaryResponse = (
       itemChange: [],
     } as DialogueSummaryResponse;
 
-    if (validated.mapHint !== undefined) {
-      validated.mapHint = validated.mapHint.trim();
-    }
-    if (validated.playerItemsHint !== undefined) {
-      validated.playerItemsHint = validated.playerItemsHint.trim();
-    }
-    if (validated.worldItemsHint !== undefined) {
-      validated.worldItemsHint = validated.worldItemsHint.trim();
-    }
-    if (validated.npcItemsHint !== undefined) {
-      validated.npcItemsHint = validated.npcItemsHint.trim();
-    }
-
-    if (Array.isArray(validated.newItems)) {
-      validated.newItems = validated.newItems.filter(isValidNewItemSuggestion);
-    }
+    trimDialogueHints(validated);
 
     return validated;
   } catch (e) {

--- a/services/storyteller/responseParser.ts
+++ b/services/storyteller/responseParser.ts
@@ -10,9 +10,9 @@ import { MAIN_TURN_OPTIONS_COUNT } from '../../constants';
 import {
     isValidCharacterUpdate,
     isValidNewCharacterPayload,
-    isDialogueSetupPayloadStructurallyValid,
-    isValidNewItemSuggestion
+    isDialogueSetupPayloadStructurallyValid
 } from '../parsers/validation';
+import { trimDialogueHints } from '../../utils/dialogueParsing';
 import {
     fetchCorrectedName_Service,
     fetchCorrectedCharacterDetails_Service,
@@ -466,22 +466,7 @@ export async function parseAIResponse(
         validated.localTime = validated.localTime?.trim() || 'Time Unknown';
         validated.localEnvironment = validated.localEnvironment?.trim() || 'Environment Undetermined';
         validated.localPlace = validated.localPlace?.trim() || 'Undetermined Location';
-        if (validated.mapHint !== undefined) {
-            validated.mapHint = validated.mapHint.trim();
-        }
-        if (validated.playerItemsHint !== undefined) {
-            validated.playerItemsHint = validated.playerItemsHint.trim();
-        }
-        if (validated.worldItemsHint !== undefined) {
-            validated.worldItemsHint = validated.worldItemsHint.trim();
-        }
-        if (validated.npcItemsHint !== undefined) {
-            validated.npcItemsHint = validated.npcItemsHint.trim();
-        }
-
-        if (Array.isArray(validated.newItems)) {
-            validated.newItems = validated.newItems.filter(isValidNewItemSuggestion);
-        }
+        trimDialogueHints(validated);
 
         delete (validated as Record<string, unknown>).placesAdded;
         delete (validated as Record<string, unknown>).placesUpdated;

--- a/utils/dialogueParsing.ts
+++ b/utils/dialogueParsing.ts
@@ -1,0 +1,41 @@
+/**
+ * @file dialogueParsing.ts
+ * @description Shared helpers for trimming dialogue-related hints and new item suggestions.
+ */
+import { NewItemSuggestion } from '../types';
+import { isValidNewItemSuggestion } from '../services/parsers/validation';
+
+/**
+ * Interface describing optional dialogue hint fields that may be present
+ * on AI responses.
+ */
+export interface DialogueHints {
+  mapHint?: string;
+  playerItemsHint?: string;
+  worldItemsHint?: string;
+  npcItemsHint?: string;
+  newItems?: NewItemSuggestion[];
+}
+
+/**
+ * Trims whitespace from hint strings and filters invalid new item suggestions.
+ * The provided object is mutated and returned for convenience.
+ */
+export const trimDialogueHints = <T extends DialogueHints>(obj: T): T => {
+  if (obj.mapHint !== undefined) {
+    obj.mapHint = obj.mapHint.trim();
+  }
+  if (obj.playerItemsHint !== undefined) {
+    obj.playerItemsHint = obj.playerItemsHint.trim();
+  }
+  if (obj.worldItemsHint !== undefined) {
+    obj.worldItemsHint = obj.worldItemsHint.trim();
+  }
+  if (obj.npcItemsHint !== undefined) {
+    obj.npcItemsHint = obj.npcItemsHint.trim();
+  }
+  if (Array.isArray(obj.newItems)) {
+    obj.newItems = obj.newItems.filter(isValidNewItemSuggestion);
+  }
+  return obj;
+};


### PR DESCRIPTION
## Summary
- add shared `trimDialogueHints` utility
- deduplicate `parseDialogueAIResponse` and `parseDialogueTurnResponse`
- use `trimDialogueHints` in dialogue and storyteller parsers

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685146a42cb48324a2e72febc76bcbe1