### PR TITLE
Refactor map update normalization helpers

### DIFF
--- a/services/cartographer/mapUpdateUtils.ts
+++ b/services/cartographer/mapUpdateUtils.ts
@@ -1,11 +1,7 @@
-import type { AIMapUpdatePayload, MapNodeData, MapEdgeData } from '../../types';
-import {
-  VALID_NODE_STATUS_VALUES,
-  VALID_NODE_TYPE_VALUES,
-  VALID_EDGE_TYPE_VALUES,
-  VALID_EDGE_STATUS_VALUES,
-} from '../../constants';
-import { NODE_STATUS_SYNONYMS, NODE_TYPE_SYNONYMS, EDGE_TYPE_SYNONYMS, EDGE_STATUS_SYNONYMS } from '../../utils/mapSynonyms';
+import type { AIMapUpdatePayload, MapNodeData } from '../../types';
+import { VALID_NODE_TYPE_VALUES } from '../../constants';
+import { NODE_TYPE_SYNONYMS } from '../../utils/mapSynonyms';
+import { applyNodeDataFix, applyEdgeDataFix } from './normalizers';
 
 /**
  * Converts node/edge update operations that merely set a status suggesting removal
@@ -120,54 +116,13 @@ export function dedupeEdgeOps(payload: AIMapUpdatePayload): void {
 export function normalizeStatusAndTypeSynonyms(payload: AIMapUpdatePayload): string[] {
   const errors: string[] = [];
 
-  const nodeStatusSynonyms = NODE_STATUS_SYNONYMS;
-  const nodeTypeSynonyms = NODE_TYPE_SYNONYMS;
-  const edgeTypeSynonyms = EDGE_TYPE_SYNONYMS;
-  const edgeStatusSynonyms = EDGE_STATUS_SYNONYMS;
-
-  const applyNodeDataFix = (data: Partial<MapNodeData> | undefined, context: string): void => {
-    if (!data) return;
-    if (data.status) {
-      const mapped = nodeStatusSynonyms[data.status.toLowerCase()];
-      if (mapped) data.status = mapped;
-      if (!VALID_NODE_STATUS_VALUES.includes(data.status)) {
-        errors.push(`${context} invalid status "${data.status}"`);
-      }
-    }
-    if (data.nodeType) {
-      const mapped = nodeTypeSynonyms[data.nodeType.toLowerCase()];
-      if (mapped) data.nodeType = mapped;
-      if (!VALID_NODE_TYPE_VALUES.includes(data.nodeType)) {
-        errors.push(`${context} invalid nodeType "${data.nodeType}"`);
-      }
-    }
-  };
-
-  const applyEdgeDataFix = (data: Partial<MapEdgeData> | undefined, context: string): void => {
-    if (!data) return;
-    if (data.type) {
-      const mapped = edgeTypeSynonyms[data.type.toLowerCase()];
-      if (mapped) data.type = mapped;
-      if (!VALID_EDGE_TYPE_VALUES.includes(data.type)) {
-        errors.push(`${context} invalid type "${data.type}"`);
-      }
-    }
-    if (data.status) {
-      const mapped = edgeStatusSynonyms[data.status.toLowerCase()];
-      if (mapped) data.status = mapped;
-      if (!VALID_EDGE_STATUS_VALUES.includes(data.status)) {
-        errors.push(`${context} invalid status "${data.status}"`);
-      }
-    }
-  };
-
-  (payload.nodesToAdd || []).forEach((n, idx) => applyNodeDataFix(n.data, `nodesToAdd[${idx}]`));
-  (payload.nodesToUpdate || []).forEach((n, idx) => applyNodeDataFix(n.newData, `nodesToUpdate[${idx}].newData`));
-  (payload.edgesToAdd || []).forEach((e, idx) => applyEdgeDataFix(e.data, `edgesToAdd[${idx}]`));
-  (payload.edgesToUpdate || []).forEach((e, idx) => applyEdgeDataFix(e.newData, `edgesToUpdate[${idx}].newData`));
+  (payload.nodesToAdd || []).forEach((n, idx) => applyNodeDataFix(n.data, errors, `nodesToAdd[${idx}]`));
+  (payload.nodesToUpdate || []).forEach((n, idx) => applyNodeDataFix(n.newData, errors, `nodesToUpdate[${idx}].newData`));
+  (payload.edgesToAdd || []).forEach((e, idx) => applyEdgeDataFix(e.data, errors, `edgesToAdd[${idx}]`));
+  (payload.edgesToUpdate || []).forEach((e, idx) => applyEdgeDataFix(e.newData, errors, `edgesToUpdate[${idx}].newData`));
 
   if (payload.splitFamily && payload.splitFamily.newNodeType) {
-    const mapped = nodeTypeSynonyms[payload.splitFamily.newNodeType.toLowerCase()];
+    const mapped = NODE_TYPE_SYNONYMS[payload.splitFamily.newNodeType.toLowerCase()];
     if (mapped) payload.splitFamily.newNodeType = mapped as MapNodeData['nodeType'];
     if (!VALID_NODE_TYPE_VALUES.includes(payload.splitFamily.newNodeType)) {
       errors.push(`splitFamily.newNodeType invalid "${payload.splitFamily.newNodeType}"`);

--- a/services/cartographer/normalizers.ts
+++ b/services/cartographer/normalizers.ts
@@ -1,0 +1,63 @@
+import type { MapNodeData, MapEdgeData } from '../../types';
+import {
+  VALID_NODE_STATUS_VALUES,
+  VALID_NODE_TYPE_VALUES,
+  VALID_EDGE_TYPE_VALUES,
+  VALID_EDGE_STATUS_VALUES,
+} from '../../constants';
+import {
+  NODE_STATUS_SYNONYMS,
+  NODE_TYPE_SYNONYMS,
+  EDGE_TYPE_SYNONYMS,
+  EDGE_STATUS_SYNONYMS,
+} from '../../utils/mapSynonyms';
+
+/**
+ * Normalizes a MapNodeData object in place and records any invalid values.
+ */
+export const applyNodeDataFix = (
+  data: Partial<MapNodeData> | undefined,
+  errors: string[],
+  context: string,
+): void => {
+  if (!data) return;
+  if (data.status) {
+    const mapped = NODE_STATUS_SYNONYMS[data.status.toLowerCase()];
+    if (mapped) data.status = mapped;
+    if (!VALID_NODE_STATUS_VALUES.includes(data.status)) {
+      errors.push(`${context} invalid status "${data.status}"`);
+    }
+  }
+  if (data.nodeType) {
+    const mapped = NODE_TYPE_SYNONYMS[data.nodeType.toLowerCase()];
+    if (mapped) data.nodeType = mapped;
+    if (!VALID_NODE_TYPE_VALUES.includes(data.nodeType)) {
+      errors.push(`${context} invalid nodeType "${data.nodeType}"`);
+    }
+  }
+};
+
+/**
+ * Normalizes a MapEdgeData object in place and records any invalid values.
+ */
+export const applyEdgeDataFix = (
+  data: Partial<MapEdgeData> | undefined,
+  errors: string[],
+  context: string,
+): void => {
+  if (!data) return;
+  if (data.type) {
+    const mapped = EDGE_TYPE_SYNONYMS[data.type.toLowerCase()];
+    if (mapped) data.type = mapped;
+    if (!VALID_EDGE_TYPE_VALUES.includes(data.type)) {
+      errors.push(`${context} invalid type "${data.type}"`);
+    }
+  }
+  if (data.status) {
+    const mapped = EDGE_STATUS_SYNONYMS[data.status.toLowerCase()];
+    if (mapped) data.status = mapped;
+    if (!VALID_EDGE_STATUS_VALUES.includes(data.status)) {
+      errors.push(`${context} invalid status "${data.status}"`);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- extract node/edge data normalization into `normalizers.ts`
- reuse these helpers in `mapUpdateUtils` and `responseParser`
- import shared `normalizeStatusAndTypeSynonyms` implementation

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685155e66bcc8324845c27b18f983f6e