### PR TITLE
Fix map node discovery on visit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^9.28.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "ts-node": "^10.9.2",
         "typescript": "~5.8.3",
         "vite": "^6.2.0"
       }
@@ -47,6 +48,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -762,6 +776,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1111,6 +1153,34 @@
         "node": "*"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1418,6 +1488,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -1459,6 +1542,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1836,6 +1926,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1970,6 +2067,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -3704,6 +3811,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4850,6 +4964,50 @@
         "code-block-writer": "^11.0.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-prune": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.3.tgz",
@@ -5020,6 +5178,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",
@@ -5289,6 +5454,16 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint --ext .ts,.tsx .",
     "test": "npm run lint",
+    "test:unit": "ts-node tests/mapVisit.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
     "eslint": "^9.28.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "ts-node": "^10.9.2",
     "typescript": "~5.8.3",
     "vite": "^6.2.0"
   }

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -1,0 +1,95 @@
+import assert from 'assert';
+import { handleMapUpdates } from '../utils/mapUpdateHandlers.ts';
+import { structuredCloneGameState } from '../utils/cloneUtils.ts';
+import type { AdventureTheme, FullGameState, GameStateFromAI, MapData, TurnChanges, MapLayoutConfig, ThemeHistoryState } from '../types';
+
+const theme: AdventureTheme = { name: 'Kaiju Defense Force' } as AdventureTheme;
+
+const mapData: MapData = {
+  nodes: [
+    {
+      id: 'universe',
+      themeName: theme.name,
+      placeName: 'Universe',
+      position: { x: 0, y: 0 },
+      data: { description: 'root', status: 'discovered', nodeType: 'region' }
+    },
+    {
+      id: 'node_rim',
+      themeName: theme.name,
+      placeName: 'Neo-Atlantic Rim',
+      position: { x: 0, y: 0 },
+      data: { description: 'coast', status: 'rumored', nodeType: 'location', parentNodeId: 'universe' }
+    }
+  ],
+  edges: []
+};
+
+const baseState: FullGameState = {
+  saveGameVersion: '1',
+  currentThemeName: theme.name,
+  currentThemeObject: theme,
+  currentScene: '',
+  actionOptions: [],
+  mainQuest: null,
+  currentObjective: null,
+  inventory: [],
+  gameLog: [],
+  lastActionLog: null,
+  themeHistory: {} as ThemeHistoryState,
+  pendingNewThemeNameAfterShift: null,
+  allCharacters: [],
+  mapData: structuredCloneGameState(mapData),
+  currentMapNodeId: 'universe',
+  destinationNodeId: null,
+  mapLayoutConfig: {
+    IDEAL_EDGE_LENGTH: 50,
+    NESTED_PADDING: 10,
+    NESTED_ANGLE_PADDING: 0.15,
+    LABEL_MARGIN_PX: 10,
+    LABEL_LINE_HEIGHT_EM: 1.1,
+    LABEL_OVERLAP_MARGIN_PX: 2,
+    ITEM_ICON_SCALE: 0.3
+  } as MapLayoutConfig,
+  mapViewBox: '',
+  score: 0,
+  localTime: null,
+  localEnvironment: null,
+  localPlace: null,
+  turnsSinceLastShift: 0,
+  globalTurnNumber: 0,
+  dialogueState: null,
+  isCustomGameMode: false,
+  playerGender: 'neutral',
+  enabledThemePacks: [],
+  stabilityLevel: 0,
+  chaosLevel: 0,
+  objectiveAnimationType: null,
+  lastDebugPacket: null,
+  lastTurnChanges: null
+};
+
+const draftState: FullGameState = structuredCloneGameState(baseState);
+
+const aiData = {
+  currentMapNodeId: 'Neo-Atlantic Rim'
+} as Partial<GameStateFromAI> as GameStateFromAI;
+
+const turnChanges: TurnChanges = {
+  itemChanges: [],
+  characterChanges: [],
+  objectiveAchieved: false,
+  objectiveTextChanged: false,
+  mainQuestTextChanged: false,
+  localTimeChanged: false,
+  localEnvironmentChanged: false,
+  localPlaceChanged: false,
+  scoreChangedBy: 0
+};
+
+await handleMapUpdates(aiData, draftState, baseState, theme, null, () => {}, turnChanges);
+
+const updated = draftState.mapData.nodes.find(n => n.id === 'node_rim')!;
+assert.strictEqual(updated.data.status, 'discovered');
+assert.strictEqual(updated.data.visited, true);
+console.log('mapVisit.test passed');

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -176,6 +176,12 @@ export const handleMapUpdates = async (
     if (currentNodeIndex !== -1) {
       if (!draftState.mapData.nodes[currentNodeIndex].data.visited) {
         draftState.mapData.nodes[currentNodeIndex].data.visited = true;
+        if (
+          draftState.mapData.nodes[currentNodeIndex].data.status === 'rumored' ||
+          draftState.mapData.nodes[currentNodeIndex].data.status === 'undiscovered'
+        ) {
+          draftState.mapData.nodes[currentNodeIndex].data.status = 'discovered';
+        }
         if (!turnChanges.mapDataChanged) turnChanges.mapDataChanged = true;
       }
       const nodeMap = new Map(draftState.mapData.nodes.map(n => [n.id, n]));
@@ -185,6 +191,12 @@ export const handleMapUpdates = async (
         const idx = draftState.mapData.nodes.findIndex(n => n.id === ancestor.id);
         if (idx !== -1 && !draftState.mapData.nodes[idx].data.visited) {
           draftState.mapData.nodes[idx].data.visited = true;
+          if (
+            draftState.mapData.nodes[idx].data.status === 'rumored' ||
+            draftState.mapData.nodes[idx].data.status === 'undiscovered'
+          ) {
+            draftState.mapData.nodes[idx].data.status = 'discovered';
+          }
           if (!turnChanges.mapDataChanged) turnChanges.mapDataChanged = true;
         }
       }


### PR DESCRIPTION
## Summary
- update `handleMapUpdates` so visiting a rumored node marks it discovered
- add unit test covering visited/discovered logic
- install `ts-node` for running tests

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx ts-node tests/mapVisit.test.ts` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_68515d31d9108324a8c7bc5e8c05fe1b