### PR TITLE
Add correction heuristic test

### DIFF
--- a/tests/correctionHeuristics.test.ts
+++ b/tests/correctionHeuristics.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../services/modelDispatcher', () => ({
+  dispatchAIRequest: vi.fn(),
+}));
+
+import { dispatchAIRequest } from '../services/modelDispatcher';
+import { fetchCorrectedNodeType_Service } from '../services/corrections/placeDetails.ts';
+import { fetchCorrectedEdgeType_Service } from '../services/corrections/edgeFixes.ts';
+
+const mockedDispatch = vi.mocked(dispatchAIRequest);
+
+describe('correction heuristics', () => {
+  it('infers node and edge types without API calls', async () => {
+    const nodeType = await fetchCorrectedNodeType_Service({
+      placeName: 'Example',
+      nodeType: 'castle',
+    });
+    expect(nodeType).toBe('exterior');
+
+    const edgeType = await fetchCorrectedEdgeType_Service({
+      description: 'secret tunnel',
+    });
+    expect(edgeType).toBe('secret_passage');
+
+    expect(mockedDispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test that fetchCorrectedNodeType_Service and fetchCorrectedEdgeType_Service resolve using heuristics without API calls

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68517314bb948324b279388fdcfd64a0