### PR TITLE
Fix menu modals returning to game

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -149,6 +149,8 @@ const App: React.FC = () => {
     setIsMapVisible,
     userRequestedTitleMenuOpen,
     setUserRequestedTitleMenuOpen,
+    shouldReturnToTitleMenu,
+    setShouldReturnToTitleMenu,
     isHistoryVisible,
     setIsHistoryVisible,
     isDebugViewVisible,
@@ -291,26 +293,30 @@ const App: React.FC = () => {
 
   const openSettingsFromMenu = () => {
     setUserRequestedTitleMenuOpen(false);
+    setShouldReturnToTitleMenu(true);
     setIsSettingsVisible(true);
   };
 
   const closeSettings = () => {
     setIsSettingsVisible(false);
-    if (userRequestedTitleMenuOpen || !hasGameBeenInitialized) {
+    if (shouldReturnToTitleMenu || !hasGameBeenInitialized) {
       setUserRequestedTitleMenuOpen(true);
     }
+    setShouldReturnToTitleMenu(false);
   };
 
   const openInfoFromMenu = () => {
     setUserRequestedTitleMenuOpen(false);
+    setShouldReturnToTitleMenu(true);
     setIsInfoVisible(true);
   };
 
   const closeInfo = () => {
     setIsInfoVisible(false);
-    if (userRequestedTitleMenuOpen || !hasGameBeenInitialized) {
+    if (shouldReturnToTitleMenu || !hasGameBeenInitialized) {
       setUserRequestedTitleMenuOpen(true);
     }
+    setShouldReturnToTitleMenu(false);
   };
 
 

--- a/hooks/useModalState.ts
+++ b/hooks/useModalState.ts
@@ -13,6 +13,7 @@ export const useModalState = () => {
   const [isInfoVisible, setIsInfoVisible] = useState(false);
   const [isMapVisible, setIsMapVisible] = useState(false);
   const [userRequestedTitleMenuOpen, setUserRequestedTitleMenuOpen] = useState(false);
+  const [shouldReturnToTitleMenu, setShouldReturnToTitleMenu] = useState(false);
   const [isHistoryVisible, setIsHistoryVisible] = useState(false);
   const [isDebugViewVisible, setIsDebugViewVisible] = useState(false);
   const [isCustomGameSetupVisible, setIsCustomGameSetupVisible] = useState(false);
@@ -39,6 +40,8 @@ export const useModalState = () => {
     setIsMapVisible,
     userRequestedTitleMenuOpen,
     setUserRequestedTitleMenuOpen,
+    shouldReturnToTitleMenu,
+    setShouldReturnToTitleMenu,
     isHistoryVisible,
     setIsHistoryVisible,
     isDebugViewVisible,


### PR DESCRIPTION
## Summary
- track whether a modal was opened from the title menu
- reopen the menu when closing Settings or About if needed

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68517a8e6dfc8324837631df6576627d