### PR TITLE
Refactor progress events

### DIFF
--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -4,7 +4,8 @@
  * @description Loading spinner indicating in-progress actions.
  */
 import React from 'react';
-import { LoadingReason } from '../types'; // Import LoadingReason
+import { LoadingReason } from '../types';
+import { LOADING_REASON_UI_MAP } from '../constants';
 import { useLoadingProgress } from '../hooks/useLoadingProgress';
 
 interface LoadingSpinnerProps {
@@ -20,45 +21,12 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ loadingReason }) => {
   const spinnerClass = `${spinnerBaseClass} animate-spin border-sky-600`;
   const textColor = "text-sky-400";
   
-  let textMessage = "Loading..."; // Default
-  
-  switch (loadingReason) {
-    case 'initial_load':
-      textMessage = "Loading...";
-      break;
-    case 'reality_shift_load':
-      textMessage = "Reality is shifting...";
-      break;
-    case 'storyteller':
-      textMessage = "Dungeon Master is thinking...";
-      break;
-    case 'map':
-      textMessage = "Dungeon Master is drawing the map...";
-      break;
-    case 'correction':
-      textMessage = "Dungeon Master is fixing mistakes...";
-      break;
-    case 'inventory':
-      textMessage = "Dungeon Master is handling items...";
-      break;
-    case 'dialogue_turn':
-      textMessage = "The conversation continues...";
-      break;
-    case 'dialogue_summary': 
-      textMessage = "Concluding dialogue...";
-      break;
-    case 'dialogue_memory_creation': 
-      textMessage = "Forming memories...";
-      break;
-    case 'dialogue_conclusion_summary': 
-      textMessage = "Returning to the world...";
-      break;
-    default:
-      if (loadingReason === null) { 
-          textMessage = "Hmmmmmm...";
-      }
-      break;
-  }
+  const textMessage =
+    loadingReason && LOADING_REASON_UI_MAP[loadingReason]
+      ? LOADING_REASON_UI_MAP[loadingReason].text
+      : loadingReason === null
+      ? 'Hmmmmmm...'
+      : 'Loading...';
 
   const progressDisplay = progress
     ? progress + progress.split('').reverse().join('')

--- a/constants.ts
+++ b/constants.ts
@@ -69,6 +69,19 @@ export const LOADING_REASONS = [
   'reality_shift_load',
 ] as const;
 
+export const LOADING_REASON_UI_MAP: Record<(typeof LOADING_REASONS)[number], { text: string; icon: string }> = {
+  storyteller: { text: 'Dungeon Master is thinking...', icon: '██' },
+  map: { text: 'Dungeon Master is drawing the map...', icon: '▓▓' },
+  correction: { text: 'Dungeon Master is fixing mistakes...', icon: '○' },
+  inventory: { text: 'Dungeon Master is handling items...', icon: '░░' },
+  dialogue_turn: { text: 'The conversation continues...', icon: '○' },
+  dialogue_summary: { text: 'Concluding dialogue...', icon: '○' },
+  dialogue_memory_creation: { text: 'Forming memories...', icon: '○' },
+  dialogue_conclusion_summary: { text: 'Returning to the world...', icon: '○' },
+  initial_load: { text: 'Loading...', icon: '▒▒' },
+  reality_shift_load: { text: 'Reality is shifting...', icon: '▒▒' },
+};
+
 // Centralized map node/edge valid values
 
 export const VALID_NODE_STATUS_VALUES = [

--- a/hooks/useLoadingProgress.ts
+++ b/hooks/useLoadingProgress.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState, useCallback } from 'react';
-import { subscribeToProgress, clearProgress as clearFn, getProgress } from '../utils/loadingProgress';
+import { onProgress, offProgress, clearProgress as clearFn, getProgress } from '../utils/loadingProgress';
 
 export const useLoadingProgress = () => {
   const [progress, setProgress] = useState<string>(getProgress());
 
   useEffect(() => {
-    const unsub = subscribeToProgress(setProgress);
-    return unsub;
+    onProgress(setProgress);
+    return () => offProgress(setProgress);
   }, []);
 
   const clearProgress = useCallback(() => {

--- a/services/cartographer/request.ts
+++ b/services/cartographer/request.ts
@@ -7,6 +7,7 @@ import {
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
   MAX_RETRIES,
+  LOADING_REASON_UI_MAP,
 } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { isApiConfigured } from '../apiClient';
@@ -39,7 +40,7 @@ export const executeMapUpdateRequest = async (
     throw new Error('API Key not configured.');
   }
   const result = await retryAiCall<GenerateContentResponse>(async () => {
-    addProgressSymbol('▓▓');
+    addProgressSymbol(LOADING_REASON_UI_MAP['map'].icon);
     const { response } = await dispatchAIRequest({
       modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
       prompt,

--- a/services/corrections/character.ts
+++ b/services/corrections/character.ts
@@ -12,7 +12,7 @@ import {
   GEMINI_MODEL_NAME,
 } from '../../constants';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
-import { CORRECTION_TEMPERATURE } from '../../constants';
+import { CORRECTION_TEMPERATURE, LOADING_REASON_UI_MAP } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
@@ -78,7 +78,7 @@ Constraints:
 
   return retryAiCall<CorrectedCharacterDetails>(async attempt => {
     try {
-      addProgressSymbol('●');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -173,7 +173,7 @@ Example Response: If unclear from context, respond with a generic but plausible 
 
   return retryAiCall<string>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -15,6 +15,7 @@ import { isDialogueSetupPayloadStructurallyValid } from '../parsers/validation';
 import { CORRECTION_TEMPERATURE } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
+import { LOADING_REASON_UI_MAP } from '../../constants';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
 import { isApiConfigured } from '../apiClient';
 import { retryAiCall } from '../../utils/retry';
@@ -74,7 +75,7 @@ Respond ONLY with the single, complete, corrected JSON object for 'dialogueSetup
 
   return retryAiCall<DialogueSetupPayload>(async attempt => {
     try {
-      addProgressSymbol('●');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -145,7 +146,7 @@ Respond ONLY with the corrected JSON object.`;
 
   return retryAiCall<DialogueAIResponse>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/corrections/edgeFixes.ts
+++ b/services/corrections/edgeFixes.ts
@@ -16,6 +16,7 @@ import {
 import { dispatchAIRequest } from '../modelDispatcher';
 import { CORRECTION_TEMPERATURE } from '../../constants';
 import { addProgressSymbol } from '../../utils/loadingProgress';
+import { LOADING_REASON_UI_MAP } from '../../constants';
 import { retryAiCall } from '../../utils/retry';
 import { isApiConfigured } from '../apiClient';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
@@ -56,7 +57,7 @@ Respond ONLY with the single edge type.`;
   const systemInstruction = `Infer a map edge's type. Answer with one of: ${VALID_EDGE_TYPE_VALUES.join(', ')}.`;
   return retryAiCall<MapEdgeData['type']>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -115,7 +116,7 @@ export const fetchConnectorChains_Service = async (
     themeNodes: MapNode[];
   },
 ): Promise<ConnectorChainsServiceResult> => {
-  addProgressSymbol('▒▒');
+  addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
   if (!isApiConfigured() || requests.length === 0)
     return { payload: null, debugInfo: null };
 

--- a/services/corrections/hierarchyUpgrade.ts
+++ b/services/corrections/hierarchyUpgrade.ts
@@ -10,7 +10,7 @@ import {
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
 } from '../../constants';
-import { CORRECTION_TEMPERATURE } from '../../constants';
+import { CORRECTION_TEMPERATURE, LOADING_REASON_UI_MAP } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
@@ -37,7 +37,7 @@ Choose the best fix: "convert_child" to make the child a sibling, or "upgrade_pa
 
   return retryAiCall<'convert_child' | 'upgrade_parent'>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -87,7 +87,7 @@ Return JSON {"originalChildren": ["ids"], "newChildren": ["ids"]}`;
 
   const result = await retryAiCall<{ originalChildren: string[]; newChildren: string[] }>(async () => {
     try {
-      addProgressSymbol('●');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/corrections/inventory.ts
+++ b/services/corrections/inventory.ts
@@ -10,7 +10,7 @@ import {
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
 } from '../../constants';
-import { CORRECTION_TEMPERATURE } from '../../constants';
+import { CORRECTION_TEMPERATURE, LOADING_REASON_UI_MAP } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { isApiConfigured } from '../apiClient';
@@ -66,7 +66,7 @@ Task: Provide ONLY the corrected JSON array of ItemChange objects.`;
 
   return retryAiCall<ItemChange[]>(async attempt => {
     try {
-      addProgressSymbol('●');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -11,7 +11,7 @@ import {
   GEMINI_MODEL_NAME,
 } from '../../constants';
 import { isValidItem } from '../parsers/validation';
-import { CORRECTION_TEMPERATURE } from '../../constants';
+import { CORRECTION_TEMPERATURE, LOADING_REASON_UI_MAP } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
@@ -125,7 +125,7 @@ Respond ONLY with the single, complete, corrected JSON object for the 'item' fie
 
   return retryAiCall<Item>(async attempt => {
     try {
-      addProgressSymbol('●');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -207,7 +207,7 @@ If no action can be confidently determined, respond with an empty string.`;
 
   return retryAiCall<ItemChange['action']>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/corrections/name.ts
+++ b/services/corrections/name.ts
@@ -9,7 +9,7 @@ import {
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
 } from '../../constants';
-import { CORRECTION_TEMPERATURE } from '../../constants';
+import { CORRECTION_TEMPERATURE, LOADING_REASON_UI_MAP } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { retryAiCall } from '../../utils/retry';
@@ -57,7 +57,7 @@ If no suitable match can be confidently made, respond with an empty string.`;
 
   return retryAiCall<string>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/corrections/placeDetails.ts
+++ b/services/corrections/placeDetails.ts
@@ -10,7 +10,7 @@ import {
   ALIAS_INSTRUCTION,
 } from '../../constants';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
-import { CORRECTION_TEMPERATURE } from '../../constants';
+import { CORRECTION_TEMPERATURE, LOADING_REASON_UI_MAP } from '../../constants';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
@@ -64,7 +64,7 @@ Respond ONLY with the inferred "localPlace" as a single string.`;
 
   return retryAiCall<string>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -153,7 +153,7 @@ Respond ONLY with the single, complete, corrected JSON object.`;
   return retryAiCall<{ name: string; description: string; aliases?: string[] }>(
     async attempt => {
       try {
-        addProgressSymbol('●');
+        addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
         const { response } = await dispatchAIRequest({
           modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
           prompt,
@@ -230,7 +230,7 @@ Respond ONLY with the single, complete JSON object.`;
   return retryAiCall<{ name: string; description: string; aliases?: string[] }>(
     async attempt => {
       try {
-        addProgressSymbol('●');
+        addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
         const { response } = await dispatchAIRequest({
           modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
           prompt,
@@ -313,7 +313,7 @@ Respond ONLY with the single node type.`;
   const systemInstruction = `Infer a map node's type. Answer with one of: ${VALID_NODE_TYPE_VALUES.join(', ')}.`;
   return retryAiCall<NonNullable<MapNodeData['nodeType']>>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -402,7 +402,7 @@ Respond ONLY with the name or id of the best parent node, or "Universe" if none.
 
   return retryAiCall<string>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,
@@ -448,7 +448,7 @@ Known map nodes in the current theme:\n${nodeList}\nChoose the most likely inten
 
   return retryAiCall<string>(async attempt => {
     try {
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['correction'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
         prompt,

--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -21,7 +21,7 @@ import { dispatchAIRequest } from '../modelDispatcher';
 import { isServerOrClientError } from '../../utils/aiErrorUtils';
 import { fetchCorrectedDialogueTurn_Service } from '../corrections';
 import { CORRECTION_TEMPERATURE } from '../../constants';
-import { MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME } from '../../constants';
+import { MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME, LOADING_REASON_UI_MAP } from '../../constants';
 import { addProgressSymbol } from '../../utils/loadingProgress';
 import { isApiConfigured } from '../apiClient';
 import { buildDialogueTurnPrompt, buildDialogueSummaryPrompt, buildDialogueMemorySummaryPrompts } from './promptBuilder';
@@ -224,7 +224,7 @@ export const executeMemorySummary = async (
   for (let attempt = 1; attempt <= MAX_RETRIES + 1; ) {
     try {
       console.log(`Generating memory summary for dialogue with ${context.dialogueParticipants.join(', ')}, Attempt ${attempt}/${MAX_RETRIES + 1})`);
-      addProgressSymbol('○');
+      addProgressSymbol(LOADING_REASON_UI_MAP['dialogue_memory_creation'].icon);
       const { response } = await dispatchAIRequest({
         modelNames: [MINIMAL_MODEL_NAME, AUXILIARY_MODEL_NAME],
         prompt: userPromptPart,

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -4,7 +4,7 @@
  */
 
 import { GenerateContentResponse } from '@google/genai';
-import { MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME } from '../../constants';
+import { MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME, LOADING_REASON_UI_MAP } from '../../constants';
 import { SYSTEM_INSTRUCTION } from './systemPrompt';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { isApiConfigured } from '../apiClient';
@@ -24,7 +24,7 @@ export const executeInventoryRequest = async (
     console.error('API Key not configured for Inventory Service.');
     return Promise.reject(new Error('API Key not configured.'));
   }
-  addProgressSymbol('░░');
+  addProgressSymbol(LOADING_REASON_UI_MAP['inventory'].icon);
   const { response } = await dispatchAIRequest({
     modelNames: [MINIMAL_MODEL_NAME, GEMINI_MODEL_NAME],
     prompt,

--- a/services/storyteller/api.ts
+++ b/services/storyteller/api.ts
@@ -5,7 +5,7 @@
  */
 import { GenerateContentResponse } from "@google/genai";
 import { AdventureTheme } from '../../types';
-import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES } from '../../constants';
+import { GEMINI_MODEL_NAME, AUXILIARY_MODEL_NAME, MAX_RETRIES, LOADING_REASON_UI_MAP } from '../../constants';
 import { SYSTEM_INSTRUCTION } from './systemPrompt';
 import { dispatchAIRequest } from '../modelDispatcher';
 import { isApiConfigured } from '../apiClient';
@@ -17,7 +17,7 @@ export const executeAIMainTurn = async (
     fullPrompt: string,
     themeSystemInstructionModifier: string | undefined // Retain as string for direct use
 ): Promise<{ response: GenerateContentResponse; thoughts: string[] }> => {
-    addProgressSymbol('██');
+    addProgressSymbol(LOADING_REASON_UI_MAP['storyteller'].icon);
     if (!isApiConfigured()) {
       console.error("API Key not configured for Gemini Service.");
       return Promise.reject(new Error("API Key not configured."));

--- a/utils/loadingProgress.ts
+++ b/utils/loadingProgress.ts
@@ -1,22 +1,28 @@
 let progressString = '';
-let subscribers: Array<(s: string) => void> = [];
+const listeners: Array<(s: string) => void> = [];
 
-export const subscribeToProgress = (fn: (s: string) => void): (() => void) => {
-  subscribers.push(fn);
+const emit = () => {
+  listeners.forEach(fn => fn(progressString));
+};
+
+export const onProgress = (fn: (s: string) => void): void => {
+  listeners.push(fn);
   fn(progressString);
-  return () => {
-    subscribers = subscribers.filter((s) => s !== fn);
-  };
 };
 
-export const addProgressSymbol = (sym: string) => {
+export const offProgress = (fn: (s: string) => void): void => {
+  const idx = listeners.indexOf(fn);
+  if (idx !== -1) listeners.splice(idx, 1);
+};
+
+export const addProgressSymbol = (sym: string): void => {
   progressString = sym + progressString;
-  subscribers.forEach((fn) => fn(progressString));
+  emit();
 };
 
-export const clearProgress = () => {
+export const clearProgress = (): void => {
   progressString = '';
-  subscribers.forEach((fn) => fn(progressString));
+  emit();
 };
 
 export const getProgress = () => progressString;


### PR DESCRIPTION
## Summary
- use a simple event emitter to track loading progress
- centralize spinner text and progress icons
- expose `onProgress`/`offProgress` helpers
- update service modules to use the shared lookup

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68517d93f3748324859bf410e759c1ec