### PR TITLE
Add heuristics tests and item type normalization

### DIFF
--- a/tests/itemChangeParsing.test.ts
+++ b/tests/itemChangeParsing.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { parseInventoryResponse } from '../services/inventory/responseParser';
+
+const PLAYER = 'player';
+
+describe('parseInventoryResponse', () => {
+  it('filters invalid ItemChange entries', () => {
+    const rawPayload = {
+      itemChanges: [
+        { action: 'gain', item: { name: 'Lantern', type: 'equipment', description: 'Bright', holderId: PLAYER } },
+        { action: 'gain', item: { name: 'BadItem', type: 'invalid', description: 'oops', holderId: PLAYER } },
+        { action: 'update', item: { name: 'Lantern', newName: 'Bright Lantern', holderId: PLAYER } },
+        { action: 'update', item: { newName: 'No Name' } },
+        { action: 'destroy', item: { id: 'old1', name: 'Old Lantern' } },
+        { action: 'destroy', item: null },
+        { action: 'give', item: { id: 'gift1', fromId: PLAYER, toId: 'npc1' } },
+        { action: 'take', item: { id: 'gift2', fromId: 'npc2', toId: PLAYER } },
+        { action: 'give', item: { id: 5, fromId: PLAYER } },
+        { action: 123, item: { name: 'Bad', type: 'equipment', description: 'x', holderId: PLAYER } },
+        { action: 'gain', item: 'not object' },
+      ],
+      observations: 'obs',
+      rationale: 'why',
+    };
+
+    const responseText = "```json\n" + JSON.stringify(rawPayload) + "\n```";
+    const result = parseInventoryResponse(responseText)!
+
+    expect(result.itemChanges.length).toBe(5);
+    expect(result.itemChanges).toEqual([
+      rawPayload.itemChanges[0],
+      rawPayload.itemChanges[2],
+      rawPayload.itemChanges[4],
+      rawPayload.itemChanges[6],
+      rawPayload.itemChanges[7],
+    ]);
+    expect(result.observations).toBe('obs');
+    expect(result.rationale).toBe('why');
+  });
+
+  it('handles update rename and destroy heuristics with put action', () => {
+    const payload = {
+      itemChanges: [
+        { action: 'update', item: { id: 'i1', name: 'Old Sword', newName: 'Shiny Sword' } },
+        { action: 'update', item: { id: 'i2', name: 'Old Shield' } },
+        { action: 'update', item: { id: 'i3', name: 'Broken Torch', type: 'destroyed' } },
+        { action: 'update', item: { id: 'i4', name: 'Lost Ring', status: 'gone' } },
+        { action: 'put', item: { name: 'Lantern', type: 'Equipment', description: 'Bright', holderId: 'node1' } },
+      ],
+    };
+
+    const text = '```json\n' + JSON.stringify(payload) + '\n```';
+    const res = parseInventoryResponse(text)!;
+
+    expect(res.itemChanges).toEqual([
+      payload.itemChanges[0],
+      payload.itemChanges[1],
+      { action: 'destroy', item: { id: 'i3', name: 'Broken Torch' } },
+      { action: 'destroy', item: { id: 'i4', name: 'Lost Ring' } },
+      { action: 'put', item: { name: 'Lantern', type: 'equipment', description: 'Bright', holderId: 'node1' } },
+    ]);
+  });
+});

--- a/tests/newItemSuggestions.test.ts
+++ b/tests/newItemSuggestions.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { trimDialogueHints, type DialogueHints } from '../utils/dialogueParsing';
+import type { NewItemSuggestion } from '../types';
+
+describe('trimDialogueHints', () => {
+  it('filters out invalid newItems and trims hints', () => {
+    const obj = {
+      mapHint: '  the map  ',
+      playerItemsHint: '  gained  ',
+      npcItemsHint: '  npc hint ',
+      newItems: [
+        { name: 'Torch', type: 'equipment', description: 'A trusty torch' },
+        { name: '', type: 'equipment', description: 'Bad' }, // invalid name
+        { name: 'Rope', description: 'Missing type' }, // missing type
+        { name: 'Hammer', type: 'tool', description: 'Wrong type' }, // invalid type
+        null as unknown as object, // null entry
+        { name: 'Rug', type: 'equipment', description: '' }, // empty description
+      ],
+    } as unknown as DialogueHints;
+
+    const result = trimDialogueHints(obj);
+
+    expect(result.mapHint).toBe('the map');
+    expect(result.playerItemsHint).toBe('gained');
+    expect(result.npcItemsHint).toBe('npc hint');
+    expect(result.newItems).toEqual([
+      { name: 'Torch', type: 'equipment', description: 'A trusty torch' },
+      { name: 'Hammer', type: 'equipment', description: 'Wrong type' },
+    ]);
+  });
+
+  it('normalizes item type synonyms and removes invalid ones', () => {
+    const obj: DialogueHints = {
+      newItems: [
+        { name: 'Potion', type: 'single use', description: 'Heal' } as unknown as NewItemSuggestion,
+        { name: 'Bow', type: 'Weapon', description: 'Range' } as unknown as NewItemSuggestion,
+        { name: 'Rock', type: 'rubbish', description: 'Junk' } as unknown as NewItemSuggestion,
+        { name: 'Toolkit', type: 'tool', description: 'fix' } as unknown as NewItemSuggestion,
+      ],
+    };
+
+    const result = trimDialogueHints(obj);
+    expect(result.newItems).toEqual([
+      { name: 'Potion', type: 'single-use', description: 'Heal' },
+      { name: 'Bow', type: 'weapon', description: 'Range' },
+      { name: 'Toolkit', type: 'equipment', description: 'fix' },
+    ]);
+  });
+});

--- a/utils/itemSynonyms.ts
+++ b/utils/itemSynonyms.ts
@@ -1,0 +1,37 @@
+import { ItemType } from '../types';
+import { VALID_ITEM_TYPES } from '../constants';
+
+export const ITEM_TYPE_SYNONYMS: Record<string, ItemType> = {
+  'single use': 'single-use',
+  'single-use item': 'single-use',
+  'one use': 'single-use',
+  'multi use': 'multi-use',
+  'multi-use item': 'multi-use',
+  gear: 'equipment',
+  armour: 'equipment',
+  armor: 'equipment',
+  tool: 'equipment',
+  ammo: 'ammunition',
+  ammunition: 'ammunition',
+  projectiles: 'ammunition',
+};
+
+export const DESTROY_SYNONYMS = new Set([
+  'destroyed',
+  'consumed',
+  'deleted',
+  'removed',
+  'lost',
+  'gone',
+  'broken',
+]);
+
+export function normalizeItemType(type: unknown): ItemType | null {
+  if (typeof type !== 'string') return null;
+  const lower = type.toLowerCase().trim();
+  if ((VALID_ITEM_TYPES as readonly string[]).includes(lower as ItemType)) {
+    return lower as ItemType;
+  }
+  const mapped = ITEM_TYPE_SYNONYMS[lower];
+  return mapped || null;
+}


### PR DESCRIPTION
## Summary
- support item type synonyms in validation
- convert update actions to destroy for destroy-type/status
- test type synonym handling in dialogue hints
- test update rename/destroy heuristics including `put` action

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6851820c74008324a51d064e19d13a62