### PR TITLE
Refactor tooltip position calculation

### DIFF
--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -3,7 +3,7 @@
  * @description SVG view rendering map nodes and edges with tooltip interactions.
  */
 
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState, useRef, useLayoutEffect } from 'react';
 import { MapNode, MapEdge } from '../../types';
 import { useMapInteractions } from '../../hooks/useMapInteractions';
 import {
@@ -161,18 +161,25 @@ const MapNodeView: React.FC<MapNodeViewProps> = ({
   const tooltipTimeout = useRef<number | null>(null);
   const TOOLTIP_DELAY_MS = 250;
 
+  const [tooltipScreenPosition, setTooltipScreenPosition] = useState<
+    { x: number; y: number } | null
+  >(null);
+
   // Recalculate tooltip position when viewBox changes so it stays anchored
   // during panning or zooming.
-  const tooltipScreenPosition = useMemo(() => {
-    if (!tooltip || !svgRef.current) return null;
+  useLayoutEffect(() => {
+    if (!tooltip || !svgRef.current) {
+      setTooltipScreenPosition(null);
+      return;
+    }
     const { x, y } = getScreenCoordinates(
       svgRef.current,
       tooltip.svgX,
       tooltip.svgY
     );
     const rect = svgRef.current.getBoundingClientRect();
-    return { x: x - rect.left, y: y - rect.top };
-  }, [tooltip, viewBox, svgRef]); // eslint-disable-line react-hooks/exhaustive-deps
+    setTooltipScreenPosition({ x: x - rect.left, y: y - rect.top });
+  }, [tooltip, viewBox, svgRef]);
 
   const isSmallFontType = (type: string | undefined) =>
     type === 'feature' || type === 'room' || type === 'interior';


### PR DESCRIPTION
## Summary
- update MapNodeView tooltip logic to use `useLayoutEffect` and state
- remove eslint disable comment now that dependencies match

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685193dac8a08324b8d0f93e7a544716