### PR TITLE
Refactor player action helpers

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -27,7 +27,7 @@ import {
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { getDefaultMapLayoutConfig } from './useMapUpdates';
 import { DEFAULT_VIEWBOX } from '../utils/mapConstants';
-import { ProcessAiResponseFn } from './usePlayerActions';
+import { ProcessAiResponseFn } from './useProcessAiResponse';
 
 export interface LoadInitialGameOptions {
   isRestart?: boolean;

--- a/hooks/useInventoryActions.ts
+++ b/hooks/useInventoryActions.ts
@@ -1,0 +1,127 @@
+import { useCallback } from 'react';
+import {
+  FullGameState,
+  ItemChangeRecord,
+  TurnChanges,
+} from '../types';
+import { PLAYER_HOLDER_ID, MAX_LOG_MESSAGES } from '../constants';
+import { structuredCloneGameState } from '../utils/cloneUtils';
+import { addLogMessageToList } from '../utils/gameLogicUtils';
+import { getAdjacentNodeIds } from '../utils/mapGraphUtils';
+
+export interface UseInventoryActionsProps {
+  getCurrentGameState: () => FullGameState;
+  commitGameState: (state: FullGameState) => void;
+  isLoading: boolean;
+}
+
+export const useInventoryActions = ({
+  getCurrentGameState,
+  commitGameState,
+  isLoading,
+}: UseInventoryActionsProps) => {
+  const handleDropItem = useCallback(
+    (itemName: string, logMessageOverride?: string) => {
+      const currentFullState = getCurrentGameState();
+      if (isLoading || currentFullState.dialogueState) return;
+
+      const itemToDiscard = currentFullState.inventory.find(
+        (item) => item.name === itemName && item.holderId === PLAYER_HOLDER_ID,
+      );
+      if (!itemToDiscard) return;
+
+      const draftState = structuredCloneGameState(currentFullState);
+      const currentLocationId = currentFullState.currentMapNodeId || 'unknown';
+      draftState.inventory = draftState.inventory.map((item) =>
+        item.name === itemName && item.holderId === PLAYER_HOLDER_ID
+          ? { ...item, holderId: currentLocationId }
+          : item,
+      );
+      const itemChangeRecord: ItemChangeRecord = { type: 'loss', lostItem: { ...itemToDiscard } };
+      const turnChangesForDiscard: TurnChanges = {
+        itemChanges: [itemChangeRecord],
+        characterChanges: [],
+        objectiveAchieved: false,
+        objectiveTextChanged: false,
+        mainQuestTextChanged: false,
+        localTimeChanged: false,
+        localEnvironmentChanged: false,
+        localPlaceChanged: false,
+        currentMapNodeIdChanged: false,
+        scoreChangedBy: 0,
+        mapDataChanged: false,
+      };
+      draftState.lastTurnChanges = turnChangesForDiscard;
+
+      let logMessage = logMessageOverride;
+      if (!logMessage) {
+        const placeName =
+          currentFullState.mapData.nodes.find((n) => n.id === currentLocationId)?.placeName ||
+          currentFullState.localPlace ||
+          'Unknown Place';
+        if (itemToDiscard.type === 'vehicle' && !itemToDiscard.isActive) {
+          logMessage = `You left your ${itemName} parked at ${placeName}.`;
+        } else {
+          logMessage = `You left your ${itemName} at ${placeName}.`;
+        }
+      }
+
+      if (logMessage) {
+        draftState.gameLog = addLogMessageToList(draftState.gameLog, logMessage, MAX_LOG_MESSAGES);
+        draftState.lastActionLog = logMessage;
+      }
+      commitGameState(draftState);
+    },
+    [getCurrentGameState, commitGameState, isLoading],
+  );
+
+  const handleTakeLocationItem = useCallback(
+    (itemName: string) => {
+      const currentFullState = getCurrentGameState();
+      if (isLoading || currentFullState.dialogueState) return;
+
+      const currentLocationId = currentFullState.currentMapNodeId;
+      if (!currentLocationId) return;
+
+      const adjacentIds = getAdjacentNodeIds(currentFullState.mapData, currentLocationId);
+      const itemToTake = currentFullState.inventory.find((item) => {
+        if (item.name !== itemName) return false;
+        if (item.holderId === currentLocationId) return true;
+        return adjacentIds.includes(item.holderId);
+      });
+      if (!itemToTake) return;
+
+      const draftState = structuredCloneGameState(currentFullState);
+      draftState.inventory = draftState.inventory.map((item) =>
+        item.name === itemName && item.holderId === itemToTake.holderId
+          ? { ...item, holderId: PLAYER_HOLDER_ID }
+          : item,
+      );
+
+      const itemChangeRecord: ItemChangeRecord = {
+        type: 'gain',
+        gainedItem: { ...itemToTake, holderId: PLAYER_HOLDER_ID },
+      };
+      const turnChangesForTake: TurnChanges = {
+        itemChanges: [itemChangeRecord],
+        characterChanges: [],
+        objectiveAchieved: false,
+        objectiveTextChanged: false,
+        mainQuestTextChanged: false,
+        localTimeChanged: false,
+        localEnvironmentChanged: false,
+        localPlaceChanged: false,
+        currentMapNodeIdChanged: false,
+        scoreChangedBy: 0,
+        mapDataChanged: false,
+      };
+      draftState.lastTurnChanges = turnChangesForTake;
+      commitGameState(draftState);
+    },
+    [getCurrentGameState, commitGameState, isLoading],
+  );
+
+  return { handleDropItem, handleTakeLocationItem };
+};
+
+export type InventoryActions = ReturnType<typeof useInventoryActions>;

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -3,19 +3,13 @@
  * @description Hook that handles player actions and AI response processing.
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import {
-  GameStateFromAI,
-  Item,
-  ItemReference,
   KnownUse,
-  AdventureTheme,
+  Item,
   FullGameState,
   GameStateStack,
-  ItemChange,
-  ItemChangeRecord,
   LoadingReason,
-  TurnChanges,
 } from '../types';
 import {
   executeAIMainTurn,
@@ -23,39 +17,15 @@ import {
   buildMainGameTurnPrompt
 } from '../services/storyteller';
 import { isServerOrClientError, extractStatusFromError } from '../utils/aiErrorUtils';
-import { fetchCorrectedName_Service } from '../services/corrections';
 import {
   FREE_FORM_ACTION_COST,
-  MAX_LOG_MESSAGES,
   RECENT_LOG_COUNT_FOR_PROMPT,
   PLAYER_HOLDER_ID,
 } from '../constants';
-import {
-  addLogMessageToList,
-  buildItemChangeRecords,
-  applyAllItemChanges,
-} from '../utils/gameLogicUtils';
+
 import { structuredCloneGameState } from '../utils/cloneUtils';
-import { useMapUpdateProcessor } from './useMapUpdateProcessor';
-import { formatInventoryForPrompt } from '../utils/promptFormatters/inventory';
-import { formatLimitedMapContextForPrompt } from '../utils/promptFormatters/map';
-import { getAdjacentNodeIds } from '../utils/mapGraphUtils';
-import { applyInventoryHints_Service } from '../services/inventory';
-
-export interface ProcessAiResponseOptions {
-  forceEmptyInventory?: boolean;
-  baseStateSnapshot: FullGameState;
-  isFromDialogueSummary?: boolean;
-  scoreChangeFromAction?: number;
-  playerActionText?: string;
-}
-
-export type ProcessAiResponseFn = (
-  aiData: GameStateFromAI | null,
-  themeContextForResponse: AdventureTheme | null,
-  draftState: FullGameState,
-  options: ProcessAiResponseOptions
-) => Promise<void>;
+import { useProcessAiResponse } from './useProcessAiResponse';
+import { useInventoryActions } from './useInventoryActions';
 
 export interface UsePlayerActionsProps {
   getCurrentGameState: () => FullGameState;
@@ -101,272 +71,18 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     loadingReason,
   } = props;
 
-  const { processMapUpdates } = useMapUpdateProcessor({
+  const { processAiResponse, clearObjectiveAnimationTimer } = useProcessAiResponse({
     loadingReason,
     setLoadingReason,
     setError,
+    setGameStateStack,
   });
-  const objectiveAnimationClearTimerRef = useRef<number | null>(null);
 
-  const processAiResponse: ProcessAiResponseFn = useCallback(
-    async (
-      aiData,
-      themeContextForResponse,
-      draftState,
-      options
-    ) => {
-      const { baseStateSnapshot, isFromDialogueSummary = false, scoreChangeFromAction = 0, playerActionText } = options;
-
-      const turnChanges: TurnChanges = {
-        itemChanges: [],
-        characterChanges: [],
-        objectiveAchieved: false,
-        objectiveTextChanged: false,
-        mainQuestTextChanged: false,
-        localTimeChanged: false,
-        localEnvironmentChanged: false,
-        localPlaceChanged: false,
-        currentMapNodeIdChanged: false,
-        scoreChangedBy: scoreChangeFromAction,
-        mapDataChanged: false,
-      };
-
-      if (!aiData) {
-        setError('The Dungeon Master\'s connection is unstable... (Invalid AI response after retries)');
-        if (!isFromDialogueSummary && 'actionOptions' in draftState) {
-          draftState.actionOptions = [
-            'Try to wait for the connection to improve.',
-            'Consult the ancient network spirits.',
-            'Check your own connection.',
-            'Sigh dramatically.',
-          ];
-        }
-        draftState.lastActionLog = 'The Dungeon Master seems to be having trouble communicating the outcome of your last action.';
-        draftState.localTime = draftState.localTime ?? 'Time Unknown';
-        draftState.localEnvironment = draftState.localEnvironment ?? 'Environment Undetermined';
-        draftState.localPlace = draftState.localPlace ?? 'Undetermined Location';
-        draftState.lastTurnChanges = turnChanges;
-        draftState.dialogueState = null;
-        return;
-      }
-
-      draftState.lastDebugPacket = {
-        ...(draftState.lastDebugPacket ?? {}),
-        prompt:
-          draftState.lastDebugPacket?.prompt ||
-          'Prompt not captured for this state transition',
-        rawResponseText:
-          draftState.lastDebugPacket?.rawResponseText || 'Raw text not captured',
-        parsedResponse: aiData,
-        timestamp: new Date().toISOString(),
-        mapUpdateDebugInfo: null,
-        inventoryDebugInfo: null,
-      };
-
-      if (aiData.localTime !== undefined) {
-        if (draftState.localTime !== aiData.localTime) turnChanges.localTimeChanged = true;
-        draftState.localTime = aiData.localTime;
-      }
-      if (aiData.localEnvironment !== undefined) {
-        if (draftState.localEnvironment !== aiData.localEnvironment) turnChanges.localEnvironmentChanged = true;
-        draftState.localEnvironment = aiData.localEnvironment;
-      }
-      if (aiData.localPlace !== undefined) {
-        if (draftState.localPlace !== aiData.localPlace) turnChanges.localPlaceChanged = true;
-        draftState.localPlace = aiData.localPlace;
-      }
-
-      if (aiData.mainQuest !== undefined) {
-        if (draftState.mainQuest !== aiData.mainQuest) turnChanges.mainQuestTextChanged = true;
-        draftState.mainQuest = aiData.mainQuest;
-      }
-      const oldObjectiveText = draftState.currentObjective;
-      if (aiData.currentObjective !== undefined) {
-        if (draftState.currentObjective !== aiData.currentObjective) turnChanges.objectiveTextChanged = true;
-        draftState.currentObjective = aiData.currentObjective;
-      }
-
-      if (objectiveAnimationClearTimerRef.current) {
-        clearTimeout(objectiveAnimationClearTimerRef.current);
-        objectiveAnimationClearTimerRef.current = null;
-      }
-      let animationToSet: 'success' | 'neutral' | null = null;
-      if (aiData.currentObjective !== undefined && aiData.currentObjective !== oldObjectiveText) {
-        animationToSet = aiData.objectiveAchieved ? 'success' : 'neutral';
-      } else if (aiData.objectiveAchieved && oldObjectiveText !== null) {
-        animationToSet = 'success';
-      }
-      if (animationToSet) {
-        draftState.objectiveAnimationType = animationToSet;
-        objectiveAnimationClearTimerRef.current = window.setTimeout(() => {
-          setGameStateStack((prev) => [{ ...prev[0], objectiveAnimationType: null }, prev[1]]);
-          objectiveAnimationClearTimerRef.current = null;
-        }, 5000);
-      } else {
-        draftState.objectiveAnimationType = null;
-      }
-      turnChanges.objectiveAchieved = aiData.objectiveAchieved || false;
-      if (aiData.objectiveAchieved) {
-        draftState.score = draftState.score + 1;
-        turnChanges.scoreChangedBy += 1;
-      }
-
-      if ('sceneDescription' in aiData && aiData.sceneDescription) {
-        draftState.currentScene = aiData.sceneDescription;
-      }
-      if ('options' in aiData && aiData.options && aiData.options.length > 0 && !('dialogueSetup' in aiData && aiData.dialogueSetup)) {
-        draftState.actionOptions = aiData.options;
-      } else if (!isFromDialogueSummary && !('dialogueSetup' in aiData && aiData.dialogueSetup)) {
-        draftState.actionOptions = [
-          'Look around.',
-          'Ponder your situation.',
-          'Check your inventory.',
-          'Wait for something to happen.',
-          'Consider your objective.',
-          'Plan your next steps.'
-        ];
-      }
-
-      const aiItemChangesFromParser = aiData.itemChange || [];
-      const correctedAndVerifiedItemChanges: ItemChange[] = [];
-      if (themeContextForResponse) {
-        for (const change of aiItemChangesFromParser) {
-          const currentChange = { ...change };
-          if (currentChange.action === 'destroy' && currentChange.item) {
-            const itemRef = currentChange.item as ItemReference;
-            const itemNameFromAI = itemRef.name;
-            const exactMatchInInventory = baseStateSnapshot.inventory
-              .filter(i => i.holderId === PLAYER_HOLDER_ID)
-              .find(invItem =>
-                (itemRef.id && invItem.id === itemRef.id) ||
-                (itemRef.name && invItem.name === itemRef.name)
-              );
-            if (!exactMatchInInventory) {
-              const originalLoadingReason = loadingReason;
-              setLoadingReason('correction');
-              const correctedName = await fetchCorrectedName_Service(
-                'item',
-                itemNameFromAI || '',
-                aiData.logMessage,
-                'sceneDescription' in aiData ? aiData.sceneDescription : baseStateSnapshot.currentScene,
-                baseStateSnapshot.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID).map((item) => item.name),
-                themeContextForResponse
-              );
-              if (correctedName) {
-                currentChange.item = { id: correctedName, name: correctedName };
-              }
-              setLoadingReason(originalLoadingReason);
-            }
-
-            const dropText = `${aiData.logMessage || ''} ${'sceneDescription' in aiData ? aiData.sceneDescription : ''} ${playerActionText || ''}`.toLowerCase();
-            const dropIndicators = ['drop', 'dropped', 'leave', 'left', 'put down', 'set down', 'place', 'placed'];
-            if (dropIndicators.some(word => dropText.includes(word))) {
-              const invItem = baseStateSnapshot.inventory.find(i =>
-                i.holderId === PLAYER_HOLDER_ID &&
-                ((itemRef.id && i.id === itemRef.id) || (itemRef.name && i.name.toLowerCase() === itemRef.name.toLowerCase()))
-              );
-              if (invItem) {
-                currentChange.action = 'put';
-                currentChange.item = { ...invItem, holderId: baseStateSnapshot.currentMapNodeId || 'unknown' } as Item;
-              }
-            }
-          }
-          correctedAndVerifiedItemChanges.push(currentChange);
-        }
-      } else {
-        correctedAndVerifiedItemChanges.push(...aiItemChangesFromParser);
-      }
-      const baseInventoryForPlayer = baseStateSnapshot.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID);
-      const locationInventory = baseStateSnapshot.inventory.filter(
-        i => i.holderId === baseStateSnapshot.currentMapNodeId
-      );
-      const companionChars = baseStateSnapshot.allCharacters.filter(
-        c => c.presenceStatus === 'companion'
-      );
-      const nearbyChars = baseStateSnapshot.allCharacters.filter(
-        c => c.presenceStatus === 'nearby'
-      );
-
-      const formatCharInventoryList = (chars: typeof companionChars): string => {
-        if (chars.length === 0) return 'None.';
-        return chars
-          .map(ch => {
-            const items = baseStateSnapshot.inventory.filter(i => i.holderId === ch.id);
-            return `ID: ${ch.id} - ${ch.name}: ${formatInventoryForPrompt(items)}`;
-          })
-          .join('\n');
-      };
-
-      let combinedItemChanges = [...correctedAndVerifiedItemChanges];
-
-      if (themeContextForResponse) {
-        await processMapUpdates(
-          aiData,
-          draftState,
-          baseStateSnapshot,
-          themeContextForResponse,
-          turnChanges
-        );
-      }
-
-        if (themeContextForResponse) {
-          const originalLoadingReason = loadingReason;
-          setLoadingReason('inventory');
-          const limitedMapContext = formatLimitedMapContextForPrompt(
-            draftState.mapData,
-            draftState.currentMapNodeId,
-            baseStateSnapshot.inventory
-          );
-          const invResult = await applyInventoryHints_Service(
-            'playerItemsHint' in aiData ? aiData.playerItemsHint : undefined,
-            'worldItemsHint' in aiData ? aiData.worldItemsHint : undefined,
-            'npcItemsHint' in aiData ? aiData.npcItemsHint : undefined,
-            ('newItems' in aiData && Array.isArray(aiData.newItems)) ? aiData.newItems : [],
-            playerActionText || '',
-            formatInventoryForPrompt(baseInventoryForPlayer),
-            formatInventoryForPrompt(locationInventory),
-            baseStateSnapshot.currentMapNodeId || null,
-            formatCharInventoryList(companionChars),
-            formatCharInventoryList(nearbyChars),
-            'sceneDescription' in aiData ? aiData.sceneDescription : baseStateSnapshot.currentScene,
-            aiData.logMessage,
-            themeContextForResponse,
-            limitedMapContext
-          );
-          setLoadingReason(originalLoadingReason);
-          if (invResult) {
-            combinedItemChanges = combinedItemChanges.concat(invResult.itemChanges);
-            if (draftState.lastDebugPacket)
-              draftState.lastDebugPacket.inventoryDebugInfo = invResult.debugInfo;
-          }
-      }
-
-      turnChanges.itemChanges = buildItemChangeRecords(combinedItemChanges, baseInventoryForPlayer);
-      draftState.inventory = applyAllItemChanges(
-        combinedItemChanges,
-        options.forceEmptyInventory ? [] : baseStateSnapshot.inventory
-      );
-
-      if (aiData.logMessage) {
-        draftState.gameLog = addLogMessageToList(draftState.gameLog, aiData.logMessage, MAX_LOG_MESSAGES);
-        draftState.lastActionLog = aiData.logMessage;
-      } else if (!isFromDialogueSummary) {
-        draftState.lastActionLog = 'The Dungeon Master remains silent on the outcome of your last action.';
-      }
-
-      if ('dialogueSetup' in aiData && aiData.dialogueSetup) {
-        draftState.actionOptions = [];
-        draftState.dialogueState = {
-          participants: aiData.dialogueSetup.participants,
-          history: aiData.dialogueSetup.initialNpcResponses,
-          options: aiData.dialogueSetup.initialPlayerOptions,
-        };
-      } else if (isFromDialogueSummary) {
-        draftState.dialogueState = null;
-      }
-
-      draftState.lastTurnChanges = turnChanges;
-    }, [loadingReason, setLoadingReason, setError, setGameStateStack, processMapUpdates]);
+  const { handleDropItem, handleTakeLocationItem } = useInventoryActions({
+    getCurrentGameState,
+    commitGameState,
+    isLoading,
+  });
 
   /**
    * Executes a player's chosen action by querying the AI storyteller.
@@ -580,113 +296,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     [executePlayerAction]
   );
 
-  /**
-   * Drops an item from the inventory at the current location and optionally logs a message.
-   */
-  const handleDropItem = useCallback(
-    (itemName: string, logMessageOverride?: string) => {
-      const currentFullState = getCurrentGameState();
-      if (isLoading || currentFullState.dialogueState) return;
-
-      const itemToDiscard = currentFullState.inventory.find((item) => item.name === itemName && item.holderId === PLAYER_HOLDER_ID);
-      if (!itemToDiscard) return;
-
-      const draftState = structuredCloneGameState(currentFullState);
-      const currentLocationId = currentFullState.currentMapNodeId || 'unknown';
-      draftState.inventory = draftState.inventory.map((item) =>
-        item.name === itemName && item.holderId === PLAYER_HOLDER_ID
-          ? { ...item, holderId: currentLocationId }
-          : item
-      );
-      const itemChangeRecord: ItemChangeRecord = { type: 'loss', lostItem: { ...itemToDiscard } };
-      const turnChangesForDiscard: TurnChanges = {
-        itemChanges: [itemChangeRecord],
-        characterChanges: [],
-        objectiveAchieved: false,
-        objectiveTextChanged: false,
-        mainQuestTextChanged: false,
-        localTimeChanged: false,
-        localEnvironmentChanged: false,
-        localPlaceChanged: false,
-        currentMapNodeIdChanged: false,
-        scoreChangedBy: 0,
-        mapDataChanged: false,
-      };
-      draftState.lastTurnChanges = turnChangesForDiscard;
-
-      let logMessage = logMessageOverride;
-      if (!logMessage) {
-        const placeName =
-          currentFullState.mapData.nodes.find(n => n.id === currentLocationId)?.placeName ||
-          currentFullState.localPlace ||
-          'Unknown Place';
-        if (itemToDiscard.type === 'vehicle' && !itemToDiscard.isActive) {
-          logMessage = `You left your ${itemName} parked at ${placeName}.`;
-        } else {
-          logMessage = `You left your ${itemName} at ${placeName}.`;
-        }
-      }
-
-      if (logMessage) {
-        draftState.gameLog = addLogMessageToList(draftState.gameLog, logMessage, MAX_LOG_MESSAGES);
-        draftState.lastActionLog = logMessage;
-      }
-      commitGameState(draftState);
-    },
-    [getCurrentGameState, commitGameState, isLoading]
-  );
-
-  /**
-   * Picks up an item from the current location without triggering a turn.
-   */
-  const handleTakeLocationItem = useCallback(
-    (itemName: string) => {
-      const currentFullState = getCurrentGameState();
-      if (isLoading || currentFullState.dialogueState) return;
-
-      const currentLocationId = currentFullState.currentMapNodeId;
-      if (!currentLocationId) return;
-
-      const adjacentIds = getAdjacentNodeIds(
-        currentFullState.mapData,
-        currentLocationId
-      );
-      const itemToTake = currentFullState.inventory.find(item => {
-        if (item.name !== itemName) return false;
-        if (item.holderId === currentLocationId) return true;
-        return adjacentIds.includes(item.holderId);
-      });
-      if (!itemToTake) return;
-
-      const draftState = structuredCloneGameState(currentFullState);
-      draftState.inventory = draftState.inventory.map((item) =>
-        item.name === itemName && item.holderId === itemToTake.holderId
-          ? { ...item, holderId: PLAYER_HOLDER_ID }
-          : item
-      );
-
-      const itemChangeRecord: ItemChangeRecord = {
-        type: 'gain',
-        gainedItem: { ...itemToTake, holderId: PLAYER_HOLDER_ID },
-      };
-      const turnChangesForTake: TurnChanges = {
-        itemChanges: [itemChangeRecord],
-        characterChanges: [],
-        objectiveAchieved: false,
-        objectiveTextChanged: false,
-        mainQuestTextChanged: false,
-        localTimeChanged: false,
-        localEnvironmentChanged: false,
-        localPlaceChanged: false,
-        currentMapNodeIdChanged: false,
-        scoreChangedBy: 0,
-        mapDataChanged: false,
-      };
-      draftState.lastTurnChanges = turnChangesForTake;
-      commitGameState(draftState);
-    },
-    [getCurrentGameState, commitGameState, isLoading]
-  );
 
   /**
    * Executes the player's typed free-form action if allowed.
@@ -711,15 +320,12 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     setGameStateStack((prevStack) => {
       const [current, previous] = prevStack;
       if (previous && current.globalTurnNumber > 0) {
-        if (objectiveAnimationClearTimerRef.current) {
-          clearTimeout(objectiveAnimationClearTimerRef.current);
-          objectiveAnimationClearTimerRef.current = null;
-        }
+        clearObjectiveAnimationTimer();
         return [previous, current];
       }
       return prevStack;
     });
-  }, [setGameStateStack]);
+  }, [setGameStateStack, clearObjectiveAnimationTimer]);
 
   return {
     processAiResponse,

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -1,0 +1,330 @@
+import { useCallback, useRef } from 'react';
+import {
+  AdventureTheme,
+  FullGameState,
+  GameStateFromAI,
+  GameStateStack,
+  Item,
+  ItemReference,
+  ItemChange,
+  LoadingReason,
+  TurnChanges,
+} from '../types';
+import { fetchCorrectedName_Service } from '../services/corrections';
+import { PLAYER_HOLDER_ID, MAX_LOG_MESSAGES } from '../constants';
+import {
+  addLogMessageToList,
+  buildItemChangeRecords,
+  applyAllItemChanges,
+} from '../utils/gameLogicUtils';
+import { formatInventoryForPrompt } from '../utils/promptFormatters/inventory';
+import { formatLimitedMapContextForPrompt } from '../utils/promptFormatters/map';
+import { useMapUpdateProcessor } from './useMapUpdateProcessor';
+import { applyInventoryHints_Service } from '../services/inventory';
+
+export interface ProcessAiResponseOptions {
+  forceEmptyInventory?: boolean;
+  baseStateSnapshot: FullGameState;
+  isFromDialogueSummary?: boolean;
+  scoreChangeFromAction?: number;
+  playerActionText?: string;
+}
+
+export type ProcessAiResponseFn = (
+  aiData: GameStateFromAI | null,
+  themeContextForResponse: AdventureTheme | null,
+  draftState: FullGameState,
+  options: ProcessAiResponseOptions,
+) => Promise<void>;
+
+export interface UseProcessAiResponseProps {
+  loadingReason: LoadingReason | null;
+  setLoadingReason: (reason: LoadingReason | null) => void;
+  setError: (err: string | null) => void;
+  setGameStateStack: React.Dispatch<React.SetStateAction<GameStateStack>>;
+}
+
+export const useProcessAiResponse = ({
+  loadingReason,
+  setLoadingReason,
+  setError,
+  setGameStateStack,
+}: UseProcessAiResponseProps) => {
+  const { processMapUpdates } = useMapUpdateProcessor({
+    loadingReason,
+    setLoadingReason,
+    setError,
+  });
+
+  const objectiveAnimationClearTimerRef = useRef<number | null>(null);
+
+  const clearObjectiveAnimationTimer = useCallback(() => {
+    if (objectiveAnimationClearTimerRef.current) {
+      clearTimeout(objectiveAnimationClearTimerRef.current);
+      objectiveAnimationClearTimerRef.current = null;
+    }
+  }, []);
+
+  const processAiResponse: ProcessAiResponseFn = useCallback(
+    async (aiData, themeContextForResponse, draftState, options) => {
+      const {
+        baseStateSnapshot,
+        isFromDialogueSummary = false,
+        scoreChangeFromAction = 0,
+        playerActionText,
+      } = options;
+
+      const turnChanges: TurnChanges = {
+        itemChanges: [],
+        characterChanges: [],
+        objectiveAchieved: false,
+        objectiveTextChanged: false,
+        mainQuestTextChanged: false,
+        localTimeChanged: false,
+        localEnvironmentChanged: false,
+        localPlaceChanged: false,
+        currentMapNodeIdChanged: false,
+        scoreChangedBy: scoreChangeFromAction,
+        mapDataChanged: false,
+      };
+
+      if (!aiData) {
+        setError("The Dungeon Master's connection is unstable... (Invalid AI response after retries)");
+        if (!isFromDialogueSummary && 'actionOptions' in draftState) {
+          draftState.actionOptions = [
+            'Try to wait for the connection to improve.',
+            'Consult the ancient network spirits.',
+            'Check your own connection.',
+            'Sigh dramatically.',
+          ];
+        }
+        draftState.lastActionLog =
+          "The Dungeon Master seems to be having trouble communicating the outcome of your last action.";
+        draftState.localTime = draftState.localTime ?? 'Time Unknown';
+        draftState.localEnvironment = draftState.localEnvironment ?? 'Environment Undetermined';
+        draftState.localPlace = draftState.localPlace ?? 'Undetermined Location';
+        draftState.lastTurnChanges = turnChanges;
+        draftState.dialogueState = null;
+        return;
+      }
+
+      draftState.lastDebugPacket = {
+        ...(draftState.lastDebugPacket ?? {}),
+        prompt: draftState.lastDebugPacket?.prompt || 'Prompt not captured for this state transition',
+        rawResponseText: draftState.lastDebugPacket?.rawResponseText || 'Raw text not captured',
+        parsedResponse: aiData,
+        timestamp: new Date().toISOString(),
+        mapUpdateDebugInfo: null,
+        inventoryDebugInfo: null,
+      };
+
+      if (aiData.localTime !== undefined) {
+        if (draftState.localTime !== aiData.localTime) turnChanges.localTimeChanged = true;
+        draftState.localTime = aiData.localTime;
+      }
+      if (aiData.localEnvironment !== undefined) {
+        if (draftState.localEnvironment !== aiData.localEnvironment) turnChanges.localEnvironmentChanged = true;
+        draftState.localEnvironment = aiData.localEnvironment;
+      }
+      if (aiData.localPlace !== undefined) {
+        if (draftState.localPlace !== aiData.localPlace) turnChanges.localPlaceChanged = true;
+        draftState.localPlace = aiData.localPlace;
+      }
+
+      if (aiData.mainQuest !== undefined) {
+        if (draftState.mainQuest !== aiData.mainQuest) turnChanges.mainQuestTextChanged = true;
+        draftState.mainQuest = aiData.mainQuest;
+      }
+      const oldObjectiveText = draftState.currentObjective;
+      if (aiData.currentObjective !== undefined) {
+        if (draftState.currentObjective !== aiData.currentObjective) turnChanges.objectiveTextChanged = true;
+        draftState.currentObjective = aiData.currentObjective;
+      }
+
+      clearObjectiveAnimationTimer();
+      let animationToSet: 'success' | 'neutral' | null = null;
+      if (aiData.currentObjective !== undefined && aiData.currentObjective !== oldObjectiveText) {
+        animationToSet = aiData.objectiveAchieved ? 'success' : 'neutral';
+      } else if (aiData.objectiveAchieved && oldObjectiveText !== null) {
+        animationToSet = 'success';
+      }
+      if (animationToSet) {
+        draftState.objectiveAnimationType = animationToSet;
+        objectiveAnimationClearTimerRef.current = window.setTimeout(() => {
+          setGameStateStack((prev) => [{ ...prev[0], objectiveAnimationType: null }, prev[1]]);
+          objectiveAnimationClearTimerRef.current = null;
+        }, 5000);
+      } else {
+        draftState.objectiveAnimationType = null;
+      }
+      turnChanges.objectiveAchieved = aiData.objectiveAchieved || false;
+      if (aiData.objectiveAchieved) {
+        draftState.score = draftState.score + 1;
+        turnChanges.scoreChangedBy += 1;
+      }
+
+      if ('sceneDescription' in aiData && aiData.sceneDescription) {
+        draftState.currentScene = aiData.sceneDescription;
+      }
+      if (
+        'options' in aiData &&
+        aiData.options &&
+        aiData.options.length > 0 &&
+        !('dialogueSetup' in aiData && aiData.dialogueSetup)
+      ) {
+        draftState.actionOptions = aiData.options;
+      } else if (!isFromDialogueSummary && !('dialogueSetup' in aiData && aiData.dialogueSetup)) {
+        draftState.actionOptions = [
+          'Look around.',
+          'Ponder your situation.',
+          'Check your inventory.',
+          'Wait for something to happen.',
+          'Consider your objective.',
+          'Plan your next steps.',
+        ];
+      }
+
+      const aiItemChangesFromParser = aiData.itemChange || [];
+      const correctedAndVerifiedItemChanges: ItemChange[] = [];
+      if (themeContextForResponse) {
+        for (const change of aiItemChangesFromParser) {
+          const currentChange = { ...change };
+          if (currentChange.action === 'destroy' && currentChange.item) {
+            const itemRef = currentChange.item as ItemReference;
+            const itemNameFromAI = itemRef.name;
+            const exactMatchInInventory = baseStateSnapshot.inventory
+              .filter((i) => i.holderId === PLAYER_HOLDER_ID)
+              .find(
+                (invItem) =>
+                  (itemRef.id && invItem.id === itemRef.id) ||
+                  (itemRef.name && invItem.name === itemRef.name),
+              );
+            if (!exactMatchInInventory) {
+              const originalLoadingReason = loadingReason;
+              setLoadingReason('correction');
+              const correctedName = await fetchCorrectedName_Service(
+                'item',
+                itemNameFromAI || '',
+                aiData.logMessage,
+                'sceneDescription' in aiData ? aiData.sceneDescription : baseStateSnapshot.currentScene,
+                baseStateSnapshot.inventory
+                  .filter((i) => i.holderId === PLAYER_HOLDER_ID)
+                  .map((item) => item.name),
+                themeContextForResponse,
+              );
+              if (correctedName) {
+                currentChange.item = { id: correctedName, name: correctedName };
+              }
+              setLoadingReason(originalLoadingReason);
+            }
+
+            const dropText = `${aiData.logMessage || ''} ${
+              'sceneDescription' in aiData ? aiData.sceneDescription : ''
+            } ${playerActionText || ''}`.toLowerCase();
+            const dropIndicators = ['drop', 'dropped', 'leave', 'left', 'put down', 'set down', 'place', 'placed'];
+            if (dropIndicators.some((word) => dropText.includes(word))) {
+              const invItem = baseStateSnapshot.inventory.find(
+                (i) =>
+                  i.holderId === PLAYER_HOLDER_ID &&
+                  ((itemRef.id && i.id === itemRef.id) ||
+                    (itemRef.name && i.name.toLowerCase() === itemRef.name.toLowerCase()))
+              );
+              if (invItem) {
+                currentChange.action = 'put';
+                currentChange.item = {
+                  ...invItem,
+                  holderId: baseStateSnapshot.currentMapNodeId || 'unknown',
+                } as Item;
+              }
+            }
+          }
+          correctedAndVerifiedItemChanges.push(currentChange);
+        }
+      } else {
+        correctedAndVerifiedItemChanges.push(...aiItemChangesFromParser);
+      }
+      const baseInventoryForPlayer = baseStateSnapshot.inventory.filter((i) => i.holderId === PLAYER_HOLDER_ID);
+      const locationInventory = baseStateSnapshot.inventory.filter((i) => i.holderId === baseStateSnapshot.currentMapNodeId);
+      const companionChars = baseStateSnapshot.allCharacters.filter((c) => c.presenceStatus === 'companion');
+      const nearbyChars = baseStateSnapshot.allCharacters.filter((c) => c.presenceStatus === 'nearby');
+
+      const formatCharInventoryList = (chars: typeof companionChars): string => {
+        if (chars.length === 0) return 'None.';
+        return chars
+          .map((ch) => {
+            const items = baseStateSnapshot.inventory.filter((i) => i.holderId === ch.id);
+            return `ID: ${ch.id} - ${ch.name}: ${formatInventoryForPrompt(items)}`;
+          })
+          .join('\n');
+      };
+
+      let combinedItemChanges = [...correctedAndVerifiedItemChanges];
+
+      if (themeContextForResponse) {
+        await processMapUpdates(aiData, draftState, baseStateSnapshot, themeContextForResponse, turnChanges);
+      }
+
+      if (themeContextForResponse) {
+        const originalLoadingReason = loadingReason;
+        setLoadingReason('inventory');
+        const limitedMapContext = formatLimitedMapContextForPrompt(
+          draftState.mapData,
+          draftState.currentMapNodeId,
+          baseStateSnapshot.inventory,
+        );
+        const invResult = await applyInventoryHints_Service(
+          'playerItemsHint' in aiData ? aiData.playerItemsHint : undefined,
+          'worldItemsHint' in aiData ? aiData.worldItemsHint : undefined,
+          'npcItemsHint' in aiData ? aiData.npcItemsHint : undefined,
+          'newItems' in aiData && Array.isArray(aiData.newItems) ? aiData.newItems : [],
+          playerActionText || '',
+          formatInventoryForPrompt(baseInventoryForPlayer),
+          formatInventoryForPrompt(locationInventory),
+          baseStateSnapshot.currentMapNodeId || null,
+          formatCharInventoryList(companionChars),
+          formatCharInventoryList(nearbyChars),
+          'sceneDescription' in aiData ? aiData.sceneDescription : baseStateSnapshot.currentScene,
+          aiData.logMessage,
+          themeContextForResponse,
+          limitedMapContext,
+        );
+        setLoadingReason(originalLoadingReason);
+        if (invResult) {
+          combinedItemChanges = combinedItemChanges.concat(invResult.itemChanges);
+          if (draftState.lastDebugPacket) draftState.lastDebugPacket.inventoryDebugInfo = invResult.debugInfo;
+        }
+      }
+
+      turnChanges.itemChanges = buildItemChangeRecords(combinedItemChanges, baseInventoryForPlayer);
+      draftState.inventory = applyAllItemChanges(
+        combinedItemChanges,
+        options.forceEmptyInventory ? [] : baseStateSnapshot.inventory,
+      );
+
+      if (aiData.logMessage) {
+        draftState.gameLog = addLogMessageToList(draftState.gameLog, aiData.logMessage, MAX_LOG_MESSAGES);
+        draftState.lastActionLog = aiData.logMessage;
+      } else if (!isFromDialogueSummary) {
+        draftState.lastActionLog = 'The Dungeon Master remains silent on the outcome of your last action.';
+      }
+
+      if ('dialogueSetup' in aiData && aiData.dialogueSetup) {
+        draftState.actionOptions = [];
+        draftState.dialogueState = {
+          participants: aiData.dialogueSetup.participants,
+          history: aiData.dialogueSetup.initialNpcResponses,
+          options: aiData.dialogueSetup.initialPlayerOptions,
+        };
+      } else if (isFromDialogueSummary) {
+        draftState.dialogueState = null;
+      }
+
+      draftState.lastTurnChanges = turnChanges;
+    },
+    [loadingReason, setLoadingReason, setError, setGameStateStack, processMapUpdates, clearObjectiveAnimationTimer],
+  );
+
+  return { processAiResponse, clearObjectiveAnimationTimer };
+};
+
+export type ProcessAiResponseHook = ReturnType<typeof useProcessAiResponse>;


### PR DESCRIPTION
## Summary
- move inventory helper logic into `useInventoryActions`
- extract AI response parsing into `useProcessAiResponse`
- use the new hooks inside `usePlayerActions`
- update imports for initialization hook

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685196d490508324b7806ca12b20c77a