### PR TITLE
Fix eslint jsx-no-bind warnings

### DIFF
--- a/components/ActionOptions.tsx
+++ b/components/ActionOptions.tsx
@@ -5,7 +5,7 @@
  * @description Renders the list of actions the Player can choose from.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { Item, Character, MapNode } from '../types'; 
 import { highlightEntitiesInText, buildHighlightableEntities } from '../utils/highlightHelper';
 
@@ -39,6 +39,14 @@ const ActionOptions: React.FC<ActionOptionsProps> = ({
   );
 
 
+  const handleOptionClick = useCallback(
+    (action: string) => (event: React.MouseEvent<HTMLButtonElement>) => {
+      onActionSelect(action);
+      event.currentTarget.blur();
+    },
+    [onActionSelect]
+  );
+
   return (
     <div className="mt-6">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -52,10 +60,7 @@ const ActionOptions: React.FC<ActionOptionsProps> = ({
                         transform hover:scale-105 disabled:transform-none`} 
             disabled={disabled || option === "..."}
             key={option}
-            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-              onActionSelect(option);
-              event.currentTarget.blur(); 
-            }}
+            onClick={handleOptionClick(option)}
           >
             {index + 1}. {highlightEntitiesInText(option, entitiesForHighlighting)}
           </button>

--- a/components/ConfirmationDialog.tsx
+++ b/components/ConfirmationDialog.tsx
@@ -4,7 +4,7 @@
  * @file ConfirmationDialog.tsx
  * @description Modal dialog to confirm user actions.
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 
 interface ConfirmationDialogProps {
   readonly isOpen: boolean;
@@ -32,6 +32,9 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   confirmButtonClass = "bg-sky-600 hover:bg-sky-500",
   isCustomModeShift, // Destructure new prop
 }) => {
+  const stopPropagation = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  }, []);
   if (!isOpen) return null;
 
   let displayMessage = message;
@@ -55,7 +58,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
     >
       <div 
         className="bg-slate-800 p-6 md:p-8 rounded-xl shadow-2xl border border-slate-700 w-full max-w-lg transform transition-all duration-300 ease-out scale-95 opacity-0 animate-dialog-enter"
-        onClick={(e) => e.stopPropagation()} // Prevent dialog close when clicking inside
+        onClick={stopPropagation} // Prevent dialog close when clicking inside
         style={{animationFillMode: 'forwards'}} // Keep final state of animation
       >
         <h2 className="text-2xl font-bold text-sky-300 mb-5" id="confirmation-dialog-title">{title}</h2>

--- a/components/CustomGameSetupScreen.tsx
+++ b/components/CustomGameSetupScreen.tsx
@@ -3,7 +3,7 @@
  * @file CustomGameSetupScreen.tsx
  * @description Allows the Player to select starting themes.
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import { AdventureTheme, ThemePackName } from '../types';
 import { THEME_PACKS } from '../themes'; // To get pack names and structure
 
@@ -27,6 +27,11 @@ const CustomGameSetupScreen: React.FC<CustomGameSetupScreenProps> = ({
   titleText,
   descriptionText,
 }) => {
+  const handleThemeSelect = useCallback(
+    (themeName: string) => () => onThemeSelected(themeName),
+    [onThemeSelected]
+  );
+
   if (!isVisible) {
     return null;
   }
@@ -85,8 +90,8 @@ const CustomGameSetupScreen: React.FC<CustomGameSetupScreenProps> = ({
                                        ${isDisabled ? 'opacity-50 cursor-not-allowed hover:bg-slate-700 hover:border-slate-600 hover:scale-100' : ''}`}
                             disabled={isDisabled}
                             key={theme.name}
-                            onClick={() => onThemeSelected(theme.name)}
-                            style={{ minHeight: '180px' }} 
+                            onClick={handleThemeSelect(theme.name)}
+                            style={{ minHeight: '180px' }}
                           >
                             <h3 className="text-xl font-semibold text-amber-400 mb-2">{theme.name}</h3>
 

--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -3,7 +3,7 @@
  * @file DebugView.tsx
  * @description Developer panel for inspecting game state.
  */
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { extractJsonFromFence } from '../utils/jsonUtils';
 import { GameStateStack, DebugPacket, MapNode } from '../types';
 import { TravelStep } from '../utils/mapPathfinding';
@@ -48,6 +48,32 @@ const DebugView: React.FC<DebugViewProps> = ({
   const [showMapAIRaw, setShowMapAIRaw] = useState<boolean>(true);
   const [showInventoryAIRaw, setShowInventoryAIRaw] = useState<boolean>(true);
   const [showConnectorChainRaw, setShowConnectorChainRaw] = useState<Record<number, boolean>>({});
+
+  const toggleShowMainAIRaw = useCallback(
+    () => setShowMainAIRaw(prev => !prev),
+    []
+  );
+
+  const toggleShowMapAIRaw = useCallback(
+    () => setShowMapAIRaw(prev => !prev),
+    []
+  );
+
+  const toggleShowInventoryAIRaw = useCallback(
+    () => setShowInventoryAIRaw(prev => !prev),
+    []
+  );
+
+  const toggleShowConnectorChainRaw = useCallback(
+    (idx: number) => () =>
+      setShowConnectorChainRaw(prev => ({ ...prev, [idx]: !prev[idx] })),
+    []
+  );
+
+  const handleTabClick = useCallback(
+    (name: DebugTab) => () => setActiveTab(name),
+    []
+  );
 
   const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null;
@@ -204,7 +230,7 @@ const DebugView: React.FC<DebugViewProps> = ({
             <div className="my-2">
               <button
                 className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
-                onClick={() => setShowMainAIRaw(!showMainAIRaw)}
+                onClick={toggleShowMainAIRaw}
               >
                 Toggle Raw/Parsed Response
               </button>
@@ -236,7 +262,7 @@ const DebugView: React.FC<DebugViewProps> = ({
                 <div className="my-2">
                   <button
                     className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
-                    onClick={() => setShowMapAIRaw(!showMapAIRaw)}
+                    onClick={toggleShowMapAIRaw}
                   >
                     Toggle Raw/Parsed Map Update Response
                   </button>
@@ -275,9 +301,7 @@ const DebugView: React.FC<DebugViewProps> = ({
                       <div className="my-2">
                         <button
                           className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
-                          onClick={() =>
-                            setShowConnectorChainRaw(prev => ({ ...prev, [idx]: !prev[idx] }))
-                          }
+                          onClick={toggleShowConnectorChainRaw(idx)}
                         >
                           Toggle Raw/Parsed Connector Chains Response
                         </button>
@@ -372,7 +396,7 @@ const DebugView: React.FC<DebugViewProps> = ({
             <div className="my-2">
               <button
                 className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
-                onClick={() => setShowInventoryAIRaw(!showInventoryAIRaw)}
+                onClick={toggleShowInventoryAIRaw}
               >
                 Toggle Raw/Parsed Inventory Response
               </button>
@@ -490,7 +514,7 @@ const DebugView: React.FC<DebugViewProps> = ({
                             ? 'border-b-2 border-sky-400 text-sky-300' 
                             : 'text-slate-400 hover:text-sky-400'}`}
               key={tab.name}
-              onClick={() => setActiveTab(tab.name)}
+              onClick={handleTabClick(tab.name)}
             >
               {tab.label}
             </button>

--- a/utils/highlightHelper.tsx
+++ b/utils/highlightHelper.tsx
@@ -110,17 +110,18 @@ export const highlightEntitiesInText = (
     }
 
     if (matchedTermInfo) {
+      const handleMobileTap = (e: React.MouseEvent<HTMLSpanElement>) => {
+        if (window.matchMedia('(hover: none)').matches) {
+          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+          const text = e.currentTarget.getAttribute('title') || '';
+          showMobileTooltip(text, rect);
+        }
+      };
       results.push(
         <span
           className={getEntityHighlightClass(matchedTermInfo.entityData.type)}
           key={`${matchedTermInfo.entityData.name}-${matchedTermInfo.term}-${match.index}`}
-          onClick={enableMobileTap ? (e => {
-            if (window.matchMedia('(hover: none)').matches) {
-              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-              const text = e.currentTarget.getAttribute('title') || '';
-              showMobileTooltip(text, rect);
-            }
-          }) : undefined}
+          onClick={enableMobileTap ? handleMobileTap : undefined}
           title={matchedTermInfo.entityData.description || matchedTermInfo.entityData.name}
         >
           {matchedString}


### PR DESCRIPTION
## Summary
- replace inline handlers in ActionOptions
- refactor ConfirmationDialog to use callback
- clean up CustomGameSetupScreen theme select handlers
- remove inline callbacks from DebugView panels
- move highlight helper event handler out of JSX

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6851bee10d408324b0894fb6e906cf63