### PR TITLE
Fix Settings/Info modals on title screen

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -22,6 +22,8 @@ import DialogueDisplay from '../DialogueDisplay';
 import DebugView from '../DebugView';
 import ItemChangeAnimator from '../ItemChangeAnimator';
 import CustomGameSetupScreen from '../CustomGameSetupScreen';
+import SettingsDisplay from '../SettingsDisplay';
+import InfoDisplay from '../InfoDisplay';
 import Footer from './Footer';
 import AppModals from './AppModals';
 import { useLoadingProgress } from '../../hooks/useLoadingProgress';
@@ -718,13 +720,28 @@ const App: React.FC = () => {
         titleText="Select Destination Theme"
       />
 
+      <SettingsDisplay
+        chaosLevel={chaosLevel}
+        enabledThemePacks={enabledThemePacks}
+        isCustomGameMode={isCustomGameMode}
+        isVisible={isSettingsVisible}
+        onChaosChange={setChaosLevel}
+        onClose={closeSettings}
+        onPlayerGenderChange={setPlayerGender}
+        onStabilityChange={setStabilityLevel}
+        onToggleThemePack={handleToggleThemePackStable}
+        playerGender={playerGender}
+        stabilityLevel={stabilityLevel}
+      />
+
+      <InfoDisplay isVisible={isInfoVisible} onClose={closeInfo} />
+
       {hasGameBeenInitialized && currentTheme ? <AppModals
         allCharacters={allCharacters}
         cancelLoadGameFromMenu={handleCancelLoadGameFromMenu}
         cancelNewCustomGame={handleCancelNewCustomGame}
         cancelNewGameFromMenu={handleCancelNewGameFromMenu}
         cancelShift={handleCancelShift}
-        chaosLevel={chaosLevel}
         confirmLoadGameFromMenu={confirmLoadGameFromMenu}
         confirmNewCustomGame={confirmNewCustomGame}
         confirmNewGameFromMenu={confirmNewGameFromMenu}
@@ -734,17 +751,13 @@ const App: React.FC = () => {
         currentTheme={currentTheme}
         currentThemeName={currentTheme?.name || null}
         destinationNodeId={destinationNodeId}
-        enabledThemePacks={enabledThemePacks}
         gameLog={gameLog}
         initialLayoutConfig={mapLayoutConfig}
         initialViewBox={mapInitialViewBox}
-        isCustomGameMode={isCustomGameMode}
         isCustomGameModeShift={isCustomGameMode}
         isHistoryVisible={isHistoryVisible}
-        isInfoVisible={isInfoVisible}
         isKnowledgeBaseVisible={isKnowledgeBaseVisible}
         isMapVisible={isMapVisible}
-        isSettingsVisible={isSettingsVisible}
         isVisualizerVisible={isVisualizerVisible}
         itemPresenceByNode={itemPresenceByNode}
         loadGameFromMenuConfirmOpen={loadGameFromMenuConfirmOpen}
@@ -754,24 +767,17 @@ const App: React.FC = () => {
         mapData={mapData}
         newCustomGameConfirmOpen={newCustomGameConfirmOpen}
         newGameFromMenuConfirmOpen={newGameFromMenuConfirmOpen}
-        onChaosChange={setChaosLevel}
         onCloseInfo={closeInfo}
         onCloseMap={handleCloseMap}
-        onCloseSettings={closeSettings}
         onLayoutConfigChange={handleMapLayoutConfigChange}
         onNodesPositioned={handleMapNodesPositionChange}
-        onPlayerGenderChange={setPlayerGender}
         onSelectDestination={handleSelectDestinationNode}
-        onStabilityChange={setStabilityLevel}
-        onToggleThemePack={handleToggleThemePackStable}
         onViewBoxChange={handleMapViewBoxChange}
-        playerGender={playerGender}
         setGeneratedImage={setGeneratedImageCache}
         setIsHistoryVisible={setIsHistoryVisible}
         setIsKnowledgeBaseVisible={setIsKnowledgeBaseVisible}
         setIsVisualizerVisible={setIsVisualizerVisible}
         shiftConfirmOpen={shiftConfirmOpen}
-        stabilityLevel={stabilityLevel}
         themeHistory={themeHistory}
         visualizerImageScene={visualizerImageScene}
         visualizerImageUrl={visualizerImageUrl}

--- a/components/app/AppModals.tsx
+++ b/components/app/AppModals.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import KnowledgeBase from '../KnowledgeBase';
-import SettingsDisplay from '../SettingsDisplay';
-import InfoDisplay from '../InfoDisplay';
 import MapDisplay from '../MapDisplay';
 import ConfirmationDialog from '../ConfirmationDialog';
 import HistoryDisplay from '../HistoryDisplay';
@@ -12,7 +10,6 @@ import {
   MapLayoutConfig,
   Character,
   ThemeHistoryState,
-  ThemePackName,
   MapNode,
 } from '../../types';
 
@@ -39,19 +36,6 @@ interface AppModalsProps {
   readonly themeHistory: ThemeHistoryState;
   readonly gameLog: string[];
 
-  readonly isSettingsVisible: boolean;
-  readonly onCloseSettings: () => void;
-  readonly stabilityLevel: number;
-  readonly chaosLevel: number;
-  readonly onStabilityChange: (v: number) => void;
-  readonly onChaosChange: (v: number) => void;
-  readonly enabledThemePacks: ThemePackName[];
-  readonly onToggleThemePack: (p: ThemePackName) => void;
-  readonly playerGender: string;
-  readonly onPlayerGenderChange: (g: string) => void;
-  readonly isCustomGameMode: boolean;
-
-  readonly isInfoVisible: boolean;
   readonly onCloseInfo: () => void;
 
   readonly isMapVisible: boolean;
@@ -149,21 +133,6 @@ const AppModals: React.FC<AppModalsProps> = props => {
         onViewBoxChange={props.onViewBoxChange}
       />
 
-      <SettingsDisplay
-        chaosLevel={props.chaosLevel}
-        enabledThemePacks={props.enabledThemePacks}
-        isCustomGameMode={props.isCustomGameMode}
-        isVisible={props.isSettingsVisible}
-        onChaosChange={props.onChaosChange}
-        onClose={props.onCloseSettings}
-        onPlayerGenderChange={props.onPlayerGenderChange}
-        onStabilityChange={props.onStabilityChange}
-        onToggleThemePack={props.onToggleThemePack}
-        playerGender={props.playerGender}
-        stabilityLevel={props.stabilityLevel}
-      />
-
-      <InfoDisplay isVisible={props.isInfoVisible} onClose={props.onCloseInfo} />
 
       <ConfirmationDialog
         confirmButtonClass="bg-red-600 hover:bg-red-500"


### PR DESCRIPTION
## Summary
- render SettingsDisplay and InfoDisplay even before a game starts
- simplify AppModals now that Settings/Info are outside it

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6851e2f0ac8c83248438b29be296c89c