### PR TITLE
Fix inventory loading crash

### DIFF
--- a/components/SettingsDisplay.tsx
+++ b/components/SettingsDisplay.tsx
@@ -6,8 +6,8 @@
 import { useState, useEffect, useCallback } from 'react';
 
 import * as React from 'react';
-import { ThemePackName, ALL_THEME_PACK_NAMES } from '../themes';
-import { DEFAULT_PLAYER_GENDER } from '../constants';
+import { ThemePackName } from '../types';
+import { DEFAULT_PLAYER_GENDER, ALL_THEME_PACK_NAMES_CONST } from '../constants';
 
 interface SettingsDisplayProps {
   readonly isVisible: boolean;
@@ -259,7 +259,7 @@ const SettingsDisplay: React.FC<SettingsDisplayProps> = ({
             </p>
 
             <div className="space-y-3">
-              {ALL_THEME_PACK_NAMES.map(packName => (
+              {ALL_THEME_PACK_NAMES_CONST.map(packName => (
                 <label className="flex items-center space-x-3 cursor-pointer p-2 bg-slate-700/50 rounded-md hover:bg-slate-600/50 transition-colors" key={packName}>
                   <input
                     aria-labelledby={`theme-pack-label-${packName.replace(/\s|&/g, '-')}`}

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -573,7 +573,7 @@ const App: React.FC = () => {
               mapData={mapData.nodes}
             />
 
-            {actionOptions.length > 0 && (!error || !(error.includes("API Key"))) && hasGameBeenInitialized ? <>
+            {actionOptions.length > 0 && (typeof error !== 'string' || !error.includes("API Key")) && hasGameBeenInitialized ? <>
               <ActionOptions
                 allCharacters={allCharacters}
                 currentThemeName={currentTheme?.name || null}

--- a/constants.ts
+++ b/constants.ts
@@ -4,7 +4,6 @@
  * @description Global constants and default configuration values.
  */
 
-import { ALL_THEME_PACK_NAMES } from './themes';
 
 // Using gemini-2.5-flash model specified by API guidelines for general text tasks.
 export const GEMINI_MODEL_NAME = "gemini-2.5-flash";
@@ -19,6 +18,17 @@ export const GEMINI_RATE_LIMIT_PER_MINUTE = 10;
 export const AUXILIARY_RATE_LIMIT_PER_MINUTE = 15;
 export const MINIMAL_RATE_LIMIT_PER_MINUTE = 30;
 
+// List of available theme pack names used for default configuration.
+export const ALL_THEME_PACK_NAMES_CONST = [
+  'Fantasy & Myth',
+  'Science Fiction & Future',
+  'Horror & Dark Mystery',
+  'Action & Wasteland',
+  'Testing',
+] as const;
+
+export type ThemePackNameConst = typeof ALL_THEME_PACK_NAMES_CONST[number];
+
 export const MAX_RETRIES = 3; // Max retries for most API calls
 export const MAX_LOG_MESSAGES = 50; // Maximum number of messages to keep in the game log
 
@@ -29,7 +39,7 @@ export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
 
 export const DEFAULT_STABILITY_LEVEL = 30; // Number of turns before chaos can occur
 export const DEFAULT_CHAOS_LEVEL = 5;   // Percentage chance of chaos shift
-export const DEFAULT_ENABLED_THEME_PACKS = ALL_THEME_PACK_NAMES.filter(
+export const DEFAULT_ENABLED_THEME_PACKS = ALL_THEME_PACK_NAMES_CONST.filter(
   name => name !== 'Testing'
 );
 export const DEFAULT_PLAYER_GENDER = "Male";

--- a/types.ts
+++ b/types.ts
@@ -11,12 +11,12 @@ import {
   VALID_EDGE_TYPE_VALUES,
   VALID_EDGE_STATUS_VALUES,
   LOADING_REASONS,
+  ThemePackNameConst,
 } from './constants';
-import { ALL_THEME_PACK_NAMES } from './themes'; // For ThemePackName
 
 export type ItemType = typeof VALID_ITEM_TYPES[number];
 export type PresenceStatus = typeof VALID_PRESENCE_STATUS_VALUES[number];
-export type ThemePackName = typeof ALL_THEME_PACK_NAMES[number];
+export type ThemePackName = ThemePackNameConst;
 
 export type LoadingReason = typeof LOADING_REASONS[number] | null;
 


### PR DESCRIPTION
## Summary
- avoid calling `.includes` on a non-string error value
- break circular dependency between constants, themes, and types

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6851e8484f208324b09f9ed98a7e7d84