### PR TITLE
Resolve lint warnings for buttons and defaults

### DIFF
--- a/components/ActionOptions.tsx
+++ b/components/ActionOptions.tsx
@@ -55,14 +55,15 @@ function ActionOptions({
         {options.map((option, index) => (
           <button
             className={`w-full p-4 rounded-lg shadow-md transition-all duration-150 ease-in-out
-                        text-left text-white font-medium text-lg 
+                        text-left text-white font-medium text-lg
                         bg-sky-700 hover:bg-sky-600 focus:ring-4 focus:ring-sky-500 focus:outline-none
                         disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed
                         border border-sky-800 hover:border-sky-500
-                        transform hover:scale-105 disabled:transform-none`} 
+                        transform hover:scale-105 disabled:transform-none`}
             disabled={disabled || option === "..."}
             key={option}
             onClick={handleOptionClick(option)}
+            type="button"
           >
             {index + 1}
 

--- a/components/ConfirmationDialog.tsx
+++ b/components/ConfirmationDialog.tsx
@@ -79,6 +79,7 @@ function ConfirmationDialog({
             aria-label={cancelText}
             className="px-5 py-2.5 bg-slate-600 hover:bg-slate-500 text-white font-semibold rounded-lg shadow-md transition-all duration-150 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-slate-400"
             onClick={onCancel}
+            type="button"
           >
             {cancelText}
           </button>
@@ -87,6 +88,7 @@ function ConfirmationDialog({
             aria-label={confirmText}
             className={`px-5 py-2.5 text-white font-semibold rounded-lg shadow-md transition-all duration-150 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 ${confirmButtonClass} focus:ring-opacity-75`}
             onClick={onConfirm}
+            type="button"
           >
             {confirmText}
           </button>
@@ -112,10 +114,10 @@ function ConfirmationDialog({
 }
 
 ConfirmationDialog.defaultProps = {
-  confirmText: 'Confirm',
   cancelText: 'Cancel',
   confirmButtonClass: 'bg-sky-600 hover:bg-sky-500',
-  isCustomModeShift: false
+  confirmText: 'Confirm',
+  isCustomModeShift: false,
 };
 
 export default ConfirmationDialog;

--- a/components/CustomGameSetupScreen.tsx
+++ b/components/CustomGameSetupScreen.tsx
@@ -61,6 +61,7 @@ function CustomGameSetupScreen({
           aria-label="Close theme selection"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>
@@ -99,13 +100,14 @@ function CustomGameSetupScreen({
                         return (
                           <button
                             aria-label={`Start a new game in the theme: ${theme.name}${isDisabled ? ' (Current theme, cannot select)' : ''}`}
-                            className={`p-3 bg-slate-700 hover:bg-slate-600/80 border border-slate-600 hover:border-sky-500 rounded-lg shadow-md 
+                            className={`p-3 bg-slate-700 hover:bg-slate-600/80 border border-slate-600 hover:border-sky-500 rounded-lg shadow-md
                                        text-left text-slate-100 transition-all duration-150 ease-in-out transform hover:scale-[1.03] focus:ring-2 focus:ring-sky-400 focus:outline-none
                                        ${isDisabled ? 'opacity-50 cursor-not-allowed hover:bg-slate-700 hover:border-slate-600 hover:scale-100' : ''}`}
                             disabled={isDisabled}
                             key={theme.name}
                             onClick={handleThemeSelect(theme.name)}
                             style={{ minHeight: '180px' }}
+                            type="button"
                           >
                             <h3 className="text-xl font-semibold text-amber-400 mb-2">
                               {theme.name}
@@ -134,9 +136,9 @@ function CustomGameSetupScreen({
 }
 
 CustomGameSetupScreen.defaultProps = {
+  descriptionText: undefined,
   disabledThemeName: null,
   titleText: undefined,
-  descriptionText: undefined
 };
 
 export default CustomGameSetupScreen;

--- a/components/DebugView.tsx
+++ b/components/DebugView.tsx
@@ -216,6 +216,7 @@ function DebugView({
               className="mb-3 px-3 py-1.5 text-sm font-medium rounded shadow transition-colors duration-150 bg-orange-600 text-white hover:bg-orange-500 disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed"
               disabled={!previousState || currentState.globalTurnNumber <= 1}
               onClick={onUndoTurn}
+              type="button"
             >
               Undo Turn (Global Turn: 
               {' '}
@@ -243,6 +244,7 @@ function DebugView({
               <button
                 className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                 onClick={toggleShowMainAIRaw}
+                type="button"
               >
                 Toggle Raw/Parsed Response
               </button>
@@ -277,6 +279,7 @@ function DebugView({
                   <button
                     className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                     onClick={toggleShowMapAIRaw}
+                    type="button"
                   >
                     Toggle Raw/Parsed Map Update Response
                   </button>
@@ -318,6 +321,7 @@ function DebugView({
                         <button
                           className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                           onClick={toggleShowConnectorChainRaw(idx)}
+                          type="button"
                         >
                           Toggle Raw/Parsed Connector Chains Response
                         </button>
@@ -420,6 +424,7 @@ function DebugView({
               <button
                 className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                 onClick={toggleShowInventoryAIRaw}
+                type="button"
               >
                 Toggle Raw/Parsed Inventory Response
               </button>
@@ -532,6 +537,7 @@ function DebugView({
           aria-label="Close debug view"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>
@@ -547,11 +553,12 @@ function DebugView({
           {tabs.map(tab => (
             <button
               className={`px-3 py-2 text-sm font-medium transition-colors
-                          ${activeTab === tab.name 
-                            ? 'border-b-2 border-sky-400 text-sky-300' 
+                          ${activeTab === tab.name
+                            ? 'border-b-2 border-sky-400 text-sky-300'
                             : 'text-slate-400 hover:text-sky-400'}`}
               key={tab.name}
               onClick={handleTabClick(tab.name)}
+              type="button"
             >
               {tab.label}
             </button>

--- a/components/DialogueDisplay.tsx
+++ b/components/DialogueDisplay.tsx
@@ -110,6 +110,7 @@ function DialogueDisplay({
               disabled={optionsDisabled}
               key={option}
               onClick={handleOptionClick}
+              type="button"
             >
               {highlightEntitiesInText(option, entitiesForHighlighting)}
             </button>
@@ -125,8 +126,9 @@ function DialogueDisplay({
         </p>
 
         <button
-          className="mt-2 px-4 py-2 text-sm bg-red-700 hover:bg-red-600 text-white font-medium rounded shadow" 
+          className="mt-2 px-4 py-2 text-sm bg-red-700 hover:bg-red-600 text-white font-medium rounded shadow"
           onClick={onClose}
+          type="button"
         >
           Force End Conversation (if really stuck)
         </button>
@@ -146,9 +148,10 @@ function DialogueDisplay({
       <div className="dialogue-frame-content">
         <button
           aria-label="End Conversation"
-          className="animated-frame-close-button" 
+          className="animated-frame-close-button"
           disabled={isLoading || isDialogueExiting} // Updated disabled condition
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>

--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -41,6 +41,7 @@ function ErrorDisplay({ message, onRetry }: ErrorDisplayProps) {
         <button
           className="bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-4 rounded shadow transition duration-150 ease-in-out"
           onClick={onRetry}
+          type="button"
         >
           Try Again
         </button>

--- a/components/HistoryDisplay.tsx
+++ b/components/HistoryDisplay.tsx
@@ -37,6 +37,7 @@ function HistoryDisplay({
           aria-label="Close history"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>

--- a/components/ImageVisualizer.tsx
+++ b/components/ImageVisualizer.tsx
@@ -245,6 +245,7 @@ function ImageVisualizer({
           aria-label="Close visualizer"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>
@@ -269,6 +270,7 @@ function ImageVisualizer({
           <button
             className="mt-4 px-6 py-2 bg-sky-600 hover:bg-sky-500 text-white font-semibold rounded-md shadow transition-colors"
             onClick={handleRetry}
+            type="button"
           >
             Retry Visualization
           </button>

--- a/components/InfoDisplay.tsx
+++ b/components/InfoDisplay.tsx
@@ -30,6 +30,7 @@ function InfoDisplay({ isVisible, onClose }: InfoDisplayProps) {
           aria-label="Close game information"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>

--- a/components/InventoryDisplay.tsx
+++ b/components/InventoryDisplay.tsx
@@ -233,6 +233,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       } disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed disabled:ring-0`}
           disabled={disabled}
           onClick={handleSortByName}
+          type="button"
         >
           Sort by Name
         </button>
@@ -246,6 +247,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       } disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed disabled:ring-0`}
           disabled={disabled}
           onClick={handleSortByType}
+          type="button"
         >
           Sort by Type
         </button>
@@ -311,6 +313,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       key={`${item.name}-knownuse-${knownUse.actionName}`}
                       onClick={handleSpecificUse}
                       title={knownUse.description}
+                      type="button"
                     >
                       {knownUse.actionName}
                     </button>
@@ -325,6 +328,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                     disabled={disabled || isConfirmingDiscard}
                     key={`${item.name}-inspect`}
                     onClick={handleInspect}
+                    type="button"
                   >
                     Inspect
                   </button>
@@ -339,6 +343,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       disabled={disabled || isConfirmingDiscard}
                       key={`${item.name}-generic-use`}
                       onClick={handleGenericUse}
+                      type="button"
                     >
                       Attempt to Use (Generic)
                     </button>
@@ -354,6 +359,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       disabled={disabled || isConfirmingDiscard}
                       key={`${item.name}-vehicle-action`}
                       onClick={handleVehicleToggle}
+                      type="button"
                     >
                       {item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`}
                     </button>
@@ -410,6 +416,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       disabled={disabled}
                       key={`${item.name}-confirm-drop`}
                       onClick={handleConfirmDrop}
+                      type="button"
                     >
                       {item.type === 'vehicle' && !item.isActive ? 'Confirm Park' : item.isJunk ? 'Confirm Discard' : 'Confirm Drop'}
                     </button>
@@ -422,6 +429,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                       disabled={disabled}
                       key={`${item.name}-cancel-discard`}
                       onClick={handleCancelDiscard}
+                      type="button"
                     >
                       Cancel
                     </button>

--- a/components/ItemActionButton.tsx
+++ b/components/ItemActionButton.tsx
@@ -37,6 +37,7 @@ function ItemActionButton({
       data-item-name={dataItemName}
       disabled={disabled}
       onClick={handleClick}
+      type="button"
     >
       {label}
     </button>

--- a/components/ItemChangeAnimator.tsx
+++ b/components/ItemChangeAnimator.tsx
@@ -329,6 +329,7 @@ function ItemChangeAnimator({
             disabled
             key={`${item.name}-anim-ku-${ku.actionName}`}
             title={ku.description || ku.actionName}
+            type="button"
           >
             {ku.actionName}
           </button>
@@ -338,6 +339,7 @@ function ItemChangeAnimator({
           aria-hidden="true"
           className="w-full text-sm bg-slate-500/70 text-slate-400 font-medium py-1.5 px-3 rounded shadow cursor-not-allowed"
           disabled
+          type="button"
         >
           Inspect
         </button>
@@ -347,6 +349,7 @@ function ItemChangeAnimator({
             aria-hidden="true"
             className="w-full text-sm bg-slate-600/70 text-slate-400 font-medium py-1.5 px-3 rounded shadow cursor-not-allowed"
             disabled
+            type="button"
           >
             Attempt to Use (Generic)
           </button>
@@ -357,6 +360,7 @@ function ItemChangeAnimator({
             aria-hidden="true"
             className="w-full text-sm bg-slate-600/70 text-slate-400 font-medium py-1.5 px-3 rounded shadow cursor-not-allowed"
             disabled
+            type="button"
           >
             {item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`}
           </button>

--- a/components/KnowledgeBase.tsx
+++ b/components/KnowledgeBase.tsx
@@ -61,6 +61,7 @@ function KnowledgeBase({
           aria-label="Close knowledge base"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>

--- a/components/LocationItemsDisplay.tsx
+++ b/components/LocationItemsDisplay.tsx
@@ -75,6 +75,7 @@ function LocationItemsDisplay({ items, onTakeItem, disabled, currentNodeId, mapN
                   data-item-name={item.name}
                   disabled={disabled}
                   onClick={handleTakeItem}
+                  type="button"
                 >
                   {item.type === 'vehicle' ? 'Enter Vehicle' : 'Take'}
                 </button>

--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -91,6 +91,7 @@ function MainToolbar({
           disabled={isLoading || !currentThemeName || !currentSceneExists}
           onClick={onOpenVisualizer}
           title="Visualize Scene"
+          type="button"
         >
           <VisualizeIcon />
         </button>
@@ -103,6 +104,7 @@ function MainToolbar({
           disabled={isLoading || !currentThemeName}
           onClick={onOpenKnowledgeBase}
           title="Open Knowledge Base"
+          type="button"
         >
           <BookOpenIcon />
         </button>
@@ -115,6 +117,7 @@ function MainToolbar({
           disabled={isLoading || !currentThemeName}
           onClick={onOpenHistory}
           title="Open History"
+          type="button"
         >
           <ScrollIcon />
         </button>
@@ -127,6 +130,7 @@ function MainToolbar({
           disabled={isLoading || !currentThemeName}
           onClick={onOpenMap}
           title="Open Map"
+          type="button"
         >
           <MapIcon />
         </button>
@@ -139,6 +143,7 @@ function MainToolbar({
           disabled={isLoading || !currentThemeName}
           onClick={onManualRealityShift}
           title="Force Reality Shift"
+          type="button"
         >
           <RealityShiftIcon />
         </button>
@@ -151,6 +156,7 @@ function MainToolbar({
           disabled={isLoading}
           onClick={onOpenTitleMenu}
           title="Open Title Menu"
+          type="button"
         >
           <MenuIcon />
         </button>

--- a/components/MapDisplay.tsx
+++ b/components/MapDisplay.tsx
@@ -187,6 +187,7 @@ function MapDisplay({
           aria-label="Close map view"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>

--- a/components/QuestInfoBox.tsx
+++ b/components/QuestInfoBox.tsx
@@ -40,9 +40,9 @@ function QuestInfoBox({ mainQuest, currentObjective, objectiveAnimationType }: Q
 }
 
 QuestInfoBox.defaultProps = {
-  mainQuest: null,
   currentObjective: null,
-  objectiveAnimationType: null
+  mainQuest: null,
+  objectiveAnimationType: null,
 };
 
 export default QuestInfoBox;

--- a/components/SceneDisplay.tsx
+++ b/components/SceneDisplay.tsx
@@ -98,9 +98,9 @@ function SceneDisplay({
 
 SceneDisplay.defaultProps = {
   lastActionLog: null,
-  localTime: null,
   localEnvironment: null,
-  localPlace: null
+  localPlace: null,
+  localTime: null,
 };
 
 export default SceneDisplay;

--- a/components/SettingsDisplay.tsx
+++ b/components/SettingsDisplay.tsx
@@ -143,6 +143,7 @@ function SettingsDisplay({
           aria-label="Close settings"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
         >
           &times;
         </button>

--- a/components/TitleMenu.tsx
+++ b/components/TitleMenu.tsx
@@ -47,6 +47,7 @@ function TitleMenu({
           aria-label="Close Title Menu"
           className="animated-frame-close-button"
           onClick={onClose}
+          type="button"
                         >
           &times;
         </button> : null}
@@ -71,6 +72,7 @@ function TitleMenu({
               className="w-full px-6 py-2.5 sm:py-3 bg-red-600 hover:bg-red-500 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                          transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-red-400 focus:outline-none"
               onClick={onNewGame}
+              type="button"
             >
               New Game
             </button>
@@ -80,6 +82,7 @@ function TitleMenu({
               className="w-full px-6 py-2.5 sm:py-3 bg-orange-600 hover:bg-orange-500 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                          transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-orange-400 focus:outline-none"
               onClick={onCustomGame}
+              type="button"
             >
               Custom Game
             </button>
@@ -89,6 +92,7 @@ function TitleMenu({
               className="w-full px-6 py-2.5 sm:py-3 bg-green-600 hover:bg-green-500 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                            transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-green-400 focus:outline-none"
               onClick={onSaveGame}
+              type="button"
                                           >
               Save Game
             </button> : null}
@@ -98,6 +102,7 @@ function TitleMenu({
               className="w-full px-6 py-2.5 sm:py-3 bg-blue-600 hover:bg-blue-500 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                          transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-blue-400 focus:outline-none"
               onClick={onLoadGame}
+              type="button"
             >
               Load Game
             </button>
@@ -107,6 +112,7 @@ function TitleMenu({
               className="w-full px-6 py-2.5 sm:py-3 bg-gray-600 hover:bg-gray-500 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                          transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-gray-400 focus:outline-none"
               onClick={onOpenSettings}
+              type="button"
             >
               Settings
             </button>
@@ -116,6 +122,7 @@ function TitleMenu({
               className="w-full px-6 py-2.5 sm:py-3 bg-cyan-700 hover:bg-cyan-600 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                          transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-cyan-400 focus:outline-none"
               onClick={onOpenInfo}
+              type="button"
             >
               About
             </button>
@@ -125,6 +132,7 @@ function TitleMenu({
               className="w-full mt-6 sm:mt-8 px-6 py-2.5 sm:py-3 bg-sky-700 hover:bg-sky-600 text-white text-lg sm:text-xl font-semibold rounded-lg shadow-lg
                               transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-sky-500 focus:outline-none"
               onClick={onClose}
+              type="button"
                             >
               Return to Game
             </button> : null}

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -629,6 +629,7 @@ function App() {
                                 transition-colors duration-150"
                     disabled={!canPerformFreeAction || freeFormActionText.trim() === ""}
                     onClick={handleFreeFormActionSubmit}
+                    type="button"
                   >
                     Submit
                   </button>
@@ -769,20 +770,20 @@ function App() {
 
       {hasGameBeenInitialized && currentTheme ? <AppModals
         allCharacters={allCharacters}
-        cancelLoadGameFromMenu={handleCancelLoadGameFromMenu}
-        cancelNewCustomGame={handleCancelNewCustomGame}
-        cancelNewGameFromMenu={handleCancelNewGameFromMenu}
-        cancelShift={handleCancelShift}
-        confirmLoadGameFromMenu={confirmLoadGameFromMenu}
-        confirmNewCustomGame={confirmNewCustomGame}
-        confirmNewGameFromMenu={confirmNewGameFromMenu}
-        confirmShift={confirmShift}
         currentMapNodeId={currentMapNodeId}
         currentScene={currentScene}
         currentTheme={currentTheme}
         currentThemeName={currentTheme?.name || null}
         destinationNodeId={destinationNodeId}
         gameLog={gameLog}
+        handleCancelLoadGameFromMenu={handleCancelLoadGameFromMenu}
+        handleCancelNewCustomGame={handleCancelNewCustomGame}
+        handleCancelNewGameFromMenu={handleCancelNewGameFromMenu}
+        handleCancelShift={handleCancelShift}
+        handleConfirmLoadGameFromMenu={confirmLoadGameFromMenu}
+        handleConfirmNewCustomGame={confirmNewCustomGame}
+        handleConfirmNewGameFromMenu={confirmNewGameFromMenu}
+        handleConfirmShift={confirmShift}
         initialLayoutConfig={mapLayoutConfig}
         initialViewBox={mapInitialViewBox}
         isCustomGameModeShift={isCustomGameMode}

--- a/components/app/AppModals.tsx
+++ b/components/app/AppModals.tsx
@@ -52,17 +52,17 @@ interface AppModalsProps {
   readonly onLayoutConfigChange: (cfg: MapLayoutConfig) => void;
 
   readonly newGameFromMenuConfirmOpen: boolean;
-  readonly confirmNewGameFromMenu: () => void;
-  readonly cancelNewGameFromMenu: () => void;
+  readonly handleConfirmNewGameFromMenu: () => void;
+  readonly handleCancelNewGameFromMenu: () => void;
   readonly newCustomGameConfirmOpen: boolean;
-  readonly confirmNewCustomGame: () => void;
-  readonly cancelNewCustomGame: () => void;
+  readonly handleConfirmNewCustomGame: () => void;
+  readonly handleCancelNewCustomGame: () => void;
   readonly loadGameFromMenuConfirmOpen: boolean;
-  readonly confirmLoadGameFromMenu: () => void;
-  readonly cancelLoadGameFromMenu: () => void;
+  readonly handleConfirmLoadGameFromMenu: () => void;
+  readonly handleCancelLoadGameFromMenu: () => void;
   readonly shiftConfirmOpen: boolean;
-  readonly confirmShift: () => void;
-  readonly cancelShift: () => void;
+  readonly handleConfirmShift: () => void;
+  readonly handleCancelShift: () => void;
   readonly isCustomGameModeShift: boolean;
 }
 
@@ -139,8 +139,8 @@ function AppModals(props: AppModalsProps) {
         confirmText="Start New Game"
         isOpen={props.newGameFromMenuConfirmOpen}
         message="Are you sure you want to start a new game? Your current progress will be lost."
-        onCancel={props.cancelNewGameFromMenu}
-        onConfirm={props.confirmNewGameFromMenu}
+        onCancel={props.handleCancelNewGameFromMenu}
+        onConfirm={props.handleConfirmNewGameFromMenu}
         title="Confirm New Game"
       />
 
@@ -149,8 +149,8 @@ function AppModals(props: AppModalsProps) {
         confirmText="Start Custom Game"
         isOpen={props.newCustomGameConfirmOpen}
         message="Are you sure you want to start a new custom game? Your current progress will be lost."
-        onCancel={props.cancelNewCustomGame}
-        onConfirm={props.confirmNewCustomGame}
+        onCancel={props.handleCancelNewCustomGame}
+        onConfirm={props.handleConfirmNewCustomGame}
         title="Confirm Custom Game"
       />
 
@@ -159,8 +159,8 @@ function AppModals(props: AppModalsProps) {
         confirmText="Load Game"
         isOpen={props.loadGameFromMenuConfirmOpen}
         message="Are you sure you want to load a game? Your current progress will be overwritten if you load a new game."
-        onCancel={props.cancelLoadGameFromMenu}
-        onConfirm={props.confirmLoadGameFromMenu}
+        onCancel={props.handleCancelLoadGameFromMenu}
+        onConfirm={props.handleConfirmLoadGameFromMenu}
         title="Confirm Load Game"
       />
 
@@ -178,8 +178,8 @@ function AppModals(props: AppModalsProps) {
           {' '}
           to a new theme. Are you sure you wish to proceed?
         </>}
-        onCancel={props.cancelShift}
-        onConfirm={props.confirmShift}
+        onCancel={props.handleCancelShift}
+        onConfirm={props.handleConfirmShift}
         title="Confirm Reality Shift"
       />
     </>

--- a/components/app/Footer.tsx
+++ b/components/app/Footer.tsx
@@ -47,6 +47,7 @@ function Footer({
           aria-label={isDebugViewVisible ? 'Hide Debug View' : 'Open Debug View'}
           className="px-3 py-1 bg-slate-700 hover:bg-slate-600 text-slate-400 text-xs rounded shadow-md transition-colors"
           onClick={handleToggleDebug}
+          type="button"
         >
           Debug
         </button>

--- a/components/map/MapControls.tsx
+++ b/components/map/MapControls.tsx
@@ -149,6 +149,7 @@ function MapControls(props: MapControlsProps) {
           className="map-control-button mt-2 bg-orange-600 hover:bg-orange-500"
           onClick={onReset}
           style={{ flexBasis: '100%', marginTop: '0.5rem' }}
+          type="button"
         >
           Reset to Defaults
         </button>
@@ -158,6 +159,7 @@ function MapControls(props: MapControlsProps) {
         <button
           className="map-control-button"
           onClick={handleToggleExpanded}
+          type="button"
         >
           {expanded ? 'Hide' : 'Show'}
 

--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -711,6 +711,7 @@ function MapNodeView({
           className="map-set-destination-button"
           data-node-id={tooltip.nodeId}
           onClick={handleDestinationClick}
+          type="button"
                                              >
           {tooltip.nodeId === destinationNodeId
                 ? 'Remove Destination'


### PR DESCRIPTION
## Summary
- add missing button type attributes in many UI components
- alphabetize defaultProps in several files
- run eslint autofix to sort props and confirm no warnings remain

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68520b7471348324b48f313a52132a00