### PR TITLE
Hide Drop button for status effects

### DIFF
--- a/components/InventoryDisplay.tsx
+++ b/components/InventoryDisplay.tsx
@@ -382,7 +382,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                     />
                   ) : null}
 
-                  {!item.isJunk && !isConfirmingDiscard && item.type != 'vehicle' && (
+                  {!item.isJunk && !isConfirmingDiscard && item.type !== 'vehicle' && item.type !== 'status effect' && (
                     <ItemActionButton
                       ariaLabel={`Drop ${item.name}`}
                       className="bg-sky-700 hover:bg-sky-600"


### PR DESCRIPTION
## Summary
- inventory: disallow dropping status effect items

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852871990088324bb36d42b56752e2b