### PR TITLE
Fix ESLint issues

### DIFF
--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -52,9 +52,11 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   // applied to prevent re-loading it when starting a new game.
   const hasLoadedInitialSave = useRef<boolean>(false);
 
-  const triggerShiftRef = useRef<(c?: boolean) => void>(() => {});
-  const manualShiftRef = useRef<() => void>(() => {});
-  const loadInitialGameRef = useRef<(opts: LoadInitialGameOptions) => Promise<void>>(async () => {});
+  const triggerShiftRef = useRef<(c?: boolean) => void>(() => undefined);
+  const manualShiftRef = useRef<() => void>(() => undefined);
+  const loadInitialGameRef = useRef<(opts: LoadInitialGameOptions) => Promise<void>>(
+    () => Promise.resolve(),
+  );
 
   const getCurrentGameState = useCallback((): FullGameState => gameStateStack[0], [gameStateStack]);
   const commitGameState = useCallback((newGameState: FullGameState) => {

--- a/services/cartographer/applyUpdates.ts
+++ b/services/cartographer/applyUpdates.ts
@@ -698,7 +698,7 @@ export const applyMapUpdates = async ({
         );
         attempt++;
       }
-      if (chainResult && chainResult.payload) {
+      if (chainResult?.payload) {
         chainRequests = [];
         (chainResult.payload.nodesToAdd || []).forEach(nAdd => {
           const nodeData = nAdd.data;

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -158,8 +158,7 @@ Respond ONLY with the corrected JSON object.`;
       if (aiResponse) {
         const parsedResponse = parseDialogueTurnResponse(aiResponse, npcThoughts);
         if (
-          parsedResponse &&
-          parsedResponse.npcResponses.every(r => validParticipants.includes(r.speaker))
+          parsedResponse?.npcResponses.every(r => validParticipants.includes(r.speaker))
         ) {
           return { result: parsedResponse };
         }

--- a/services/corrections/edgeFixes.ts
+++ b/services/corrections/edgeFixes.ts
@@ -283,7 +283,7 @@ Return ONLY a JSON object strictly matching this structure:
   } else if (typeof parsed === 'object') {
     result = parsed as AIMapUpdatePayload;
   }
-  debugInfo.parsedPayload = result!;
+  debugInfo.parsedPayload = result || undefined;
   if (result) {
     if (result.observations && !debugInfo.observations) debugInfo.observations = result.observations;
     if (result.rationale && !debugInfo.rationale) debugInfo.rationale = result.rationale;

--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -117,8 +117,8 @@ export const executeDialogueTurn = async (
           thought?: boolean;
         }>;
       const thoughtParts = parts
-        .filter(p => p.thought === true && typeof p.text === 'string')
-        .map(p => p.text!);
+        .filter((p): p is { text: string; thought?: boolean } => p.thought === true && typeof p.text === 'string')
+        .map(p => p.text);
       let parsed = parseDialogueTurnResponse(response.text ?? '', thoughtParts);
       if (!parsed) {
         parsed = await fetchCorrectedDialogueTurn_Service(
@@ -178,7 +178,9 @@ export const executeDialogueSummary = async (
         label: 'Storyteller',
       });
       const parts = (response.candidates?.[0]?.content?.parts ?? []) as Array<{ text?: string; thought?: boolean }>;
-      const thoughtParts = parts.filter(p => p.thought === true && typeof p.text === 'string').map(p => p.text!);
+      const thoughtParts = parts
+        .filter((p): p is { text: string; thought?: boolean } => p.thought === true && typeof p.text === 'string')
+        .map(p => p.text);
       const parsed = await parseAIResponse(
         response.text ?? '',
         summaryContext.playerGender,

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -352,7 +352,7 @@ export function postProcessValidatedData(data: SavedGameDataShape): SavedGameDat
     const char = c as Partial<Character>;
     return {
       ...char,
-      id: char.id ?? buildCharacterId(char.name!),
+      id: char.id ?? buildCharacterId(char.name ?? ''),
       aliases: char.aliases ?? [],
       presenceStatus: char.presenceStatus ?? 'unknown',
       lastKnownLocation: char.lastKnownLocation ?? null,

--- a/services/storyteller/api.ts
+++ b/services/storyteller/api.ts
@@ -42,8 +42,8 @@ export const executeAIMainTurn = async (
             });
             const parts = (response.candidates?.[0]?.content?.parts ?? []) as Array<{ text?: string; thought?: boolean }>;
             const thoughts = parts
-              .filter(p => p.thought === true && typeof p.text === 'string')
-              .map(p => p.text!);
+              .filter((p): p is { text: string; thought?: boolean } => p.thought === true && typeof p.text === 'string')
+              .map(p => p.text);
             return { response, thoughts };
         } catch (error) {
             console.error(`Error executing AI Main Turn (Attempt ${attempt}/${MAX_RETRIES}):`, error);

--- a/services/storyteller/responseParser.ts
+++ b/services/storyteller/responseParser.ts
@@ -251,13 +251,14 @@ async function handleCharacterChanges(
                 ...(cUpdate as Record<string, unknown>),
                 name: (cUpdate as { name: string }).name,
             };
+            const payloadNameForLogs = currentCUpdatePayload.name;
             const allKnownAndCurrentlyAddedCharNames = new Set([
                 ...context.allRelevantCharacters.map(c => c.name),
                 ...finalCharactersAdded.map(c => c.name),
             ]);
 
             if (!allKnownAndCurrentlyAddedCharNames.has(currentCUpdatePayload.name)) {
-                console.warn(`parseAIResponse ('charactersUpdated'): Original target name "${currentCUpdatePayload.name}" not found. Attempting name correction.`);
+                console.warn(`parseAIResponse ('charactersUpdated'): Original target name "${payloadNameForLogs}" not found. Attempting name correction.`);
                 const correctedName = await fetchCorrectedName_Service(
                     'character name',
                     currentCUpdatePayload.name,
@@ -270,14 +271,14 @@ async function handleCharacterChanges(
                     currentCUpdatePayload.name = correctedName;
                     console.log(`parseAIResponse ('charactersUpdated'): Corrected target name to "${correctedName}".`);
                 } else {
-                    console.warn(`parseAIResponse ('charactersUpdated'): Failed to correct target name for "${currentCUpdatePayload.name}". Will attempt to process as is, may convert to 'add'.`);
+                    console.warn(`parseAIResponse ('charactersUpdated'): Failed to correct target name for "${payloadNameForLogs}". Will attempt to process as is, may convert to 'add'.`);
                 }
             }
 
             if (isValidCharacterUpdate(currentCUpdatePayload)) {
                 tempFinalCharactersUpdatedPayloads.push(currentCUpdatePayload);
             } else {
-                console.warn(`parseAIResponse ('charactersUpdated'): Payload for "${currentCUpdatePayload.name}" is invalid after potential name correction. Discarding. Payload:`, currentCUpdatePayload);
+                console.warn(`parseAIResponse ('charactersUpdated'): Payload for "${payloadNameForLogs}" is invalid after potential name correction. Discarding. Payload:`, currentCUpdatePayload);
             }
         } else {
             console.warn("parseAIResponse ('charactersUpdated'): Update missing or has invalid 'name'. Discarding.", cUpdate);

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -116,7 +116,7 @@ const turnChanges: TurnChanges = {
   scoreChangedBy: 0
 };
 
-await handleMapUpdates(aiData, draftState, baseState, theme, null, () => {}, turnChanges);
+await handleMapUpdates(aiData, draftState, baseState, theme, null, () => undefined, turnChanges);
 
 const updatedMaybe = draftState.mapData.nodes.find(n => n.id === 'node_rim_test');
 if (!updatedMaybe) throw new Error('node_rim_test not found');
@@ -132,7 +132,7 @@ const aiData2 = {
   currentMapNodeId: 'node_utility_entrance_test'
 } as Partial<GameStateFromAI> as GameStateFromAI;
 
-await handleMapUpdates(aiData2, draftState, baseState, theme, null, () => {}, turnChanges);
+await handleMapUpdates(aiData2, draftState, baseState, theme, null, () => undefined, turnChanges);
 
 const updated2Maybe = draftState.mapData.nodes.find(n => n.id === 'node_utility_entrance_test');
 const updated3Maybe = draftState.mapData.edges.find(n => n.id === 'edge_node_rim_test_to_node_utility_entrance_test_test');
@@ -165,7 +165,7 @@ const aiData3 = {
   currentMapNodeId: 'Yellow Door'
 } as Partial<GameStateFromAI> as GameStateFromAI;
 
-await handleMapUpdates(aiData3, draftState, baseState, theme, null, () => {}, turnChanges);
+await handleMapUpdates(aiData3, draftState, baseState, theme, null, () => undefined, turnChanges);
 
 const updated6Maybe = draftState.mapData.nodes.find(n => n.id === 'node_main_entrance_test');
 if (!updated6Maybe) throw new Error('node_main_entrance_test not found');

--- a/utils/jsonUtils.ts
+++ b/utils/jsonUtils.ts
@@ -12,7 +12,7 @@ export const extractJsonFromFence = (raw: string): string => {
   let jsonStr = raw.trim();
   const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
   const match = fenceRegex.exec(jsonStr);
-  if (match && match[1]) {
+  if (match?.[1]) {
     jsonStr = match[1].trim();
   }
   return jsonStr;


### PR DESCRIPTION
## Summary
- fix eslint errors in api service helpers
- clean up optional chaining and null assertions
- update tests for lint rule compliance
- clean up map update utilities

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852d26e16fc8324962c2a4a7ed59bd6