### PR TITLE
Refactor debug view sections

### DIFF
--- a/components/DebugSection.tsx
+++ b/components/DebugSection.tsx
@@ -1,0 +1,89 @@
+import { structuredCloneGameState } from '../utils/cloneUtils';
+import type { MapNode } from '../types';
+
+interface DebugSectionProps {
+  readonly title: string;
+  readonly content: unknown;
+  readonly isJson?: boolean;
+  readonly maxHeightClass?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/** Displays a section of debug information. */
+function DebugSection({
+  title,
+  content,
+  isJson = true,
+  maxHeightClass = 'max-h-60',
+}: DebugSectionProps) {
+  const displayContent: string = (() => {
+    if (content === null || content === undefined) return 'N/A';
+    if (typeof content === 'string') return content;
+    if (isJson) {
+      try {
+        const contentForDisplay = structuredCloneGameState(content);
+
+        if (title.startsWith('Current Game State') || title.startsWith('Previous Game State')) {
+          if (isRecord(contentForDisplay)) {
+            if ('lastDebugPacket' in contentForDisplay) delete contentForDisplay.lastDebugPacket;
+            if ('lastTurnChanges' in contentForDisplay) delete contentForDisplay.lastTurnChanges;
+
+            if ('mapData' in contentForDisplay) {
+              const mapData = contentForDisplay.mapData as { nodes: Array<MapNode>; edges: Array<unknown> } | undefined;
+              if (mapData && Array.isArray(mapData.nodes) && Array.isArray(mapData.edges)) {
+                contentForDisplay.mapDataSummary = {
+                  nodeCount: mapData.nodes.length,
+                  edgeCount: mapData.edges.length,
+                  firstNNodeNames: mapData.nodes.slice(0, 5).map((n: MapNode) => n.placeName),
+                };
+                delete contentForDisplay.mapData;
+              }
+            }
+          }
+        }
+
+        if (title.toLowerCase().includes('parsed')) {
+          const strip = (obj: unknown) => {
+            if (obj && typeof obj === 'object') {
+              delete (obj as Record<string, unknown>).observations;
+              delete (obj as Record<string, unknown>).rationale;
+              Object.values(obj).forEach(strip);
+            }
+          };
+          strip(contentForDisplay);
+        }
+
+        return JSON.stringify(contentForDisplay, null, 2);
+      } catch (e) {
+         
+        console.error('Error stringifying debug content:', e, content);
+         
+        return 'Error stringifying JSON content.';
+      }
+    }
+    return typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+  })();
+
+  return (
+    <section className="mb-4">
+      <h3 className="text-lg font-semibold text-sky-400 mb-1">
+        {title}
+      </h3>
+
+      <pre className={`bg-slate-900 p-2 rounded-md text-xs text-slate-200 overflow-auto ${maxHeightClass} whitespace-pre-wrap break-all`}>
+        <code>
+          {displayContent}
+        </code>
+      </pre>
+    </section>
+  );
+}
+
+DebugSection.defaultProps = {
+  isJson: true,
+  maxHeightClass: 'max-h-60',
+};
+
+export default DebugSection;

--- a/hooks/useToggle.ts
+++ b/hooks/useToggle.ts
@@ -1,0 +1,21 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * Generic boolean toggle hook for showing raw data sections.
+ */
+export const useToggle = (initial = true) => {
+  const [value, setValue] = useState<boolean>(initial);
+  const toggle = useCallback(() => { setValue(v => !v); }, []);
+  return { value, toggle } as const;
+};
+
+/**
+ * Manages toggle values keyed by index.
+ */
+export const useToggleMap = <K extends string | number>(initial: Record<K, boolean> = {} as Record<K, boolean>) => {
+  const [map, setMap] = useState<Record<K, boolean>>(initial);
+  const toggle = useCallback((key: K) => () => {
+    setMap(prev => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+  return { map, toggle } as const;
+};


### PR DESCRIPTION
## Summary
- centralize repeated toggling with `useToggle` and `useToggleMap`
- add reusable `DebugSection` component for displaying debug data
- refactor `DebugView` to use the new component and hooks

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853f4a8b7b88324bbb37ac9aa144066