### PR TITLE
Refactor game initialization helpers

### DIFF
--- a/hooks/initPromptHelpers.ts
+++ b/hooks/initPromptHelpers.ts
@@ -1,0 +1,61 @@
+/**
+ * @file initPromptHelpers.ts
+ * @description Helper for constructing initial game prompts.
+ */
+import { AdventureTheme, Character, MapData, ThemeMemory, Item } from '../types';
+import { PLAYER_HOLDER_ID } from '../constants';
+import {
+  buildNewGameFirstTurnPrompt,
+  buildNewThemePostShiftPrompt,
+  buildReturnToThemePostShiftPrompt,
+} from '../services/storyteller';
+
+export interface BuildInitialGamePromptOptions {
+  theme: AdventureTheme;
+  inventory: Array<Item>;
+  playerGender: string;
+  isTransitioningFromShift: boolean;
+  themeMemory?: ThemeMemory;
+  mapDataForTheme?: MapData;
+  charactersForTheme?: Array<Character>;
+}
+
+/**
+ * Build the storyteller prompt used when starting or resuming a theme.
+ */
+export const buildInitialGamePrompt = (
+  options: BuildInitialGamePromptOptions,
+): string => {
+  const {
+    theme,
+    inventory,
+    playerGender,
+    isTransitioningFromShift,
+    themeMemory,
+    mapDataForTheme,
+    charactersForTheme,
+  } = options;
+
+  const inventoryForPrompt = inventory.filter(i => i.holderId === PLAYER_HOLDER_ID);
+
+  let prompt = '';
+  if (isTransitioningFromShift && themeMemory && mapDataForTheme && charactersForTheme) {
+    prompt = buildReturnToThemePostShiftPrompt(
+      theme,
+      inventoryForPrompt,
+      playerGender,
+      themeMemory,
+      mapDataForTheme,
+      charactersForTheme,
+    );
+  } else if (isTransitioningFromShift) {
+    prompt = buildNewThemePostShiftPrompt(
+      theme,
+      inventoryForPrompt,
+      playerGender,
+    );
+  } else {
+    prompt = buildNewGameFirstTurnPrompt(theme, playerGender);
+  }
+  return prompt;
+};

--- a/hooks/saveSnapshotHelpers.ts
+++ b/hooks/saveSnapshotHelpers.ts
@@ -1,0 +1,47 @@
+/**
+ * @file saveSnapshotHelpers.ts
+ * @description Utilities for creating save-ready game state snapshots.
+ */
+import { FullGameState, ThemePackName } from '../types';
+import { CURRENT_SAVE_GAME_VERSION } from '../constants';
+
+export interface BuildSaveStateOptions {
+  currentState: FullGameState;
+  playerGender: string;
+  enabledThemePacks: Array<ThemePackName>;
+  stabilityLevel: number;
+  chaosLevel: number;
+}
+
+/**
+ * Generate a sanitized snapshot of the game state for saving.
+ */
+export const buildSaveStateSnapshot = (
+  options: BuildSaveStateOptions,
+): FullGameState => {
+  const {
+    currentState,
+    playerGender,
+    enabledThemePacks,
+    stabilityLevel,
+    chaosLevel,
+  } = options;
+
+  return {
+    ...currentState,
+    saveGameVersion: CURRENT_SAVE_GAME_VERSION,
+    playerGender,
+    enabledThemePacks,
+    stabilityLevel,
+    chaosLevel,
+    mapData: currentState.mapData,
+    currentMapNodeId: currentState.currentMapNodeId,
+    destinationNodeId: currentState.destinationNodeId,
+    mapLayoutConfig: currentState.mapLayoutConfig,
+    mapViewBox: currentState.mapViewBox,
+    isCustomGameMode: currentState.isCustomGameMode,
+    isAwaitingManualShiftThemeSelection: currentState.isAwaitingManualShiftThemeSelection,
+    globalTurnNumber: currentState.globalTurnNumber,
+    currentThemeObject: currentState.currentThemeObject,
+  };
+};


### PR DESCRIPTION
## Summary
- extract `buildInitialGamePrompt` helper
- extract `buildSaveStateSnapshot` helper
- use new helpers in `useGameInitialization`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853fc0f3384832482f4111c94e96e5f