### PR TITLE
Refactor MapNodeView

### DIFF
--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -3,7 +3,7 @@
  * @description SVG view rendering map nodes and edges with tooltip interactions.
  */
 
-import { useMemo, useState, useRef, useLayoutEffect, useCallback } from 'react';
+import { useMemo } from 'react';
 
 import * as React from 'react';
 import { MapNode, MapEdge } from '../../types';
@@ -17,7 +17,8 @@ import {
 } from '../../constants';
 import { Icon } from '../icons';
 import { isDescendantOf } from '../../utils/mapGraphUtils';
-import { getSVGCoordinates, getScreenCoordinates } from '../../utils/svgUtils';
+import { calculateLabelOffsets, getRadiusForNode, splitTextIntoLines, isSmallFontType, hasCenteredLabel } from '../../utils/mapLabelUtils';
+import { useMapTooltip } from '../../hooks/useMapTooltip';
 
 const buildShortcutPath = (a: MapNode, b: MapNode): string => {
   const x1 = a.position.x;
@@ -57,88 +58,6 @@ interface MapNodeViewProps {
  */
 const EMPTY_ITEM_PRESENCE_BY_NODE: Record<string, { hasUseful: boolean; hasVehicle: boolean } | undefined> = {};
 
-/**
- * Returns the radius for a node's circle. Uses the computed visualRadius from
- * nested layouts when available, otherwise falls back to a default based on the
- * node type.
- */
-const getRadiusForNode = (node: MapNode): number => {
-  if (node.data.visualRadius) return node.data.visualRadius;
-  switch (node.data.nodeType) {
-    case 'region':
-      // Larger size so that child circles and labels can fit inside.
-      return NODE_RADIUS * 2.4;
-    case 'location':
-      return NODE_RADIUS * 2.0;
-    case 'settlement':
-      return NODE_RADIUS * 1.8;
-    case 'district':
-      return NODE_RADIUS * 1.6;
-    case 'exterior':
-      return NODE_RADIUS * 1.4;
-    case 'interior':
-      return NODE_RADIUS * 1.2;
-    case 'room':
-      return NODE_RADIUS * 0.8;
-    case 'feature':
-      return NODE_RADIUS * 0.6;
-    default:
-      return NODE_RADIUS * 0.6;
-  }
-};
-
-/** Splits a label into multiple lines for display. */
-const splitTextIntoLines = (text: string, maxCharsPerLine: number, maxLines: number): Array<string> => {
-  if (!text) return [];
-  const words = text.split(' ');
-  const lines: Array<string> = [];
-  let currentLine = '';
-
-  for (const word of words) {
-    if (lines.length === maxLines) break;
-
-    if (currentLine.length === 0) {
-      currentLine = word;
-    } else if (currentLine.length + word.length + 1 <= maxCharsPerLine) {
-      currentLine += ` ${word}`;
-    } else {
-      lines.push(currentLine);
-      if (lines.length === maxLines) {
-        if (word) {
-          const lastLineContent = lines[maxLines - 1];
-          if (lastLineContent.length > 3) {
-            lines[maxLines - 1] = lastLineContent.slice(0, -3) + '...';
-          } else {
-            lines[maxLines - 1] = '..';
-          }
-        }
-        currentLine = '';
-        break;
-      }
-      currentLine = word;
-    }
-  }
-
-  if (currentLine && lines.length < maxLines) {
-    lines.push(currentLine);
-  } else if (currentLine && lines.length === maxLines && lines[maxLines - 1] && !lines[maxLines - 1].endsWith('...')) {
-    if (lines[maxLines - 1].length > 3) {
-      lines[maxLines - 1] = lines[maxLines - 1].slice(0, -3) + '...';
-    } else {
-      lines[maxLines - 1] = '..';
-    }
-  }
-
-  if (lines.length === maxLines && text.split(' ').length > words.indexOf(currentLine.split(' ')[0]) + currentLine.split(' ').length) {
-    const lastLine = lines[maxLines - 1];
-    if (lastLine && lastLine.length > 3 && !lastLine.endsWith('...')) {
-      lines[maxLines - 1] = lastLine.slice(0, Math.max(0, lastLine.length - 3)) + '...';
-    } else if (lastLine && !lastLine.endsWith('...')) {
-      lines[maxLines - 1] = '..';
-    }
-  }
-  return lines;
-};
 
 /**
  * SVG view for rendering map nodes and edges with tooltips.
@@ -157,172 +76,33 @@ function MapNodeView({
 }: MapNodeViewProps) {
   const interactions = useMapInteractions(initialViewBox, onViewBoxChange);
   const { svgRef, viewBox, handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave, handleWheel, handleTouchStart, handleTouchMove, handleTouchEnd } = interactions;
-  const [tooltip, setTooltip] = useState<{
-    content: string;
-    svgX: number;
-    svgY: number;
-    anchor: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-    nodeId?: string;
-  } | null>(null);
-  const [isTooltipLocked, setIsTooltipLocked] = useState(false);
-  const tooltipTimeout = useRef<number | null>(null);
-  const TOOLTIP_DELAY_MS = 250;
+  const {
+    tooltip,
+    tooltipScreenPosition,
+    isTooltipLocked,
+    handleMouseLeaveGeneral,
+    handleSvgClick,
+    handleEdgeMouseEnterById,
+    handleNodeMouseEnterById,
+    handleNodeClickById,
+    handleDestinationClick,
+  } = useMapTooltip({
+    nodes,
+    edges,
+    svgRef,
+    viewBox,
+    destinationNodeId,
+    onSelectDestination,
+  });
 
-  const [tooltipScreenPosition, setTooltipScreenPosition] = useState<
-    { x: number; y: number } | null
-  >(null);
-
-  // Recalculate tooltip position when viewBox changes so it stays anchored
-  // during panning or zooming.
-  useLayoutEffect(() => {
-    if (!tooltip || !svgRef.current) {
-      setTooltipScreenPosition(null);
-      return;
-    }
-    const { x, y } = getScreenCoordinates(
-      svgRef.current,
-      tooltip.svgX,
-      tooltip.svgY
-    );
-    const rect = svgRef.current.getBoundingClientRect();
-    setTooltipScreenPosition({ x: x - rect.left, y: y - rect.top });
-  }, [tooltip, viewBox, svgRef]);
-
-  const isSmallFontType = (type: string | undefined) =>
-    type === 'feature' || type === 'room' || type === 'interior';
-
-  const hasCenteredLabel = (type: string | undefined) => type === 'feature';
-
-  const computeAnchor = (
-    x: number,
-    y: number,
-    rect: DOMRect
-  ): 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' => {
-    const horizontal = x > rect.width / 2 ? 'right' : 'left';
-    const vertical = y > rect.height * 0.75 ? 'bottom' : 'top';
-    return `${vertical}-${horizontal}` as const;
-  };
+  // Utility helpers imported from mapLabelUtils
 
 
 
-  /**
-   * Calculate extra vertical offset for labels when they overlap. Feature labels
-   * stay fixed while sibling and descendant non-feature labels may shift down.
-   * Only immediate left/right siblings are considered for overlap checks.
-   */
-  const labelOffsetMap = useMemo(() => {
-    const idToNode = new Map(nodes.map(n => [n.id, n]));
-
-    const childrenMap = new Map<string, Array<MapNode>>();
-    nodes.forEach(n => {
-      if (n.data.parentNodeId) {
-        const arr = childrenMap.get(n.data.parentNodeId) ?? [];
-        arr.push(n);
-        childrenMap.set(n.data.parentNodeId, arr);
-      }
-    });
-
-    const depthCache = new Map<string, number>();
-    const getDepth = (node: MapNode | undefined): number => {
-      if (!node) return 0;
-      const cached = depthCache.get(node.id);
-      if (cached !== undefined) return cached;
-      const parent = node.data.parentNodeId ? idToNode.get(node.data.parentNodeId) : undefined;
-      const depth = parent ? getDepth(parent) + 1 : 0;
-      depthCache.set(node.id, depth);
-      return depth;
-    };
-    nodes.forEach(n => getDepth(n));
-
-    const isParent = (n: MapNode) => childrenMap.has(n.id);
-
-    const fontSizeFor = (n: MapNode) => (isSmallFontType(n.data.nodeType) ? 7 : 12);
-      const linesCache: Record<string, Array<string> | undefined> = {};
-      const getLines = (n: MapNode): Array<string> => {
-        const cached = linesCache[n.id];
-        if (cached) return cached;
-        const maxChars = isSmallFontType(n.data.nodeType) || !isParent(n) ? 20 : 25;
-        const lines = splitTextIntoLines(n.placeName, maxChars, MAX_LABEL_LINES);
-        linesCache[n.id] = lines;
-        return lines;
-      };
-
-    const labelHeight = (n: MapNode) =>
-      getLines(n).length * fontSizeFor(n) * DEFAULT_LABEL_LINE_HEIGHT_EM;
-
-    const labelWidth = (n: MapNode) =>
-      Math.max(
-        ...getLines(n).map(line => line.length * fontSizeFor(n) * 0.6)
-      );
-
-    const getLabelBox = (n: MapNode, offset: number) => {
-      const width = labelWidth(n);
-      const height = labelHeight(n);
-      if (hasCenteredLabel(n.data.nodeType)) {
-        return {
-          x: n.position.x - width / 2,
-          y: n.position.y - height / 2,
-          width,
-          height : height * 2,
-        };
-      }
-      const base = getRadiusForNode(n) + DEFAULT_LABEL_MARGIN_PX + offset;
-      return {
-        x: n.position.x - width / 2,
-        y: n.position.y + base,
-        width,
-        height,
-      };
-    };
-
-    const offsets: Record<string, number> = {};
-    nodes.forEach(n => {
-      offsets[n.id] = 0;
-    });
-
-    // Helper to test bounding box overlap
-    const boxesOverlap = (a: { x: number; y: number; width: number; height: number }, b: { x: number; y: number; width: number; height: number }) =>
-      a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
-
-    // Shift siblings that overlap. Only immediate neighbors are checked.
-    childrenMap.forEach(siblings => {
-      const ordered = [...siblings].sort((a, b) => a.position.x - b.position.x);
-      for (let i = 1; i < ordered.length; i++) {
-        const left = ordered[i - 1];
-        const right = ordered[i];
-
-        let boxLeft = getLabelBox(left, offsets[left.id]);
-        let boxRight = getLabelBox(right, offsets[right.id]);
-
-        if (boxesOverlap(boxLeft, boxRight)) {
-          const delta = boxLeft.y + boxLeft.height - boxRight.y + labelOverlapMarginPx;
-          if (right.data.nodeType !== 'feature') {
-            offsets[right.id] += delta;
-            boxRight = getLabelBox(right, offsets[right.id]);
-          } else if (left.data.nodeType !== 'feature') {
-            offsets[left.id] += delta;
-            boxLeft = getLabelBox(left, offsets[left.id]);
-          }
-        }
-      }
-    });
-
-    // Non-feature nodes must also avoid overlapping any feature descendants
-    nodes.forEach(node => {
-      if (node.data.nodeType === 'feature') return;
-      const featureDescendants = nodes.filter(n => n.data.nodeType === 'feature' && isDescendantOf(n, node, idToNode));
-      for (const feature of featureDescendants) {
-        const nodeBox = getLabelBox(node, offsets[node.id]);
-        const featureBox = getLabelBox(feature, offsets[feature.id]);
-        if (boxesOverlap(nodeBox, featureBox)) {
-          const delta = featureBox.y + featureBox.height - nodeBox.y + labelOverlapMarginPx;
-          offsets[node.id] += delta;
-        }
-      }
-    });
-
-    return offsets;
-  }, [nodes, labelOverlapMarginPx]);
+  const labelOffsetMap = useMemo(
+    () => calculateLabelOffsets(nodes, labelOverlapMarginPx),
+    [nodes, labelOverlapMarginPx]
+  );
 
   /** Map node depth for rendering order */
   const depthMap = useMemo(() => {
@@ -366,126 +146,6 @@ function MapNodeView({
   }, [destinationNodeId, nodes, currentMapNodeId]);
 
 
-  /** Hides the tooltip. */
-  const handleMouseLeaveGeneral = useCallback(function handleMouseLeaveGeneral() {
-    if (tooltipTimeout.current) {
-      clearTimeout(tooltipTimeout.current);
-      tooltipTimeout.current = null;
-    }
-    if (!isTooltipLocked) setTooltip(null);
-  }, [isTooltipLocked]);
-
-  const handleSvgClick = useCallback(function handleSvgClick(event: React.MouseEvent<SVGSVGElement>) {
-    const target = event.target as Element;
-    if (!target.closest('.map-node') && !target.closest('.map-edge-group')) {
-      setIsTooltipLocked(false);
-      setTooltip(null);
-    }
-  }, []);
-
-  const handleEdgeMouseEnterById = useCallback(function handleEdgeMouseEnterById(
-    event: React.MouseEvent<SVGGElement>
-  ) {
-      if (isTooltipLocked) return;
-      const edgeId = event.currentTarget.dataset.edgeId;
-      if (!edgeId) return;
-      const edge = edges.find(e => e.id === edgeId);
-      if (!edge) return;
-      const svgRect = svgRef.current?.getBoundingClientRect();
-      if (!svgRect) return;
-      const x = event.clientX - svgRect.left;
-      const y = event.clientY - svgRect.top;
-      const svgCoords = svgRef.current
-        ? getSVGCoordinates(svgRef.current, event.clientX, event.clientY)
-        : { x: 0, y: 0 };
-      const sourceNode = nodes.find(n => n.id === edge.sourceNodeId);
-      const targetNode = nodes.find(n => n.id === edge.targetNodeId);
-        let content = edge.data.description ??
-          `Path between ${sourceNode?.placeName ?? 'Unknown'} and ${targetNode?.placeName ?? 'Unknown'}`;
-      if (edge.data.travelTime) content += `\n${edge.data.travelTime}`;
-      if (edge.data.status) content += `\nStatus: ${edge.data.status}`;
-      const anchor = computeAnchor(x, y, svgRect);
-      if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current);
-      tooltipTimeout.current = window.setTimeout(() => {
-        setTooltip({ content, svgX: svgCoords.x, svgY: svgCoords.y, anchor });
-      }, TOOLTIP_DELAY_MS);
-    },
-    [edges, isTooltipLocked, nodes, svgRef]
-  );
-
-  const handleNodeMouseEnterById = useCallback(function handleNodeMouseEnterById(
-    event: React.MouseEvent
-  ) {
-      if (isTooltipLocked) return;
-      const nodeId = event.currentTarget.getAttribute('data-node-id');
-      if (!nodeId) return;
-      const node = nodes.find(n => n.id === nodeId);
-      if (!node) return;
-      const svgRect = svgRef.current?.getBoundingClientRect();
-      if (!svgRect) return;
-      const x = event.clientX - svgRect.left;
-      const y = event.clientY - svgRect.top;
-      const svgCoords = svgRef.current
-        ? getSVGCoordinates(svgRef.current, event.clientX, event.clientY)
-        : { x: 0, y: 0 };
-      let content = node.placeName;
-      if (node.data.aliases && node.data.aliases.length > 0) content += ` (aka ${node.data.aliases.join(', ')})`;
-      if (node.data.description) content += `\n${node.data.description}`;
-      content += `\nStatus: ${node.data.status}`;
-      const anchor = computeAnchor(x, y, svgRect);
-      if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current);
-      tooltipTimeout.current = window.setTimeout(() => {
-        setTooltip({ content, svgX: svgCoords.x, svgY: svgCoords.y, anchor, nodeId });
-      }, TOOLTIP_DELAY_MS);
-    },
-    [isTooltipLocked, nodes, svgRef]
-  );
-
-  const handleNodeClickById = useCallback(function handleNodeClickById(
-    event: React.MouseEvent
-  ) {
-      event.stopPropagation();
-      const nodeId = event.currentTarget.getAttribute('data-node-id');
-      if (!nodeId) return;
-      const node = nodes.find(n => n.id === nodeId);
-      if (!node) return;
-      if (tooltipTimeout.current) {
-        clearTimeout(tooltipTimeout.current);
-        tooltipTimeout.current = null;
-      }
-      const svgRect = svgRef.current?.getBoundingClientRect();
-      if (!svgRect) return;
-      const x = event.clientX - svgRect.left;
-      const y = event.clientY - svgRect.top;
-      const svgCoords = svgRef.current
-        ? getSVGCoordinates(svgRef.current, event.clientX, event.clientY)
-        : { x: 0, y: 0 };
-      let content = node.placeName;
-      if (node.data.aliases && node.data.aliases.length > 0) content += ` (aka ${node.data.aliases.join(', ')})`;
-      if (node.data.description) content += `\n${node.data.description}`;
-      content += `\nStatus: ${node.data.status}`;
-      setIsTooltipLocked(true);
-      const anchor = computeAnchor(x, y, svgRect);
-      setTooltip({ content, svgX: svgCoords.x, svgY: svgCoords.y, anchor, nodeId });
-    },
-    [nodes, svgRef]
-  );
-
-  const handleDestinationClick = useCallback(function handleDestinationClick(
-    event: React.MouseEvent<HTMLButtonElement>
-  ) {
-      const nodeId = event.currentTarget.dataset.nodeId;
-      if (!nodeId) return;
-      if (nodeId === destinationNodeId) {
-        onSelectDestination(null);
-      } else {
-        onSelectDestination(nodeId);
-      }
-      setIsTooltipLocked(false);
-      setTooltip(null);
-    },
-    [destinationNodeId, onSelectDestination]
-  );
 
   if (nodes.length === 0) {
     return (

--- a/hooks/useMapTooltip.ts
+++ b/hooks/useMapTooltip.ts
@@ -1,0 +1,186 @@
+/**
+ * @file useMapTooltip.ts
+ * @description Hook providing tooltip logic for the map view.
+ */
+
+import { useState, useRef, useLayoutEffect, useCallback } from 'react';
+import { MapEdge, MapNode } from '../types';
+import { getSVGCoordinates, getScreenCoordinates } from '../utils/svgUtils';
+
+export interface TooltipState {
+  content: string;
+  svgX: number;
+  svgY: number;
+  anchor: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  nodeId?: string;
+}
+
+export interface UseMapTooltipProps {
+  nodes: Array<MapNode>;
+  edges: Array<MapEdge>;
+  svgRef: React.RefObject<SVGSVGElement | null>;
+  viewBox: string;
+  destinationNodeId: string | null;
+  onSelectDestination: (nodeId: string | null) => void;
+}
+
+/**
+ * Manages tooltip state and event handlers for the map view.
+ */
+export const useMapTooltip = ({
+  nodes,
+  edges,
+  svgRef,
+  viewBox,
+  destinationNodeId,
+  onSelectDestination,
+}: UseMapTooltipProps) => {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [isTooltipLocked, setIsTooltipLocked] = useState(false);
+  const tooltipTimeout = useRef<number | null>(null);
+  const TOOLTIP_DELAY_MS = 250;
+  const [tooltipScreenPosition, setTooltipScreenPosition] = useState<{ x: number; y: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!tooltip || !svgRef.current) {
+      setTooltipScreenPosition(null);
+      return;
+    }
+    const { x, y } = getScreenCoordinates(svgRef.current, tooltip.svgX, tooltip.svgY);
+    const rect = svgRef.current.getBoundingClientRect();
+    setTooltipScreenPosition({ x: x - rect.left, y: y - rect.top });
+  }, [tooltip, viewBox, svgRef]);
+
+  const computeAnchor = useCallback(
+    (x: number, y: number, rect: DOMRect): TooltipState['anchor'] => {
+      const horizontal = x > rect.width / 2 ? 'right' : 'left';
+      const vertical = y > rect.height * 0.75 ? 'bottom' : 'top';
+      return `${vertical}-${horizontal}` as const;
+    },
+    [],
+  );
+
+  const handleMouseLeaveGeneral = useCallback(() => {
+    if (tooltipTimeout.current) {
+      clearTimeout(tooltipTimeout.current);
+      tooltipTimeout.current = null;
+    }
+    if (!isTooltipLocked) setTooltip(null);
+  }, [isTooltipLocked]);
+
+  const handleSvgClick = useCallback((event: React.MouseEvent<SVGSVGElement>) => {
+    const target = event.target as Element;
+    if (!target.closest('.map-node') && !target.closest('.map-edge-group')) {
+      setIsTooltipLocked(false);
+      setTooltip(null);
+    }
+  }, []);
+
+  const handleEdgeMouseEnterById = useCallback(
+    (event: React.MouseEvent<SVGGElement>) => {
+      if (isTooltipLocked) return;
+      const edgeId = event.currentTarget.dataset.edgeId;
+      if (!edgeId) return;
+      const edge = edges.find(e => e.id === edgeId);
+      if (!edge) return;
+      const svgRect = svgRef.current?.getBoundingClientRect();
+      if (!svgRect) return;
+      const x = event.clientX - svgRect.left;
+      const y = event.clientY - svgRect.top;
+      const svgCoords = svgRef.current ? getSVGCoordinates(svgRef.current, event.clientX, event.clientY) : { x: 0, y: 0 };
+      const sourceNode = nodes.find(n => n.id === edge.sourceNodeId);
+      const targetNode = nodes.find(n => n.id === edge.targetNodeId);
+      let content =
+        edge.data.description ??
+        `Path between ${sourceNode?.placeName ?? 'Unknown'} and ${targetNode?.placeName ?? 'Unknown'}`;
+      if (edge.data.travelTime) content += `\n${edge.data.travelTime}`;
+      if (edge.data.status) content += `\nStatus: ${edge.data.status}`;
+      const anchor = computeAnchor(x, y, svgRect);
+      if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current);
+      tooltipTimeout.current = window.setTimeout(() => {
+        setTooltip({ content, svgX: svgCoords.x, svgY: svgCoords.y, anchor });
+      }, TOOLTIP_DELAY_MS);
+    },
+    [computeAnchor, edges, isTooltipLocked, nodes, svgRef],
+  );
+
+  const handleNodeMouseEnterById = useCallback(
+    (event: React.MouseEvent) => {
+      if (isTooltipLocked) return;
+      const nodeId = event.currentTarget.getAttribute('data-node-id');
+      if (!nodeId) return;
+      const node = nodes.find(n => n.id === nodeId);
+      if (!node) return;
+      const svgRect = svgRef.current?.getBoundingClientRect();
+      if (!svgRect) return;
+      const x = event.clientX - svgRect.left;
+      const y = event.clientY - svgRect.top;
+      const svgCoords = svgRef.current ? getSVGCoordinates(svgRef.current, event.clientX, event.clientY) : { x: 0, y: 0 };
+      let content = node.placeName;
+      if (node.data.aliases && node.data.aliases.length > 0) content += ` (aka ${node.data.aliases.join(', ')})`;
+      if (node.data.description) content += `\n${node.data.description}`;
+      content += `\nStatus: ${node.data.status}`;
+      const anchor = computeAnchor(x, y, svgRect);
+      if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current);
+      tooltipTimeout.current = window.setTimeout(() => {
+        setTooltip({ content, svgX: svgCoords.x, svgY: svgCoords.y, anchor, nodeId });
+      }, TOOLTIP_DELAY_MS);
+    },
+    [computeAnchor, isTooltipLocked, nodes, svgRef],
+  );
+
+  const handleNodeClickById = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      const nodeId = event.currentTarget.getAttribute('data-node-id');
+      if (!nodeId) return;
+      const node = nodes.find(n => n.id === nodeId);
+      if (!node) return;
+      if (tooltipTimeout.current) {
+        clearTimeout(tooltipTimeout.current);
+        tooltipTimeout.current = null;
+      }
+      const svgRect = svgRef.current?.getBoundingClientRect();
+      if (!svgRect) return;
+      const x = event.clientX - svgRect.left;
+      const y = event.clientY - svgRect.top;
+      const svgCoords = svgRef.current ? getSVGCoordinates(svgRef.current, event.clientX, event.clientY) : { x: 0, y: 0 };
+      let content = node.placeName;
+      if (node.data.aliases && node.data.aliases.length > 0) content += ` (aka ${node.data.aliases.join(', ')})`;
+      if (node.data.description) content += `\n${node.data.description}`;
+      content += `\nStatus: ${node.data.status}`;
+      setIsTooltipLocked(true);
+      const anchor = computeAnchor(x, y, svgRect);
+      setTooltip({ content, svgX: svgCoords.x, svgY: svgCoords.y, anchor, nodeId });
+    },
+    [computeAnchor, nodes, svgRef],
+  );
+
+  const handleDestinationClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const nodeId = event.currentTarget.dataset.nodeId;
+      if (!nodeId) return;
+      if (nodeId === destinationNodeId) {
+        onSelectDestination(null);
+      } else {
+        onSelectDestination(nodeId);
+      }
+      setIsTooltipLocked(false);
+      setTooltip(null);
+    },
+    [destinationNodeId, onSelectDestination],
+  );
+
+  return {
+    tooltip,
+    tooltipScreenPosition,
+    isTooltipLocked,
+    handleMouseLeaveGeneral,
+    handleSvgClick,
+    handleEdgeMouseEnterById,
+    handleNodeMouseEnterById,
+    handleNodeClickById,
+    handleDestinationClick,
+    setIsTooltipLocked,
+  };
+};

--- a/utils/mapLabelUtils.ts
+++ b/utils/mapLabelUtils.ts
@@ -1,0 +1,220 @@
+/**
+ * @file mapLabelUtils.ts
+ * @description Utilities for label sizing and overlap handling on the map.
+ */
+
+import { MapNode } from '../types';
+import {
+  NODE_RADIUS,
+  MAX_LABEL_LINES,
+  DEFAULT_LABEL_MARGIN_PX,
+  DEFAULT_LABEL_LINE_HEIGHT_EM,
+} from '../constants';
+import { isDescendantOf } from './mapGraphUtils';
+
+/** Returns the radius for a node's circle. */
+export const getRadiusForNode = (node: MapNode): number => {
+  if (node.data.visualRadius) return node.data.visualRadius;
+  switch (node.data.nodeType) {
+    case 'region':
+      return NODE_RADIUS * 2.4;
+    case 'location':
+      return NODE_RADIUS * 2.0;
+    case 'settlement':
+      return NODE_RADIUS * 1.8;
+    case 'district':
+      return NODE_RADIUS * 1.6;
+    case 'exterior':
+      return NODE_RADIUS * 1.4;
+    case 'interior':
+      return NODE_RADIUS * 1.2;
+    case 'room':
+      return NODE_RADIUS * 0.8;
+    case 'feature':
+      return NODE_RADIUS * 0.6;
+    default:
+      return NODE_RADIUS * 0.6;
+  }
+};
+
+/** Splits a label into multiple lines for display. */
+export const splitTextIntoLines = (
+  text: string,
+  maxCharsPerLine: number,
+  maxLines: number,
+): Array<string> => {
+  if (!text) return [];
+  const words = text.split(' ');
+  const lines: Array<string> = [];
+  let currentLine = '';
+
+  for (const word of words) {
+    if (lines.length === maxLines) break;
+
+    if (currentLine.length === 0) {
+      currentLine = word;
+    } else if (currentLine.length + word.length + 1 <= maxCharsPerLine) {
+      currentLine += ` ${word}`;
+    } else {
+      lines.push(currentLine);
+      if (lines.length === maxLines) {
+        if (word) {
+          const lastLineContent = lines[maxLines - 1];
+          if (lastLineContent.length > 3) {
+            lines[maxLines - 1] = lastLineContent.slice(0, -3) + '...';
+          } else {
+            lines[maxLines - 1] = '..';
+          }
+        }
+        currentLine = '';
+        break;
+      }
+      currentLine = word;
+    }
+  }
+
+  if (currentLine && lines.length < maxLines) {
+    lines.push(currentLine);
+  } else if (currentLine && lines.length === maxLines && lines[maxLines - 1] && !lines[maxLines - 1].endsWith('...')) {
+    if (lines[maxLines - 1].length > 3) {
+      lines[maxLines - 1] = lines[maxLines - 1].slice(0, -3) + '...';
+    } else {
+      lines[maxLines - 1] = '..';
+    }
+  }
+
+  if (
+    lines.length === maxLines &&
+    text.split(' ').length > words.indexOf(currentLine.split(' ')[0]) + currentLine.split(' ').length
+  ) {
+    const lastLine = lines[maxLines - 1];
+    if (lastLine && lastLine.length > 3 && !lastLine.endsWith('...')) {
+      lines[maxLines - 1] = lastLine.slice(0, Math.max(0, lastLine.length - 3)) + '...';
+    } else if (lastLine && !lastLine.endsWith('...')) {
+      lines[maxLines - 1] = '..';
+    }
+  }
+  return lines;
+};
+
+export const isSmallFontType = (type: string | undefined) =>
+  type === 'feature' || type === 'room' || type === 'interior';
+
+export const hasCenteredLabel = (type: string | undefined) => type === 'feature';
+
+/**
+ * Calculate extra vertical offset for labels when they overlap. Feature labels
+ * stay fixed while sibling and descendant non-feature labels may shift down.
+ * Only immediate left/right siblings are considered for overlap checks.
+ */
+export const calculateLabelOffsets = (
+  nodes: Array<MapNode>,
+  labelOverlapMarginPx: number,
+): Record<string, number> => {
+  const idToNode = new Map(nodes.map(n => [n.id, n]));
+
+  const childrenMap = new Map<string, Array<MapNode>>();
+  nodes.forEach(n => {
+    if (n.data.parentNodeId) {
+      const arr = childrenMap.get(n.data.parentNodeId) ?? [];
+      arr.push(n);
+      childrenMap.set(n.data.parentNodeId, arr);
+    }
+  });
+
+  const depthCache = new Map<string, number>();
+  const getDepth = (node: MapNode | undefined): number => {
+    if (!node) return 0;
+    const cached = depthCache.get(node.id);
+    if (cached !== undefined) return cached;
+    const parent = node.data.parentNodeId ? idToNode.get(node.data.parentNodeId) : undefined;
+    const depth = parent ? getDepth(parent) + 1 : 0;
+    depthCache.set(node.id, depth);
+    return depth;
+  };
+  nodes.forEach(n => getDepth(n));
+
+  const isParent = (n: MapNode) => childrenMap.has(n.id);
+
+  const fontSizeFor = (n: MapNode) => (isSmallFontType(n.data.nodeType) ? 7 : 12);
+  const linesCache: Record<string, Array<string> | undefined> = {};
+  const getLines = (n: MapNode): Array<string> => {
+    const cached = linesCache[n.id];
+    if (cached) return cached;
+    const maxChars = isSmallFontType(n.data.nodeType) || !isParent(n) ? 20 : 25;
+    const lines = splitTextIntoLines(n.placeName, maxChars, MAX_LABEL_LINES);
+    linesCache[n.id] = lines;
+    return lines;
+  };
+
+  const labelHeight = (n: MapNode) => getLines(n).length * fontSizeFor(n) * DEFAULT_LABEL_LINE_HEIGHT_EM;
+
+  const labelWidth = (n: MapNode) => Math.max(...getLines(n).map(line => line.length * fontSizeFor(n) * 0.6));
+
+  const getLabelBox = (n: MapNode, offset: number) => {
+    const width = labelWidth(n);
+    const height = labelHeight(n);
+    if (hasCenteredLabel(n.data.nodeType)) {
+      return {
+        x: n.position.x - width / 2,
+        y: n.position.y - height / 2,
+        width,
+        height: height * 2,
+      };
+    }
+    const base = getRadiusForNode(n) + DEFAULT_LABEL_MARGIN_PX + offset;
+    return {
+      x: n.position.x - width / 2,
+      y: n.position.y + base,
+      width,
+      height,
+    };
+  };
+
+  const offsets: Record<string, number> = {};
+  nodes.forEach(n => {
+    offsets[n.id] = 0;
+  });
+
+  const boxesOverlap = (
+    a: { x: number; y: number; width: number; height: number },
+    b: { x: number; y: number; width: number; height: number },
+  ) => a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+
+  childrenMap.forEach(siblings => {
+    const ordered = [...siblings].sort((a, b) => a.position.x - b.position.x);
+    for (let i = 1; i < ordered.length; i++) {
+      const left = ordered[i - 1];
+      const right = ordered[i];
+
+      let boxLeft = getLabelBox(left, offsets[left.id]);
+      let boxRight = getLabelBox(right, offsets[right.id]);
+
+      if (boxesOverlap(boxLeft, boxRight)) {
+        const delta = boxLeft.y + boxLeft.height - boxRight.y + labelOverlapMarginPx;
+        if (right.data.nodeType !== 'feature') {
+          offsets[right.id] += delta;
+          boxRight = getLabelBox(right, offsets[right.id]);
+        } else if (left.data.nodeType !== 'feature') {
+          offsets[left.id] += delta;
+          boxLeft = getLabelBox(left, offsets[left.id]);
+        }
+      }
+    }
+  });
+
+  nodes.forEach(node => {
+    if (node.data.nodeType === 'feature') return;
+    const featureDescendants = nodes.filter(n => n.data.nodeType === 'feature' && isDescendantOf(n, node, idToNode));
+    for (const feature of featureDescendants) {
+      const nodeBox = getLabelBox(node, offsets[node.id]);
+      const featureBox = getLabelBox(feature, offsets[feature.id]);
+      if (boxesOverlap(nodeBox, featureBox)) {
+        const delta = featureBox.y + featureBox.height - nodeBox.y + labelOverlapMarginPx;
+        offsets[node.id] += delta;
+      }
+    }
+  });
+
+  return offsets;
+};


### PR DESCRIPTION
## Summary
- add `useMapTooltip` hook for tooltip state and handlers
- add `mapLabelUtils` utilities for label overlap math
- simplify `MapNodeView` by using new hook and utilities

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853fc2356248324aefb1e324a19a0b0