### PR TITLE
Refactor map context formatting helpers

### DIFF
--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -17,6 +17,7 @@ import { fetchMapUpdatePayload } from './request';
 import { applyMapUpdates } from './applyUpdates';
 import type { MapUpdateServiceResult } from './types';
 import { isApiConfigured } from '../apiClient';
+import { formatNodeLine, formatEdgeLine } from '../../utils/promptFormatters/map';
 
 /**
  * Combines prompt creation, AI request and payload application.
@@ -62,15 +63,11 @@ export const updateMapFromAIData_Service = async (
 
   const existingMapContext = `Current Map Nodes (for your reference):\n${
     currentThemeNodesFromMapData.length > 0
-      ? currentThemeNodesFromMapData
-          .map(n => `- "${n.placeName}" (${n.data.nodeType})`)
-          .join('\n')
+      ? currentThemeNodesFromMapData.map(n => formatNodeLine(n)).join('\n')
       : 'None exist yet.'
   }\n\nCurrent Map Edges (for your reference):\n${
     currentThemeEdgesFromMapData.length > 0
-      ? currentThemeEdgesFromMapData
-          .map(e => `- ${e.id} from ${e.sourceNodeId} to ${e.targetNodeId}`)
-          .join('\n')
+      ? currentThemeEdgesFromMapData.map(e => formatEdgeLine(e)).join('\n')
       : 'None exist yet.'
   }`;
 


### PR DESCRIPTION
## Summary
- introduce helpers `formatNodeLine`, `formatEdgeLine` and `formatObservationsForPrompt`
- reuse new helpers when building existing map context
- update map context formatter to use helper functions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853fea6c3108324b682c4711f3c8e40