### PR TITLE
Refactor useGameLogic with dedicated hooks

### DIFF
--- a/hooks/useDialogueFlow.ts
+++ b/hooks/useDialogueFlow.ts
@@ -13,7 +13,7 @@ import {
 import { useDialogueTurn } from './useDialogueTurn';
 import { useDialogueSummary } from './useDialogueSummary';
 
-interface UseDialogueFlowProps {
+export interface UseDialogueFlowProps {
   getCurrentGameState: () => FullGameState;
   commitGameState: (newGameState: FullGameState) => void;
   playerGenderProp: string;

--- a/hooks/useDialogueManagement.ts
+++ b/hooks/useDialogueManagement.ts
@@ -1,0 +1,7 @@
+import { useDialogueFlow, type UseDialogueFlowProps } from './useDialogueFlow';
+
+export type UseDialogueManagementProps = UseDialogueFlowProps;
+
+export const useDialogueManagement = (props: UseDialogueManagementProps) => {
+  return useDialogueFlow(props);
+};

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -6,10 +6,9 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { ThemePackName, FullGameState, GameStateStack, LoadingReason } from '../types';
 import { getInitialGameStates } from '../utils/initialStates';
-import { useDialogueFlow } from './useDialogueFlow';
+import { useDialogueManagement } from './useDialogueManagement';
 import { useRealityShift } from './useRealityShift';
-import { useMapUpdates } from './useMapUpdates';
-import { usePlayerActions } from './usePlayerActions';
+import { useGameTurn } from './useGameTurn';
 import { useGameInitialization, LoadInitialGameOptions } from './useGameInitialization';
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { PLAYER_HOLDER_ID } from '../constants';
@@ -71,13 +70,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   }, []);
 
   const {
-    handleMapLayoutConfigChange,
-    handleMapViewBoxChange,
-    handleMapNodesPositionChange,
-    handleSelectDestinationNode,
-  } = useMapUpdates({ setGameStateStack });
-
-  const {
     triggerRealityShift,
     executeManualRealityShift,
     completeManualShiftWithSelectedTheme,
@@ -99,6 +91,10 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   manualShiftRef.current = executeManualRealityShift;
 
   const {
+    handleMapLayoutConfigChange,
+    handleMapViewBoxChange,
+    handleMapNodesPositionChange,
+    handleSelectDestinationNode,
     processAiResponse,
     handleActionSelect,
     handleItemInteraction,
@@ -106,7 +102,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     handleTakeLocationItem,
     handleFreeFormActionSubmit,
     handleUndoTurn,
-  } = usePlayerActions({
+  } = useGameTurn({
     getCurrentGameState,
     commitGameState,
     setGameStateStack,
@@ -152,7 +148,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   loadInitialGameRef.current = loadInitialGame;
 
 
-  const { isDialogueExiting, handleDialogueOptionSelect, handleForceExitDialogue } = useDialogueFlow({
+  const { isDialogueExiting, handleDialogueOptionSelect, handleForceExitDialogue } = useDialogueManagement({
     getCurrentGameState,
     commitGameState,
     playerGenderProp,

--- a/hooks/useGameTurn.ts
+++ b/hooks/useGameTurn.ts
@@ -1,0 +1,16 @@
+import { usePlayerActions, UsePlayerActionsProps } from './usePlayerActions';
+import { useMapUpdates } from './useMapUpdates';
+
+export type UseGameTurnProps = UsePlayerActionsProps;
+
+export const useGameTurn = (props: UseGameTurnProps) => {
+  const { setGameStateStack } = props;
+
+  const mapUpdateFns = useMapUpdates({ setGameStateStack });
+  const playerActionFns = usePlayerActions(props);
+
+  return {
+    ...playerActionFns,
+    ...mapUpdateFns,
+  };
+};


### PR DESCRIPTION
## Summary
- expose `UseDialogueFlowProps`
- split player actions and map updates into `useGameTurn`
- alias dialogue management as `useDialogueManagement`
- compose new hooks inside `useGameLogic`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68540fa9df70832497f55a94f784891b