### PR TITLE
Fix eslint errors

### DIFF
--- a/components/elements/Button.tsx
+++ b/components/elements/Button.tsx
@@ -1,32 +1,32 @@
 import { useCallback } from 'react';
-import * as React from 'react';
 import type { ReactNode, MouseEvent } from 'react';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  readonly label?: ReactNode;
+export interface ButtonProps {
   readonly ariaLabel: string;
   readonly onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  readonly className?: string;
   readonly disabled?: boolean;
   readonly icon?: ReactNode;
-  readonly size?: 'sm' | 'md' | 'lg';
-  readonly className?: string;
-  readonly variant?: 'standard' | 'toolbar' | 'toggle' | 'primary' | 'danger';
+  readonly label?: ReactNode;
   readonly pressed?: boolean;
+  readonly size?: 'sm' | 'md' | 'lg';
+  readonly title?: string;
   readonly type?: 'button' | 'submit' | 'reset';
+  readonly variant?: 'standard' | 'toolbar' | 'toggle' | 'primary' | 'danger';
 }
 
 function Button({
-  label,
   ariaLabel,
   onClick,
+  className = '',
   disabled = false,
   icon,
-  size = 'md',
-  className = '',
-  variant = 'standard',
+  label,
   pressed = false,
+  size = 'md',
+  title,
   type = 'button',
-  ...rest
+  variant = 'standard',
 }: ButtonProps) {
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
@@ -59,8 +59,8 @@ function Button({
       className={`rounded shadow transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${sizeClasses[size]} ${variantClasses[variant]} ${pressedClasses} ${className}`}
       disabled={disabled}
       onClick={handleClick}
-      type={type}
-      {...rest}
+      title={title}
+      type={type === 'submit' ? 'submit' : type === 'reset' ? 'reset' : 'button'}
     >
       {icon ? (
         <span className={label ? 'mr-2 inline-flex' : 'inline-flex'}>
@@ -80,6 +80,7 @@ Button.defaultProps = {
   label: undefined,
   pressed: false,
   size: 'md',
+  title: undefined,
   type: 'button',
   variant: 'standard',
 };

--- a/components/elements/icons.tsx
+++ b/components/elements/icons.tsx
@@ -1,40 +1,40 @@
 /**
  * Provides a single Icon component that renders SVGs from the icons folder.
 */
-import realityShiftSvg from './icons/reality_shift.svg?raw';
-import coinSvg from './icons/coin.svg?raw';
-import visualizeSvg from './icons/visualize.svg?raw';
-import bookOpenSvg from './icons/book_open.svg?raw';
-import menuSvg from './icons/menu.svg?raw';
-import infoSvg from './icons/info.svg?raw';
-import scrollSvg from './icons/scroll.svg?raw';
-import mapSvg from './icons/map.svg?raw';
-import inventorySvg from './icons/inventory.svg?raw';
-import trashSvg from './icons/trash.svg?raw';
-import logSvg from './icons/log.svg?raw';
-import companionSvg from './icons/companion.svg?raw';
-import nearbyNpcSvg from './icons/nearby_npc.svg?raw';
-import mapItemBoxSvg from './icons/map_item_box.svg?raw';
-import mapWheelSvg from './icons/map_wheel.svg?raw';
-import xSvg from './icons/x.svg?raw';
+import RealityShiftIcon from './icons/reality_shift.svg?react';
+import CoinIcon from './icons/coin.svg?react';
+import VisualizeIcon from './icons/visualize.svg?react';
+import BookOpenIcon from './icons/book_open.svg?react';
+import MenuIcon from './icons/menu.svg?react';
+import InfoIcon from './icons/info.svg?react';
+import ScrollIcon from './icons/scroll.svg?react';
+import MapIcon from './icons/map.svg?react';
+import InventoryIcon from './icons/inventory.svg?react';
+import TrashIcon from './icons/trash.svg?react';
+import LogIcon from './icons/log.svg?react';
+import CompanionIcon from './icons/companion.svg?react';
+import NearbyNpcIcon from './icons/nearby_npc.svg?react';
+import MapItemBoxIcon from './icons/map_item_box.svg?react';
+import MapWheelIcon from './icons/map_wheel.svg?react';
+import XIcon from './icons/x.svg?react';
 
 const iconMap = {
-  realityShift: realityShiftSvg,
-  coin: coinSvg,
-  visualize: visualizeSvg,
-  bookOpen: bookOpenSvg,
-  menu: menuSvg,
-  info: infoSvg,
-  scroll: scrollSvg,
-  map: mapSvg,
-  inventory: inventorySvg,
-  trash: trashSvg,
-  log: logSvg,
-  companion: companionSvg,
-  nearbyNpc: nearbyNpcSvg,
-  mapItemBox: mapItemBoxSvg,
-  mapWheel: mapWheelSvg,
-  x: xSvg,
+  realityShift: RealityShiftIcon,
+  coin: CoinIcon,
+  visualize: VisualizeIcon,
+  bookOpen: BookOpenIcon,
+  menu: MenuIcon,
+  info: InfoIcon,
+  scroll: ScrollIcon,
+  map: MapIcon,
+  inventory: InventoryIcon,
+  trash: TrashIcon,
+  log: LogIcon,
+  companion: CompanionIcon,
+  nearbyNpc: NearbyNpcIcon,
+  mapItemBox: MapItemBoxIcon,
+  mapWheel: MapWheelIcon,
+  x: XIcon,
 } as const;
 
 export type IconName = keyof typeof iconMap;
@@ -67,7 +67,7 @@ export function Icon({
   marginRight,
   wrapper = 'span',
 }: IconProps) {
-  const svgMarkup = iconMap[name];
+  const SvgIcon = iconMap[name];
 
   const colorClasses: Record<IconColor, string> = {
     amber: 'text-amber-400',
@@ -82,10 +82,6 @@ export function Icon({
     .filter(Boolean)
     .join(' ');
 
-  const svgAttrs = (svgClasses ? ` class="${svgClasses}"` : '') +
-    (size ? ` width="${String(size)}" height="${String(size)}"` : '');
-  const rendered = svgMarkup.replace('<svg', `<svg${svgAttrs}`);
-
   const style = marginRight ? { marginRight } : undefined;
   const wrapperClasses = inline ? 'inline-block' : undefined;
 
@@ -93,17 +89,27 @@ export function Icon({
     return (
       <g
         className={wrapperClasses}
-        dangerouslySetInnerHTML={{ __html: rendered }}
         style={style}
-      />
+      >
+        <SvgIcon
+          className={svgClasses}
+          height={size}
+          width={size}
+        />
+      </g>
     );
   }
   return (
     <span
       className={wrapperClasses}
-      dangerouslySetInnerHTML={{ __html: rendered }}
       style={style}
-    />
+    >
+      <SvgIcon
+        className={svgClasses}
+        height={size}
+        width={size}
+      />
+    </span>
   );
 }
 

--- a/hooks/useAutosave.ts
+++ b/hooks/useAutosave.ts
@@ -27,6 +27,8 @@ export function useAutosave({
 }: UseAutosaveOptions) {
   const autosaveTimeoutRef = useRef<number | null>(null);
 
+  const dependenciesKey = JSON.stringify(dependencies);
+
   useEffect(() => {
     if (isLoading || !hasGameBeenInitialized || !appReady || !!dialogueState) {
       return;
@@ -50,6 +52,6 @@ export function useAutosave({
     hasGameBeenInitialized,
     appReady,
     dialogueState,
-    ...dependencies,
+    dependenciesKey,
   ]);
 }


### PR DESCRIPTION
## Summary
- refactor Button component to avoid spread props and enforce literal type attribute
- replace dangerouslySetInnerHTML usage in Icon component
- fix autosave hook dependencies handling to satisfy lint

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68541a24144c8324b3ca498fda781291