### PR TITLE
Fix TextBox padding, add header icon prop

### DIFF
--- a/components/GameLogDisplay.tsx
+++ b/components/GameLogDisplay.tsx
@@ -17,17 +17,15 @@ interface GameLogDisplayProps {
  */
 function GameLogDisplay({ messages }: GameLogDisplayProps) {
   const logEndRef = useRef<null | HTMLDivElement>(null);
-  const header = (
-    <>
-      <Icon
-        color="emerald"
-        inline
-        marginRight={8}
-        name="log"
-        size={20}
-      />
-      Game Log
-    </>
+  const header = 'Game Log';
+  const headerIcon = (
+    <Icon
+      color="emerald"
+      inline
+      marginRight={8}
+      name="log"
+      size={20}
+    />
   );
 
   const logItems = (() => {
@@ -60,6 +58,7 @@ function GameLogDisplay({ messages }: GameLogDisplayProps) {
       header={header}
       headerColorClass="text-emerald-400"
       headerFontClass="text-xl font-bold flex items-center"
+      headerIcon={headerIcon}
       headerTag="h3"
     >
       <ul className="space-y-2 text-sm">

--- a/components/elements/TextBox.tsx
+++ b/components/elements/TextBox.tsx
@@ -18,10 +18,12 @@ export interface TextBoxProps {
   readonly headerColorClass?: string;
   readonly contentFontClass?: string;
   readonly contentColorClass?: string;
+  readonly headerIcon?: ReactNode;
 }
 
 function TextBox({
   header,
+  headerIcon,
   children,
   text,
   highlightEntities,
@@ -39,7 +41,7 @@ function TextBox({
   const content = text
     ? text.split('\n').map(para => (
       <p
-        className="mb-3"
+        className="mb-3 last:mb-0"
         key={para}
       >
         {highlightEntities
@@ -61,6 +63,12 @@ function TextBox({
         <HeadingTag
           className={`${headerFontClass} ${headerColorClass} mb-3 pb-1 ${borderWidthClass} ${borderColorClass}`}
         >
+          {headerIcon ? (
+            <span className="mr-2 inline-flex">
+              {headerIcon}
+            </span>
+          ) : null}
+
           {header}
         </HeadingTag>
       ) : null}
@@ -84,6 +92,7 @@ TextBox.defaultProps = {
   header: undefined,
   headerColorClass: 'text-amber-400',
   headerFontClass: 'text-2xl font-semibold',
+  headerIcon: undefined,
   headerTag: 'h2',
   highlightEntities: undefined,
   text: undefined,


### PR DESCRIPTION
## Summary
- give TextBox `headerIcon` prop and fix bottom spacing
- adjust GameLogDisplay to use new icon prop

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68545b841f8c83248dab40c6fced4a26