### PR TITLE
Add versatile item list formatter

### DIFF
--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -17,7 +17,7 @@ import {
   buildItemChangeRecords,
   applyAllItemChanges,
 } from '../utils/gameLogicUtils';
-import { formatInventoryForPrompt } from '../utils/promptFormatters/inventory';
+import { itemsToString } from '../utils/promptFormatters/inventory';
 import { formatLimitedMapContextForPrompt } from '../utils/promptFormatters/map';
 import { useMapUpdateProcessor } from './useMapUpdateProcessor';
 import { applyInventoryHints_Service } from '../services/inventory';
@@ -180,7 +180,7 @@ const handleInventoryHints = async ({
     return chars
       .map((ch) => {
         const items = baseState.inventory.filter((i) => i.holderId === ch.id);
-        return `ID: ${ch.id} - ${ch.name}: ${formatInventoryForPrompt(items)}`;
+        return `ID: ${ch.id} - ${ch.name}: ${itemsToString(items, ' - ')}`;
       })
       .join('\n');
   };
@@ -201,8 +201,8 @@ const handleInventoryHints = async ({
       'npcItemsHint' in aiData ? aiData.npcItemsHint : undefined,
       'newItems' in aiData && Array.isArray(aiData.newItems) ? aiData.newItems : [],
       playerActionText ?? '',
-      formatInventoryForPrompt(baseInventoryForPlayer),
-      formatInventoryForPrompt(locationInventory),
+      itemsToString(baseInventoryForPlayer, ' - '),
+      itemsToString(locationInventory, ' - '),
       baseState.currentMapNodeId ?? null,
       formatCharInventoryList(companionChars),
       formatCharInventoryList(nearbyChars),

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -13,7 +13,7 @@ import {
   ThemeHistoryState,
 } from '../../types';
 import {
-  formatInventoryForPrompt,
+  itemsToString,
   formatKnownPlacesForPrompt,
   formatMapContextForPrompt,
   formatKnownCharactersForPrompt,
@@ -57,7 +57,7 @@ export const buildNewThemePostShiftPrompt = (
   inventory: Array<Item>,
   playerGender: string
 ): string => {
-  const inventoryPrompt = formatInventoryForPrompt(inventory);
+  const inventoryPrompt = itemsToString(inventory, ' - ');
   const prompt = `The player is entering a NEW theme "${theme.name}" after a reality shift.
 Player's Character Gender: "${playerGender}"
 Initial Scene: "${theme.initialSceneDescriptionSeed}" (adapt to an arrival scene describing the disorienting transition).
@@ -89,7 +89,7 @@ export const buildReturnToThemePostShiftPrompt = (
   mapDataForTheme: MapData,
   allCharactersForTheme: Array<Character>
 ): string => {
-  const inventoryPrompt = formatInventoryForPrompt(inventory);
+  const inventoryPrompt = itemsToString(inventory, ' - ');
   const currentThemeMainMapNodes = mapDataForTheme.nodes.filter(
     n => n.themeName === theme.name && n.data.nodeType !== 'feature' && n.data.nodeType !== 'room'
   );
@@ -141,8 +141,9 @@ export const buildMainGameTurnPrompt = (
   fullMapData: MapData,
   destinationNodeId: string | null
 ): string => {
-  const inventoryPrompt = formatInventoryForPrompt(inventory);
-  const locationItemsPrompt = locationItems.length > 0 ? formatInventoryForPrompt(locationItems) : '';
+  const inventoryPrompt = itemsToString(inventory, ' - ');
+  const locationItemsPrompt =
+    locationItems.length > 0 ? itemsToString(locationItems, ' - ') : '';
   const inventorySection = `${inventoryPrompt}${locationItemsPrompt ? `\nThere are items at this location:\n${locationItemsPrompt}` : ''}`;
   const placesContext = formatKnownPlacesForPrompt(currentThemeMainMapNodes, true);
   const charactersContext = formatKnownCharactersForPrompt(currentThemeCharacters, true);

--- a/utils/promptFormatters/inventory.ts
+++ b/utils/promptFormatters/inventory.ts
@@ -9,16 +9,29 @@ import { Item } from '../../types';
 /**
  * Formats a list of items for use in AI prompts.
  */
-export const formatInventoryForPrompt = (inventory: Array<Item>): string => {
-  if (inventory.length === 0) return "Empty.";
-  return inventory
+export const itemsToString = (
+  items: Item | Array<Item>,
+  prefix = '',
+  addDescription = true,
+  addKnownUses = true,
+  singleLine = false,
+): string => {
+  const itemList = Array.isArray(items) ? items : [items];
+  if (itemList.length === 0) return 'Empty.';
+  const delimiter = singleLine ? '; ' : ';\n';
+
+  return itemList
     .map(item => {
-      let itemStr = ` - ${item.id} - "${item.name}" (Type: "${item.type}", Description: "${
-        item.isActive && item.activeDescription
-          ? item.activeDescription
-          : item.description
-      }"${item.isActive ? ', It is active' : ''})`;
-      if (item.knownUses && item.knownUses.length > 0) {
+      let itemStr = `${prefix}${item.id} - "${item.name}"`;
+      if (addDescription) {
+        itemStr += ` (Type: "${item.type}", Description: "${
+          item.isActive && item.activeDescription
+            ? item.activeDescription
+            : item.description
+        }"${item.isActive ? ', It is active' : ''})`;
+      }
+
+      if (addKnownUses && item.knownUses && item.knownUses.length > 0) {
         const applicableUses = item.knownUses.filter(ku => {
           const isActive = !!item.isActive;
           if (
@@ -42,8 +55,9 @@ export const formatInventoryForPrompt = (inventory: Array<Item>): string => {
             .join(', ')}`;
         }
       }
+
       return itemStr;
     })
-    .join(";\n");
+    .join(delimiter);
 };
 


### PR DESCRIPTION
## Summary
- replace `formatInventoryForPrompt` with more flexible `itemsToString`
- adjust storyteller prompt builder to use new function
- update AI response processing to call `itemsToString`
- support formatting single item or list with optional description/uses and custom delimiter

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68546b1cf1188324a0a4b218b5a686c3