### PR TITLE
Implement map string helpers

### DIFF
--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -66,7 +66,7 @@ export const updateMapFromAIData_Service = async (
 
   const existingMapContext = `Current Map Nodes (for your reference):\n${
     currentThemeNodesFromMapData.length > 0
-      ? formatNodesAsTree(currentThemeNodesFromMapData).join('\n')
+      ? formatNodesAsTree(currentThemeNodesFromMapData)
       : 'None exist yet.'
   }\n\nCurrent Map Edges (for your reference):\n${
     currentThemeEdgesFromMapData.length > 0


### PR DESCRIPTION
## Summary
- add new helpers `mapNodesToString` and `mapEdgesToString`
- refactor `formatNodesAsTree` to use `mapNodesToString` and return a string
- adjust cartographer API to use updated tree formatter
- drop the unused `prefix` parameter from `formatNodesAsTree`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68548bc489808324b356efdd2b459ddd