### PR TITLE
Add button presets

### DIFF
--- a/components/ActionOptions.tsx
+++ b/components/ActionOptions.tsx
@@ -56,7 +56,6 @@ function ActionOptions({
         {options.map((option) => (
           <Button
             ariaLabel={option}
-            className="w-full p-4 rounded-lg shadow-md transition-all duration-150 ease-in-out text-left text-white font-medium text-lg bg-sky-700 hover:bg-sky-600 focus:ring-4 focus:ring-sky-500 focus:outline-none disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed border border-sky-800 hover:border-sky-500 transform hover:scale-105 disabled:transform-none"
             disabled={disabled || option === '...'}
             key={option}
             label={<>
@@ -64,7 +63,9 @@ function ActionOptions({
               {highlightEntitiesInText(option, entitiesForHighlighting)}
             </>}
             onClick={handleOptionClick(option)}
+            preset="sky"
             size="md"
+            variant="left"
           />
         ))}
       </div>

--- a/components/ConfirmationDialog.tsx
+++ b/components/ConfirmationDialog.tsx
@@ -5,7 +5,7 @@
  * @description Modal dialog to confirm user actions.
  */
 import { useCallback } from 'react';
-import Button from './elements/Button';
+import Button, { type ButtonProps } from './elements/Button';
 
 import * as React from 'react';
 
@@ -17,7 +17,7 @@ interface ConfirmationDialogProps {
   readonly onCancel: () => void;
   readonly confirmText?: string;
   readonly cancelText?: string;
-  readonly confirmButtonClass?: string;
+  readonly confirmPreset?: ButtonProps['preset'];
   readonly isCustomModeShift?: boolean; // New prop
 }
 
@@ -30,9 +30,9 @@ function ConfirmationDialog({
   message,
   onConfirm,
   onCancel,
-  confirmText = "Confirm",
-  cancelText = "Cancel",
-  confirmButtonClass = "bg-sky-600 hover:bg-sky-500",
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  confirmPreset = 'sky',
   isCustomModeShift = false, // Destructure new prop with default
 }: ConfirmationDialogProps) {
   const stopPropagation = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -78,18 +78,20 @@ function ConfirmationDialog({
         <div className="flex justify-end space-x-4">
           <Button
             ariaLabel={cancelText}
-            className="bg-slate-600 hover:bg-slate-500 text-white font-semibold rounded-lg shadow-md transition-all duration-150 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-slate-400"
             label={cancelText}
             onClick={onCancel}
+            preset="slate"
             size="md"
+            variant="compact"
           />
 
           <Button
             ariaLabel={confirmText}
-            className={`text-white font-semibold rounded-lg shadow-md transition-all duration-150 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 ${confirmButtonClass} focus:ring-opacity-75`}
             label={confirmText}
             onClick={onConfirm}
+            preset={confirmPreset}
             size="md"
+            variant="compact"
           />
         </div>
       </div>
@@ -114,7 +116,7 @@ function ConfirmationDialog({
 
 ConfirmationDialog.defaultProps = {
   cancelText: 'Cancel',
-  confirmButtonClass: 'bg-sky-600 hover:bg-sky-500',
+  confirmPreset: 'sky',
   confirmText: 'Confirm',
   isCustomModeShift: false,
 };

--- a/components/DialogueDisplay.tsx
+++ b/components/DialogueDisplay.tsx
@@ -104,7 +104,6 @@ function DialogueDisplay({
           {options.map(option => (
             <Button
               ariaLabel={option}
-              className="w-full p-3 rounded-md shadow transition-all duration-150 ease-in-out text-left text-white font-medium animate-dialogue-new-entry bg-sky-700 hover:bg-sky-600 focus:ring-2 focus:ring-sky-500 focus:outline-none disabled:bg-slate-500 disabled:text-slate-400 disabled:cursor-not-allowed border border-sky-800 hover:border-sky-500"
               data-option={option}
               disabled={optionsDisabled}
               enableHighlightTap
@@ -112,7 +111,9 @@ function DialogueDisplay({
               key={option}
               label={option}
               onClick={handleOptionClick}
+              preset="sky"
               size="md"
+              variant="left"
             />
           ))}
         </div>
@@ -132,7 +133,6 @@ function DialogueDisplay({
       <div className="dialogue-frame-content">
         <Button
           ariaLabel="End Conversation"
-          className="animated-frame-close-button"
           disabled={isLoading || isDialogueExiting}
           icon={<Icon
             name="x"
@@ -140,6 +140,7 @@ function DialogueDisplay({
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <h1

--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -89,7 +89,6 @@ function MainToolbar({
       <div className="flex space-x-2">
         <Button
           ariaLabel="Visualize Scene"
-          className="bg-blue-700 hover:bg-blue-600 text-white rounded-md shadow-md disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={isLoading || !currentThemeName || !currentSceneExists}
           icon={<Icon
             inline
@@ -97,6 +96,7 @@ function MainToolbar({
             size={20}
                 />}
           onClick={onOpenVisualizer}
+          preset="blue"
           size="md"
           title="Visualize Scene"
           variant="toolbar"
@@ -104,7 +104,6 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open Knowledge Base"
-          className="bg-blue-700 hover:bg-blue-600 text-white rounded-md shadow-md disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={isLoading || !currentThemeName}
           icon={<Icon
             inline
@@ -112,6 +111,7 @@ function MainToolbar({
             size={20}
                 />}
           onClick={onOpenKnowledgeBase}
+          preset="blue"
           size="md"
           title="Open Knowledge Base"
           variant="toolbar"
@@ -119,7 +119,6 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open History"
-          className="bg-blue-700 hover:bg-blue-600 text-white rounded-md shadow-md disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={isLoading || !currentThemeName}
           icon={<Icon
             inline
@@ -127,6 +126,7 @@ function MainToolbar({
             size={20}
                 />}
           onClick={onOpenHistory}
+          preset="blue"
           size="md"
           title="Open History"
           variant="toolbar"
@@ -134,7 +134,6 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open Map"
-          className="bg-blue-700 hover:bg-blue-600 text-white rounded-md shadow-md disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={isLoading || !currentThemeName}
           icon={<Icon
             inline
@@ -142,6 +141,7 @@ function MainToolbar({
             size={20}
                 />}
           onClick={onOpenMap}
+          preset="blue"
           size="md"
           title="Open Map"
           variant="toolbar"
@@ -149,7 +149,6 @@ function MainToolbar({
 
         <Button
           ariaLabel="Force Reality Shift"
-          className="bg-purple-700 hover:bg-purple-600 text-white rounded-md shadow-md disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={isLoading || !currentThemeName}
           icon={<Icon
             inline
@@ -157,6 +156,7 @@ function MainToolbar({
             size={20}
                 />}
           onClick={onManualRealityShift}
+          preset="purple"
           size="md"
           title="Force Reality Shift"
           variant="toolbar"
@@ -164,7 +164,6 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open Title Menu"
-          className="bg-gray-700 hover:bg-gray-600 text-white rounded-md shadow-md disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={isLoading}
           icon={<Icon
             inline
@@ -172,6 +171,7 @@ function MainToolbar({
             size={20}
                 />}
           onClick={onOpenTitleMenu}
+          preset="gray"
           size="md"
           title="Open Title Menu"
           variant="toolbar"

--- a/components/app/AppModals.tsx
+++ b/components/app/AppModals.tsx
@@ -165,7 +165,7 @@ function AppModals({
 
 
       <ConfirmationDialog
-        confirmButtonClass="bg-red-600 hover:bg-red-500"
+        confirmPreset="red"
         confirmText="Start New Game"
         isOpen={newGameFromMenuConfirmOpen}
         message="Are you sure you want to start a new game? Your current progress will be lost."
@@ -175,7 +175,7 @@ function AppModals({
       />
 
       <ConfirmationDialog
-        confirmButtonClass="bg-orange-600 hover:bg-orange-500"
+        confirmPreset="orange"
         confirmText="Start Custom Game"
         isOpen={newCustomGameConfirmOpen}
         message="Are you sure you want to start a new custom game? Your current progress will be lost."
@@ -185,7 +185,7 @@ function AppModals({
       />
 
       <ConfirmationDialog
-        confirmButtonClass="bg-blue-600 hover:bg-blue-500"
+        confirmPreset="blue"
         confirmText="Load Game"
         isOpen={loadGameFromMenuConfirmOpen}
         message="Are you sure you want to load a game? Your current progress will be overwritten if you load a new game."
@@ -195,7 +195,7 @@ function AppModals({
       />
 
       <ConfirmationDialog
-        confirmButtonClass="bg-purple-600 hover:bg-purple-500"
+        confirmPreset="purple"
         confirmText="Shift Reality"
         isCustomModeShift={isCustomGameModeShift}
         isOpen={shiftConfirmOpen}

--- a/components/app/FreeActionInput.tsx
+++ b/components/app/FreeActionInput.tsx
@@ -51,11 +51,12 @@ function FreeActionInput({
 
         <Button
           ariaLabel="Submit custom action"
-          className="px-4 py-2 bg-green-700 hover:bg-green-600 text-white font-semibold rounded-md shadow disabled:bg-slate-500 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150"
           disabled={!canPerformFreeAction || freeFormActionText.trim() === ''}
           label="Submit"
           onClick={handleSubmitClick}
+          preset="green"
           type="button"
+          variant="compact"
         />
       </div>
 

--- a/components/debug/DebugView.tsx
+++ b/components/debug/DebugView.tsx
@@ -121,11 +121,12 @@ function DebugView({
           <>
             <Button
               ariaLabel="Undo last turn"
-              className="mb-3 bg-orange-600 text-white hover:bg-orange-500 disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed"
               disabled={!previousState || currentState.globalTurnNumber <= 1}
               label={`Undo Turn (Global Turn: ${String(currentState.globalTurnNumber)})`}
               onClick={onUndoTurn}
+              preset="orange"
               size="sm"
+              variant="compact"
             />
 
             <DebugSection
@@ -160,9 +161,9 @@ function DebugView({
             <div className="my-2">
               <Button
                 ariaLabel="Toggle raw parsed response"
-                className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                 label="Toggle Raw/Parsed Response"
                 onClick={toggleShowMainAIRaw}
+                preset="slate"
                 pressed={showMainAIRaw}
                 size="sm"
                 variant="toggle"
@@ -218,9 +219,9 @@ function DebugView({
                 <div className="my-2">
                   <Button
                     ariaLabel="Toggle raw parsed map response"
-                    className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                     label="Toggle Raw/Parsed Map Update Response"
                     onClick={toggleShowMapAIRaw}
+                    preset="slate"
                     pressed={showMapAIRaw}
                     size="sm"
                     variant="toggle"
@@ -286,9 +287,9 @@ function DebugView({
                       <div className="my-2">
                         <Button
                           ariaLabel="Toggle raw parsed connector chain response"
-                          className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                           label="Toggle Raw/Parsed Connector Chains Response"
                           onClick={toggleShowConnectorChainRaw(idx)}
+                          preset="slate"
                           pressed={showConnectorChainRaw[idx] ?? true}
                           size="sm"
                           variant="toggle"
@@ -415,9 +416,9 @@ function DebugView({
             <div className="my-2">
               <Button
                 ariaLabel="Toggle raw parsed inventory response"
-                className="px-3 py-1 text-xs bg-slate-600 hover:bg-slate-500 rounded"
                 label="Toggle Raw/Parsed Inventory Response"
                 onClick={toggleShowInventoryAIRaw}
+                preset="slate"
                 pressed={showInventoryAIRaw}
                 size="sm"
                 variant="toggle"
@@ -578,13 +579,13 @@ function DebugView({
       <div className="animated-frame-content flex flex-col">
         <Button
           ariaLabel="Close debug view"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <h1
@@ -598,11 +599,12 @@ function DebugView({
           {tabs.map(tab => (
             <Button
               ariaLabel={tab.label}
-              className={`px-3 py-2 text-sm font-medium transition-colors ${activeTab === tab.name ? 'border-b-2 border-sky-400 text-sky-300' : 'text-slate-400 hover:text-sky-400'}`}
               key={tab.name}
               label={tab.label}
               onClick={handleTabClick(tab.name)}
+              pressed={activeTab === tab.name}
               size="sm"
+              variant="tab"
             />
           ))}
         </div>

--- a/components/elements/Button.tsx
+++ b/components/elements/Button.tsx
@@ -7,7 +7,6 @@ export interface ButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'className' | 'disabled' | 'type'> {
   readonly ariaLabel: string;
   readonly onClick: (event: MouseEvent<HTMLButtonElement>) => void;
-  readonly className?: string;
   readonly disabled?: boolean;
   readonly icon?: ReactNode;
   readonly label?: ReactNode;
@@ -17,13 +16,43 @@ export interface ButtonProps
   readonly size?: 'sm' | 'md' | 'lg';
   readonly title?: string;
   readonly type?: 'button' | 'submit' | 'reset';
-  readonly variant?: 'standard' | 'toolbar' | 'toggle' | 'primary' | 'danger';
+  readonly variant?:
+    | 'standard'
+    | 'left'
+    | 'compact'
+    | 'toolbar'
+    | 'toggle'
+    | 'close'
+    | 'tab'
+    | 'primary';
+  readonly preset?:
+    | 'slate'
+    | 'gray'
+    | 'zinc'
+    | 'neutral'
+    | 'stone'
+    | 'red'
+    | 'orange'
+    | 'amber'
+    | 'yellow'
+    | 'lime'
+    | 'green'
+    | 'emerald'
+    | 'teal'
+    | 'cyan'
+    | 'sky'
+    | 'blue'
+    | 'indigo'
+    | 'violet'
+    | 'purple'
+    | 'fuchsia'
+    | 'pink'
+    | 'rose';
 }
 
 function Button({
   ariaLabel,
   onClick,
-  className = '',
   disabled = false,
   icon,
   label,
@@ -34,6 +63,7 @@ function Button({
   title,
   type = 'button',
   variant = 'standard',
+  preset,
   ...rest
 }: ButtonProps) {
   const handleClick = useCallback(
@@ -50,15 +80,61 @@ function Button({
     lg: 'px-6 py-3 text-lg',
   };
 
-  const variantClasses: Record<'standard' | 'toolbar' | 'toggle' | 'primary' | 'danger', string> = {
-    standard: '',
+  const appliedSize =
+    variant === 'standard' || variant === 'compact' || variant === 'primary'
+      ? sizeClasses[size]
+      : '';
+
+  const variantClasses: Record<
+    'standard' | 'left' | 'compact' | 'toolbar' | 'toggle' | 'close' | 'tab' | 'primary',
+    string
+  > = {
+    standard: 'w-full flex items-center justify-center',
+    left: 'w-full flex items-start justify-start text-left',
+    compact: 'inline-flex items-center justify-center',
     toolbar: 'flex items-center justify-center w-9 h-9 p-2',
-    toggle: 'px-3 py-1.5 text-xs',
-    primary: 'w-full text-white font-medium bg-sky-700 hover:bg-sky-600 disabled:bg-slate-500 disabled:text-slate-400 flex items-center justify-center transition-colors duration-150 ease-in-out',
-    danger: 'w-full text-white font-medium bg-orange-700 hover:bg-orange-600 disabled:bg-slate-500 disabled:text-slate-400 flex items-center justify-center transition-colors duration-150 ease-in-out',
+    toggle: 'inline-flex items-center justify-center px-3 py-1 text-xs',
+    close: 'animated-frame-close-button',
+    tab: 'px-3 py-2 text-sm font-medium transition-colors',
+    primary: 'w-full flex items-center justify-center',
   };
 
-  const pressedClasses = variant === 'toggle' && pressed ? 'ring-2 ring-sky-400 ring-offset-1 ring-offset-slate-800' : '';
+  const presetClasses: Record<NonNullable<ButtonProps['preset']>, string> = {
+    slate: 'bg-slate-600 hover:bg-slate-500 focus:ring-slate-400',
+    gray: 'bg-gray-600 hover:bg-gray-500 focus:ring-gray-400',
+    zinc: 'bg-zinc-600 hover:bg-zinc-500 focus:ring-zinc-400',
+    neutral: 'bg-neutral-600 hover:bg-neutral-500 focus:ring-neutral-400',
+    stone: 'bg-stone-600 hover:bg-stone-500 focus:ring-stone-400',
+    red: 'bg-red-600 hover:bg-red-500 focus:ring-red-400',
+    orange: 'bg-orange-600 hover:bg-orange-500 focus:ring-orange-400',
+    amber: 'bg-amber-600 hover:bg-amber-500 focus:ring-amber-400',
+    yellow: 'bg-yellow-600 hover:bg-yellow-500 focus:ring-yellow-400',
+    lime: 'bg-lime-600 hover:bg-lime-500 focus:ring-lime-400',
+    green: 'bg-green-600 hover:bg-green-500 focus:ring-green-400',
+    emerald: 'bg-emerald-600 hover:bg-emerald-500 focus:ring-emerald-400',
+    teal: 'bg-teal-600 hover:bg-teal-500 focus:ring-teal-400',
+    cyan: 'bg-cyan-600 hover:bg-cyan-500 focus:ring-cyan-400',
+    sky: 'bg-sky-600 hover:bg-sky-500 focus:ring-sky-400',
+    blue: 'bg-blue-600 hover:bg-blue-500 focus:ring-blue-400',
+    indigo: 'bg-indigo-600 hover:bg-indigo-500 focus:ring-indigo-400',
+    violet: 'bg-violet-600 hover:bg-violet-500 focus:ring-violet-400',
+    purple: 'bg-purple-600 hover:bg-purple-500 focus:ring-purple-400',
+    fuchsia: 'bg-fuchsia-600 hover:bg-fuchsia-500 focus:ring-fuchsia-400',
+    pink: 'bg-pink-600 hover:bg-pink-500 focus:ring-pink-400',
+    rose: 'bg-rose-600 hover:bg-rose-500 focus:ring-rose-400',
+  };
+
+  const pressedClasses = (() => {
+    if (variant === 'toggle' && pressed) {
+      return 'ring-2 ring-sky-400 ring-offset-1 ring-offset-slate-800';
+    }
+    if (variant === 'tab') {
+      return pressed
+        ? 'border-b-2 border-sky-400 text-sky-300'
+        : 'text-slate-400 hover:text-sky-400 border-b-2 border-transparent';
+    }
+    return '';
+  })();
 
   const displayLabel =
     highlightEntities && typeof label === 'string'
@@ -69,7 +145,7 @@ function Button({
     <button
       aria-label={ariaLabel}
       aria-pressed={variant === 'toggle' ? pressed : undefined}
-      className={`rounded shadow transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${sizeClasses[size]} ${variantClasses[variant]} ${pressedClasses} ${className}`}
+      className={`rounded-md shadow transition-colors duration-150 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 ${appliedSize} ${variantClasses[variant]} ${preset ? presetClasses[preset] : ''} ${pressedClasses}`}
       disabled={disabled}
       onClick={handleClick}
       title={title}
@@ -89,12 +165,12 @@ function Button({
 }
 
 Button.defaultProps = {
-  className: '',
   disabled: false,
   enableHighlightTap: false,
   highlightEntities: undefined,
   icon: undefined,
   label: undefined,
+  preset: undefined,
   pressed: false,
   size: 'md',
   title: undefined,

--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -68,7 +68,6 @@ function InventoryItem({
         {applicableUses.map(knownUse => (
           <Button
             ariaLabel={`${knownUse.actionName}${knownUse.description ? ': ' + knownUse.description : ''}`}
-            className="w-full bg-teal-600 hover:bg-teal-500 text-white font-medium rounded shadow disabled:bg-slate-500 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
             data-action-name={knownUse.actionName}
             data-item-name={item.name}
             data-prompt-effect={knownUse.promptEffect}
@@ -76,6 +75,7 @@ function InventoryItem({
             key={`${item.name}-knownuse-${knownUse.actionName}`}
             label={knownUse.actionName}
             onClick={onSpecificUse}
+            preset="teal"
             size="sm"
             title={knownUse.description}
           />
@@ -83,24 +83,24 @@ function InventoryItem({
 
         <Button
           ariaLabel={`Inspect ${item.name}`}
-          className="w-full bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded shadow disabled:bg-slate-500 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
           data-item-name={item.name}
           disabled={disabled || isConfirmingDiscard}
           key={`${item.name}-inspect`}
           label="Inspect"
           onClick={onInspect}
+          preset="indigo"
           size="sm"
         />
 
         {(item.type !== 'knowledge' && item.type !== 'status effect' && item.type !== 'vehicle') && (
           <Button
             ariaLabel={`Attempt to use ${item.name} (generic action)`}
-            className="w-full bg-sky-700 hover:bg-sky-600 text-white font-medium rounded shadow disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
             data-item-name={item.name}
             disabled={disabled || isConfirmingDiscard}
             key={`${item.name}-generic-use`}
             label="Attempt to Use (Generic)"
             onClick={onGenericUse}
+            preset="sky"
             size="sm"
           />
         )}
@@ -108,12 +108,12 @@ function InventoryItem({
         {item.type === 'vehicle' && (
           <Button
             ariaLabel={item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`}
-            className="w-full bg-green-700 hover:bg-green-600 text-white font-medium rounded shadow disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
             data-item-name={item.name}
             disabled={disabled || isConfirmingDiscard}
             key={`${item.name}-vehicle-action`}
             label={item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`}
             onClick={onVehicleToggle}
+            preset="green"
             size="sm"
           />
         )}
@@ -121,7 +121,6 @@ function InventoryItem({
         {item.isJunk && !isConfirmingDiscard ? (
           <Button
             ariaLabel={`Discard ${item.name}`}
-            className="w-full text-white font-medium disabled:bg-slate-500 disabled:text-slate-400 flex items-center justify-center transition-colors duration-150 ease-in-out"
             data-item-name={item.name}
             disabled={disabled}
             icon={
@@ -136,36 +135,34 @@ function InventoryItem({
             key={`${item.name}-discard`}
             label="Discard"
             onClick={onStartConfirmDiscard}
+            preset="red"
             size="sm"
-            variant="danger"
           />
         ) : null}
 
         {!item.isJunk && !isConfirmingDiscard && item.type !== 'vehicle' && item.type !== 'status effect' && (
           <Button
             ariaLabel={`Drop ${item.name}`}
-            className="w-full text-white font-medium disabled:bg-slate-500 disabled:text-slate-400 flex items-center justify-center transition-colors duration-150 ease-in-out"
             data-item-name={item.name}
             disabled={disabled}
             key={`${item.name}-drop`}
             label="Drop"
             onClick={onStartConfirmDiscard}
+            preset="sky"
             size="sm"
-            variant="primary"
           />
         )}
 
         {!item.isJunk && !isConfirmingDiscard && item.type === 'vehicle' && !item.isActive && (
           <Button
             ariaLabel={`Park ${item.name} here`}
-            className="w-full text-white font-medium disabled:bg-slate-500 disabled:text-slate-400 flex items-center justify-center transition-colors duration-150 ease-in-out"
             data-item-name={item.name}
             disabled={disabled}
             key={`${item.name}-drop`}
             label="Park Here"
             onClick={onStartConfirmDiscard}
+            preset="sky"
             size="sm"
-            variant="primary"
           />
         )}
 
@@ -173,22 +170,22 @@ function InventoryItem({
           <div className="grid grid-cols-2 gap-2 mt-2">
             <Button
               ariaLabel={`Confirm drop of ${item.name}`}
-              className="w-full bg-red-600 hover:bg-red-500 text-white font-semibold rounded shadow disabled:bg-slate-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
               data-item-name={item.name}
               disabled={disabled}
               key={`${item.name}-confirm-drop`}
               label={item.type === 'vehicle' && !item.isActive ? 'Confirm Park' : item.isJunk ? 'Confirm Discard' : 'Confirm Drop'}
               onClick={onConfirmDrop}
+              preset="red"
               size="sm"
             />
 
             <Button
               ariaLabel="Cancel discard"
-              className="w-full bg-slate-600 hover:bg-slate-500 text-white font-medium rounded shadow disabled:bg-slate-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
               disabled={disabled}
               key={`${item.name}-cancel-discard`}
               label="Cancel"
               onClick={onCancelDiscard}
+              preset="slate"
               size="sm"
             />
           </div>

--- a/components/inventory/InventorySortControls.tsx
+++ b/components/inventory/InventorySortControls.tsx
@@ -14,10 +14,10 @@ function InventorySortControls({ sortOrder, disabled, onSortByName, onSortByType
     <div className="mb-4 flex flex-wrap gap-2">
       <Button
         ariaLabel="Sort by Name"
-        className={`${sortOrder === 'name' ? 'bg-sky-600 text-white hover:bg-sky-500 ring-2 ring-sky-400 ring-offset-1 ring-offset-slate-800' : 'bg-slate-600 text-slate-300 hover:bg-slate-500'} disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed disabled:ring-0`}
         disabled={disabled}
         label="Sort by Name"
         onClick={onSortByName}
+        preset={sortOrder === 'name' ? 'sky' : 'slate'}
         pressed={sortOrder === 'name'}
         size="sm"
         variant="toggle"
@@ -25,10 +25,10 @@ function InventorySortControls({ sortOrder, disabled, onSortByName, onSortByType
 
       <Button
         ariaLabel="Sort by Type"
-        className={`${sortOrder === 'type' ? 'bg-sky-600 text-white hover:bg-sky-500 ring-2 ring-sky-400 ring-offset-1 ring-offset-slate-800' : 'bg-slate-600 text-slate-300 hover:bg-slate-500'} disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed disabled:ring-0`}
         disabled={disabled}
         label="Sort by Type"
         onClick={onSortByType}
+        preset={sortOrder === 'type' ? 'sky' : 'slate'}
         pressed={sortOrder === 'type'}
         size="sm"
         variant="toggle"

--- a/components/map/MapDisplay.tsx
+++ b/components/map/MapDisplay.tsx
@@ -185,13 +185,13 @@ function MapDisplay({
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close map view"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <h1

--- a/components/modals/CustomGameSetupScreen.tsx
+++ b/components/modals/CustomGameSetupScreen.tsx
@@ -62,13 +62,13 @@ function CustomGameSetupScreen({
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close theme selection"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <div className="flex flex-col items-center w-full h-full p-2">

--- a/components/modals/HistoryDisplay.tsx
+++ b/components/modals/HistoryDisplay.tsx
@@ -38,13 +38,13 @@ function HistoryDisplay({
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close history"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <div className="theme-memory-content-area">

--- a/components/modals/ImageVisualizer.tsx
+++ b/components/modals/ImageVisualizer.tsx
@@ -253,13 +253,13 @@ function ImageVisualizer({
       <div className="animated-frame-content visualizer-content-area"> 
         <Button
           ariaLabel="Close visualizer"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
         
         {isLoading ? <div className="visualizer-spinner-container">

--- a/components/modals/InfoDisplay.tsx
+++ b/components/modals/InfoDisplay.tsx
@@ -58,13 +58,13 @@ function InfoDisplay({ isVisible, onClose }: InfoDisplayProps) {
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close game information"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <div className="info-content-area">

--- a/components/modals/KnowledgeBase.tsx
+++ b/components/modals/KnowledgeBase.tsx
@@ -58,13 +58,13 @@ function KnowledgeBase({
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close knowledge base"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <div className="knowledge-base-content-area"> 

--- a/components/modals/SettingsDisplay.tsx
+++ b/components/modals/SettingsDisplay.tsx
@@ -70,13 +70,13 @@ function SettingsDisplay({
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close settings"
-          className="animated-frame-close-button"
           icon={<Icon
             name="x"
             size={20}
                 />}
           onClick={onClose}
           size="sm"
+          variant="close"
         />
 
         <div className="settings-content-area">

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -49,13 +49,13 @@ function TitleMenu({
         {isGameActive ? (
           <Button
             ariaLabel="Close Title Menu"
-            className="animated-frame-close-button"
             icon={<Icon
               name="x"
               size={20}
                   />}
             onClick={onClose}
             size="sm"
+            variant="close"
           />
         ) : null}
 
@@ -76,60 +76,60 @@ function TitleMenu({
           <div className="space-y-4 sm:space-y-5 w-full max-w-xs sm:max-w-sm">
             <Button
               ariaLabel={isGameActive ? 'Start a New Game (Random Shifts, Progress will be lost)' : 'Start a New Game (Random Shifts)'}
-              className="w-full bg-red-600 hover:bg-red-500 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-red-400 focus:outline-none"
               label="New Game"
               onClick={onNewGame}
+              preset="red"
               size="lg"
             />
 
             <Button
               ariaLabel={isGameActive ? 'Start a Custom Game (Choose Theme, No Random Shifts, Progress will be lost)' : 'Start a Custom Game (Choose Theme, No Random Shifts)'}
-              className="w-full bg-orange-600 hover:bg-orange-500 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-orange-400 focus:outline-none"
               label="Custom Game"
               onClick={onCustomGame}
+              preset="orange"
               size="lg"
             />
 
             {isGameActive && onSaveGame ? (
               <Button
                 ariaLabel="Save Current Game to File"
-                className="w-full bg-green-600 hover:bg-green-500 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-green-400 focus:outline-none"
                 label="Save Game"
                 onClick={onSaveGame}
+                preset="green"
                 size="lg"
               />
             ) : null}
 
             <Button
               ariaLabel={isGameActive ? 'Load Game from File (Current progress will be lost)' : 'Load Game from File'}
-              className="w-full bg-blue-600 hover:bg-blue-500 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-blue-400 focus:outline-none"
               label="Load Game"
               onClick={onLoadGame}
+              preset="blue"
               size="lg"
             />
 
             <Button
               ariaLabel="Open Settings"
-              className="w-full bg-gray-600 hover:bg-gray-500 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-gray-400 focus:outline-none"
               label="Settings"
               onClick={onOpenSettings}
+              preset="gray"
               size="lg"
             />
 
             <Button
               ariaLabel="About & Game Guide"
-              className="w-full bg-cyan-700 hover:bg-cyan-600 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-cyan-400 focus:outline-none"
               label="About"
               onClick={onOpenInfo}
+              preset="cyan"
               size="lg"
             />
 
             {isGameActive ? (
               <Button
                 ariaLabel="Return to Game"
-                className="w-full mt-6 sm:mt-8 bg-sky-700 hover:bg-sky-600 text-white font-semibold rounded-lg shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105 focus:ring-4 focus:ring-sky-500 focus:outline-none"
                 label="Return to Game"
                 onClick={onClose}
+                preset="sky"
                 size="lg"
               />
             ) : null}


### PR DESCRIPTION
## Summary
- add style presets to Button for all Tailwind colors
- remove danger variant and centralize default classes
- simplify button usage by replacing className props with variants

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68553b6837608324815e068d950dce59