### PR TITLE
Replace map buttons with shared component

### DIFF
--- a/components/map/MapControls.tsx
+++ b/components/map/MapControls.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useCallback, useState } from 'react';
+import Button from '../elements/Button';
 
 import ParameterControl from './ParameterControl';
 
@@ -89,32 +90,33 @@ function MapControls(props: MapControlsProps) {
           value={itemIconScale}
         />
 
-        <button
-          className="map-control-button mt-2 bg-orange-600 hover:bg-orange-500"
-          onClick={onReset}
-          style={{ flexBasis: '100%', marginTop: '0.5rem' }}
-          type="button"
-        >
-          Reset to Defaults
-        </button>
+        <div className="mt-2">
+          <Button
+            ariaLabel="Reset to Defaults"
+            label="Reset to Defaults"
+            onClick={onReset}
+            preset="orange"
+            variant="standard"
+          />
+        </div>
       </div> : null}
 
       <div className="map-action-buttons-row">
-        <button
-          className="map-control-button"
+        <Button
+          ariaLabel="Toggle Layout Controls"
+          label={`${expanded ? 'Hide' : 'Show'} Layout Controls`}
           onClick={handleToggleExpanded}
-          type="button"
-        >
-          {`${expanded ? 'Hide' : 'Show'} Layout Controls`}
-        </button>
+          preset="blue"
+          variant="standard"
+        />
 
-        <button
-          className="map-control-button"
+        <Button
+          ariaLabel="Refresh Layout"
+          label="Refresh Layout"
           onClick={onRefreshLayout}
-          type="button"
-        >
-          Refresh Layout
-        </button>
+          preset="blue"
+          variant="standard"
+        />
       </div>
     </div>
   );

--- a/components/map/MapNodeView.tsx
+++ b/components/map/MapNodeView.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_LABEL_LINE_HEIGHT_EM,
 } from '../../constants';
 import { Icon } from '../elements/icons';
+import Button from '../elements/Button';
 import { isDescendantOf } from '../../utils/mapGraphUtils';
 import { calculateLabelOffsets, getRadiusForNode, splitTextIntoLines, isSmallFontType, hasCenteredLabel } from '../../utils/mapLabelUtils';
 import { useMapTooltip } from '../../hooks/useMapTooltip';
@@ -375,16 +376,27 @@ function MapNodeView({
         className={`map-tooltip anchor-${tooltip.anchor}`}
         style={{ top: tooltipScreenPosition.y, left: tooltipScreenPosition.x, pointerEvents: isTooltipLocked ? 'auto' : 'none' }}
                                           >
-        {isTooltipLocked && tooltip.nodeId ? <button
-          className="map-set-destination-button"
-          data-node-id={tooltip.nodeId}
-          onClick={handleDestinationClick}
-          type="button"
-                                             >
-          {tooltip.nodeId === destinationNodeId
-                ? 'Remove Destination'
-                : 'Set Destination'}
-        </button> : null}
+        {isTooltipLocked && tooltip.nodeId ? (
+          <div className="mb-1">
+            <Button
+              ariaLabel={
+                tooltip.nodeId === destinationNodeId
+                  ? 'Remove Destination'
+                  : 'Set Destination'
+              }
+              data-node-id={tooltip.nodeId}
+              label={
+                tooltip.nodeId === destinationNodeId
+                  ? 'Remove Destination'
+                  : 'Set Destination'
+              }
+              onClick={handleDestinationClick}
+              preset="amber"
+              size="sm"
+              variant="standard"
+            />
+          </div>
+        ) : null}
 
         {tooltip.content.split('\n').map((line, index) => (
           <React.Fragment key={`${String(tooltip.nodeId)}-${String(line)}`}>


### PR DESCRIPTION
## Summary
- swap raw `<button>` elements in `MapControls` for shared `Button`
- use `Button` in `MapNodeView` tooltip actions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855575caa3c8324b32fd8acf621cc94