### PR TITLE
Fix inventory item button events

### DIFF
--- a/components/elements/Button.tsx
+++ b/components/elements/Button.tsx
@@ -15,6 +15,10 @@ export interface ButtonProps {
   readonly size?: 'sm' | 'md' | 'lg';
   readonly title?: string;
   readonly type?: 'button' | 'submit' | 'reset';
+  readonly 'data-action-name'?: string;
+  readonly 'data-item-name'?: string;
+  readonly 'data-option'?: string;
+  readonly 'data-prompt-effect'?: string;
   readonly variant?:
     | 'standard'
     | 'center'
@@ -62,6 +66,10 @@ function Button({
   type = 'button',
   variant = 'standard',
   preset,
+  'data-action-name': dataActionName,
+  'data-item-name': dataItemName,
+  'data-option': dataOption,
+  'data-prompt-effect': dataPromptEffect,
 }: ButtonProps) {
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
@@ -144,6 +152,10 @@ function Button({
       aria-label={ariaLabel}
       aria-pressed={variant === 'toggle' ? pressed : undefined}
       className={`rounded-md shadow transition-colors duration-150 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 ${appliedSize} ${variantClasses[variant]} ${preset ? presetClasses[preset] : ''} ${pressedClasses}`}
+      data-action-name={dataActionName}
+      data-item-name={dataItemName}
+      data-option={dataOption}
+      data-prompt-effect={dataPromptEffect}
       disabled={disabled}
       onClick={handleClick}
       title={title}
@@ -165,6 +177,10 @@ function Button({
 }
 
 Button.defaultProps = {
+  'data-action-name': undefined,
+  'data-item-name': undefined,
+  'data-option': undefined,
+  'data-prompt-effect': undefined,
   disabled: false,
   enableHighlightTap: false,
   highlightEntities: undefined,


### PR DESCRIPTION
## Summary
- ensure Button component forwards data- attributes without prop spreading

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68556d5ea9a0832494bee09421dce323