### PR TITLE
Add clock and error icons

### DIFF
--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -4,6 +4,7 @@
  */
 
 import Button from './elements/Button';
+import { Icon } from './elements/icons';
 
 interface ErrorDisplayProps {
   readonly message: string;
@@ -17,18 +18,13 @@ function ErrorDisplay({ message, onRetry }: ErrorDisplayProps) {
   return (
     <div className="bg-red-800 border border-red-600 text-red-100 p-6 rounded-lg shadow-xl my-4 animate-pulse">
       <div className="flex items-center mb-2">
-        <svg
-          className="h-8 w-8 mr-3 text-red-300"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clipRule="evenodd"
-            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
-            fillRule="evenodd"
-          />
-        </svg>
+        <Icon
+          color="red"
+          inline
+          marginRight={12}
+          name="error"
+          size={32}
+        />
 
         <h3 className="font-bold text-2xl text-red-200">
           A Shadow Falls!

--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -63,20 +63,13 @@ function MainToolbar({
           className="flex items-center p-2 border border-indigo-500 rounded-md shadow-md"
           title={`Turns since last reality shift: ${String(turnsSinceLastShift)}`}
                             >
-          <svg
-            className="h-5 w-5 mr-2 text-indigo-400"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <Icon
+            color="indigo"
+            inline
+            marginRight={8}
+            name="clock"
+            size={20}
+          />
 
           <span className="text-indigo-400 font-semibold text-lg">
             {turnsSinceLastShift}

--- a/components/elements/icons.tsx
+++ b/components/elements/icons.tsx
@@ -17,6 +17,8 @@ import NearbyNpcIcon from './icons/nearby_npc.svg?react';
 import MapItemBoxIcon from './icons/map_item_box.svg?react';
 import MapWheelIcon from './icons/map_wheel.svg?react';
 import XIcon from './icons/x.svg?react';
+import ClockIcon from './icons/clock.svg?react';
+import ErrorIcon from './icons/error.svg?react';
 
 const iconMap = {
   realityShift: RealityShiftIcon,
@@ -34,18 +36,37 @@ const iconMap = {
   nearbyNpc: NearbyNpcIcon,
   mapItemBox: MapItemBoxIcon,
   mapWheel: MapWheelIcon,
+  clock: ClockIcon,
+  error: ErrorIcon,
   x: XIcon,
 } as const;
 
 export type IconName = keyof typeof iconMap;
 
 export type IconColor =
+  | 'slate'
+  | 'gray'
+  | 'zinc'
+  | 'neutral'
+  | 'stone'
+  | 'red'
+  | 'orange'
   | 'amber'
-  | 'emerald'
+  | 'yellow'
+  | 'lime'
   | 'green'
-  | 'white'
+  | 'emerald'
+  | 'teal'
+  | 'cyan'
   | 'sky'
-  | 'indigo';
+  | 'blue'
+  | 'indigo'
+  | 'violet'
+  | 'purple'
+  | 'fuchsia'
+  | 'pink'
+  | 'rose'
+  | 'white';
 
 export interface IconProps {
   readonly name: IconName;
@@ -70,12 +91,29 @@ export function Icon({
   const SvgIcon = iconMap[name];
 
   const colorClasses: Record<IconColor, string> = {
+    slate: 'text-slate-400',
+    gray: 'text-gray-400',
+    zinc: 'text-zinc-400',
+    neutral: 'text-neutral-400',
+    stone: 'text-stone-400',
+    red: 'text-red-400',
+    orange: 'text-orange-400',
     amber: 'text-amber-400',
-    emerald: 'text-emerald-400',
+    yellow: 'text-yellow-400',
+    lime: 'text-lime-400',
     green: 'text-green-400',
-    white: 'text-white',
+    emerald: 'text-emerald-400',
+    teal: 'text-teal-400',
+    cyan: 'text-cyan-400',
     sky: 'text-sky-400',
+    blue: 'text-blue-400',
     indigo: 'text-indigo-400',
+    violet: 'text-violet-400',
+    purple: 'text-purple-400',
+    fuchsia: 'text-fuchsia-400',
+    pink: 'text-pink-400',
+    rose: 'text-rose-400',
+    white: 'text-white',
   };
 
   const wrapperClasses = [

--- a/components/elements/icons/clock.svg
+++ b/components/elements/icons/clock.svg
@@ -1,0 +1,3 @@
+<svg fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/components/elements/icons/error.svg
+++ b/components/elements/icons/error.svg
@@ -1,0 +1,3 @@
+<svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" fill-rule="evenodd" clip-rule="evenodd"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace inline icons in ErrorDisplay and MainToolbar with `Icon`
- add clock and error SVGs
- support all Tailwind color names in `Icon`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68557738bc448324a745de6df09b6136