### PR TITLE
Add pinch zoom for mobile image visualizer

### DIFF
--- a/index.css
+++ b/index.css
@@ -109,6 +109,12 @@ body {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+.visualizer-image-container:active {
+  cursor: grabbing;
 }
 .visualizer-image {
   max-width: 100%;
@@ -116,6 +122,7 @@ body {
   object-fit: contain;
   border-radius: 0.25rem;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
 }
 .visualizer-spinner-container,
 .visualizer-error-container {


### PR DESCRIPTION
## Summary
- enable pinch-zoom and dragging on mobile for the scene visualizer
- style image container to support touch gestures

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855c17f758c832494fbc79b263a181b