### PR TITLE
Add small text shadow to button labels

### DIFF
--- a/components/elements/Button.tsx
+++ b/components/elements/Button.tsx
@@ -168,7 +168,7 @@ function Button({
       ) : null}
 
       {displayLabel ? (
-        <span className="flex-1">
+        <span className="flex-1 text-shadow-sm">
           {displayLabel}
         </span>
       ) : null}

--- a/index.css
+++ b/index.css
@@ -712,3 +712,8 @@ body {
   border-color: rgba(209, 213, 219, 0.7); /* gray-300 */
 }
 
+/* Small text shadow for button labels */
+.text-shadow-sm {
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+


### PR DESCRIPTION
## Summary
- create `.text-shadow-sm` utility in CSS
- apply text-shadow utility to button label spans

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855cf546bac8324a1ee646682ff8de6