### PR TITLE
Improve pathfinding efficiency using min-heap

### DIFF
--- a/utils/priorityQueue.ts
+++ b/utils/priorityQueue.ts
@@ -1,0 +1,73 @@
+/**
+ * @file priorityQueue.ts
+ * @description Simple binary min heap implementation used for pathfinding.
+ */
+
+export interface HeapItem<T> {
+  value: T;
+  priority: number;
+}
+
+export interface MinHeap<T> {
+  push(value: T, priority: number): void;
+  pop(): T | undefined;
+  size(): number;
+}
+
+export const createMinHeap = <T>(): MinHeap<T> => {
+  const heap: Array<HeapItem<T>> = [];
+
+  const swap = (i: number, j: number) => {
+    const temp = heap[i];
+    heap[i] = heap[j];
+    heap[j] = temp;
+  };
+
+  const bubbleUp = (index: number) => {
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2);
+      if (heap[parent].priority <= heap[index].priority) break;
+      swap(parent, index);
+      index = parent;
+    }
+  };
+
+  const bubbleDown = (index: number) => {
+    const lastIndex = heap.length - 1;
+    for (;;) {
+      const left = index * 2 + 1;
+      const right = index * 2 + 2;
+      let smallest = index;
+
+      if (left <= lastIndex && heap[left].priority < heap[smallest].priority) {
+        smallest = left;
+      }
+      if (right <= lastIndex && heap[right].priority < heap[smallest].priority) {
+        smallest = right;
+      }
+      if (smallest === index) break;
+      swap(index, smallest);
+      index = smallest;
+    }
+  };
+
+  return {
+    push(value: T, priority: number) {
+      heap.push({ value, priority });
+      bubbleUp(heap.length - 1);
+    },
+    pop(): T | undefined {
+      if (heap.length === 0) return undefined;
+      const top = heap[0].value;
+      const last = heap.pop();
+      if (last !== undefined && heap.length > 0) {
+        heap[0] = last;
+        bubbleDown(0);
+      }
+      return top;
+    },
+    size() {
+      return heap.length;
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- implement a simple binary heap `createMinHeap`
- use the heap in `findTravelPath` for more efficient priority queue operations

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6856b6f753488324824f0325d1c0cb1b