### PR TITLE
Refactor GameSidebar highlight logic

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -10,11 +10,9 @@ import * as React from 'react';
 import { useGameLogic } from '../../hooks/useGameLogic';
 import SceneDisplay from '../SceneDisplay';
 import ActionOptions from '../ActionOptions';
-import InventoryDisplay from '../inventory/InventoryDisplay';
-import LocationItemsDisplay from '../inventory/LocationItemsDisplay';
+import GameSidebar from './GameSidebar';
 import LoadingSpinner from '../LoadingSpinner';
 import ErrorDisplay from '../ErrorDisplay';
-import TextBox from '../elements/TextBox';
 import MainToolbar from '../MainToolbar';
 import ModelUsageIndicators from '../ModelUsageIndicators';
 import TitleMenu from '../modals/TitleMenu';
@@ -28,7 +26,6 @@ import Footer from './Footer';
 import AppModals from './AppModals';
 import AppHeader from './AppHeader';
 import FreeActionInput from './FreeActionInput';
-import { buildHighlightableEntities } from '../../utils/highlightHelper';
 import { useLoadingProgress } from '../../hooks/useLoadingProgress';
 import { useSaveLoad } from '../../hooks/useSaveLoad';
 import { useAppModals } from '../../hooks/useAppModals';
@@ -235,16 +232,6 @@ function App() {
 
   const canPerformFreeAction = score >= FREE_FORM_ACTION_COST && !isLoading && hasGameBeenInitialized && !dialogueState;
 
-  const questHighlightEntities = React.useMemo(
-    () =>
-      buildHighlightableEntities(
-        inventory,
-        mapData.nodes,
-        allCharacters,
-        currentTheme ? currentTheme.name : null
-      ),
-    [inventory, mapData.nodes, allCharacters, currentTheme]
-  );
 
   const enableMobileTap =
     typeof window !== 'undefined' &&
@@ -578,63 +565,28 @@ function App() {
             {!hasGameBeenInitialized ? (
               <div className="hidden lg:block bg-slate-800/50 border border-slate-700 rounded-lg flex-grow min-h-48" />
             ) : (
-              <>
-                { mainQuest ? (
-                  <TextBox
-                    backgroundColorClass="bg-purple-800/50"
-                    borderColorClass="border-purple-600"
-                    borderWidthClass="border rounded-lg"
-                    containerClassName="p-3 "
-                    contentColorClass="text-purple-200"
-                    contentFontClass="text-lg"
-                    enableMobileTap={enableMobileTap}
-                    header="Main Quest"
-                    headerFont="lg"
-                    headerPreset="purple"
-                    highlightEntities={questHighlightEntities}
-                    text={mainQuest}
-                  />
-                ) : null}
-
-                {currentObjective ? (
-                  <TextBox
-                    backgroundColorClass="bg-amber-800/50"
-                    borderColorClass="border-amber-600"
-                    borderWidthClass="border rounded-lg"
-                    containerClassName={`p-3 ${
-                      objectiveAnimationType === 'success'
-                        ? 'animate-objective-success'
-                        : objectiveAnimationType === 'neutral'
-                          ? 'animate-objective-neutral'
-                          : ''
-                    }`}
-                    contentColorClass="text-amber-200"
-                    contentFontClass="text-lg"
-                    enableMobileTap={enableMobileTap}
-                    header="Current Objective"
-                    headerFont="lg"
-                    headerPreset="amber"
-                    highlightEntities={questHighlightEntities}
-                    text={currentObjective}
-                  />
-                ) : null}
-
-                <LocationItemsDisplay
-                  currentNodeId={currentMapNodeId}
-                  disabled={isLoading || !!dialogueState || effectiveIsTitleMenuOpen || isCustomGameSetupVisible || isManualShiftThemeSelectionVisible}
-                  items={itemsHere}
-                  mapNodes={mapData.nodes}
-                  onTakeItem={handleTakeLocationItem}
-                />
-
-                <InventoryDisplay
-                  disabled={isLoading || !!dialogueState || effectiveIsTitleMenuOpen || isCustomGameSetupVisible || isManualShiftThemeSelectionVisible}
-                  items={inventory}
-                  onDropItem={gameLogic.handleDropItem}
-                  onItemInteract={handleItemInteraction}
-                />
-
-              </>
+              <GameSidebar
+                allCharacters={allCharacters}
+                currentMapNodeId={currentMapNodeId}
+                currentObjective={currentObjective}
+                currentThemeName={currentTheme ? currentTheme.name : null}
+                disabled={
+                  isLoading ||
+                  !!dialogueState ||
+                  effectiveIsTitleMenuOpen ||
+                  isCustomGameSetupVisible ||
+                  isManualShiftThemeSelectionVisible
+                }
+                enableMobileTap={enableMobileTap}
+                inventory={inventory}
+                itemsHere={itemsHere}
+                mainQuest={mainQuest}
+                mapNodes={mapData.nodes}
+                objectiveAnimationType={objectiveAnimationType}
+                onDropItem={gameLogic.handleDropItem}
+                onItemInteract={handleItemInteraction}
+                onTakeItem={handleTakeLocationItem}
+              />
             )}
           </div>
         </main>

--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -1,0 +1,121 @@
+import TextBox from '../elements/TextBox';
+import LocationItemsDisplay from '../inventory/LocationItemsDisplay';
+import InventoryDisplay from '../inventory/InventoryDisplay';
+import { useMemo } from 'react';
+import { buildHighlightableEntities } from '../../utils/highlightHelper';
+import {
+  Character,
+  Item,
+  KnownUse,
+  MapNode,
+} from '../../types';
+
+interface GameSidebarProps {
+  readonly allCharacters: Array<Character>;
+  readonly currentMapNodeId: string | null;
+  readonly currentObjective: string | null;
+  readonly currentThemeName: string | null;
+  readonly enableMobileTap: boolean;
+  readonly inventory: Array<Item>;
+  readonly itemsHere: Array<Item>;
+  readonly mainQuest: string | null;
+  readonly mapNodes: Array<MapNode>;
+  readonly objectiveAnimationType: 'success' | 'neutral' | null;
+  readonly onDropItem: (itemName: string) => void;
+  readonly onItemInteract: (
+    item: Item,
+    interactionType: 'generic' | 'specific' | 'inspect',
+    knownUse?: KnownUse,
+  ) => void;
+  readonly onTakeItem: (itemName: string) => void;
+  readonly disabled: boolean;
+}
+
+function GameSidebar({
+  allCharacters,
+  currentMapNodeId,
+  currentObjective,
+  currentThemeName,
+  enableMobileTap,
+  inventory,
+  itemsHere,
+  mainQuest,
+  mapNodes,
+  objectiveAnimationType,
+  onDropItem,
+  onItemInteract,
+  onTakeItem,
+  disabled,
+}: GameSidebarProps) {
+  const questHighlightEntities = useMemo(
+    () =>
+      buildHighlightableEntities(
+        inventory,
+        mapNodes,
+        allCharacters,
+        currentThemeName,
+      ),
+    [inventory, mapNodes, allCharacters, currentThemeName],
+  );
+
+  return (
+    <>
+      {mainQuest ? (
+        <TextBox
+          backgroundColorClass="bg-purple-800/50"
+          borderColorClass="border-purple-600"
+          borderWidthClass="border rounded-lg"
+          containerClassName="p-3"
+          contentColorClass="text-purple-200"
+          contentFontClass="text-lg"
+          enableMobileTap={enableMobileTap}
+          header="Main Quest"
+          headerFont="lg"
+          headerPreset="purple"
+          highlightEntities={questHighlightEntities}
+          text={mainQuest}
+        />
+      ) : null}
+
+      {currentObjective ? (
+        <TextBox
+          backgroundColorClass="bg-amber-800/50"
+          borderColorClass="border-amber-600"
+          borderWidthClass="border rounded-lg"
+          containerClassName={`p-3 ${
+            objectiveAnimationType === 'success'
+              ? 'animate-objective-success'
+              : objectiveAnimationType === 'neutral'
+                ? 'animate-objective-neutral'
+                : ''
+          }`}
+          contentColorClass="text-amber-200"
+          contentFontClass="text-lg"
+          enableMobileTap={enableMobileTap}
+          header="Current Objective"
+          headerFont="lg"
+          headerPreset="amber"
+          highlightEntities={questHighlightEntities}
+          text={currentObjective}
+        />
+      ) : null}
+
+      <LocationItemsDisplay
+        currentNodeId={currentMapNodeId}
+        disabled={disabled}
+        items={itemsHere}
+        mapNodes={mapNodes}
+        onTakeItem={onTakeItem}
+      />
+
+      <InventoryDisplay
+        disabled={disabled}
+        items={inventory}
+        onDropItem={onDropItem}
+        onItemInteract={onItemInteract}
+      />
+    </>
+  );
+}
+
+export default GameSidebar;


### PR DESCRIPTION
## Summary
- remove `useQuestHighlights` hook
- compute highlightable entities directly inside `GameSidebar`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856cb818dfc8324a2f5fe7623e63092