### PR TITLE
Refactor map pathfinding adjacency

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -30,7 +30,7 @@ import { useLoadingProgress } from '../../hooks/useLoadingProgress';
 import { useSaveLoad } from '../../hooks/useSaveLoad';
 import { useAppModals } from '../../hooks/useAppModals';
 import { useAutosave } from '../../hooks/useAutosave';
-import { findTravelPath, TravelStep } from '../../utils/mapPathfinding';
+import { findTravelPath, buildTravelAdjacency, TravelStep, TravelAdjacency } from '../../utils/mapPathfinding';
 import { isDescendantIdOf } from '../../utils/mapGraphUtils';
 import { applyNestedCircleLayout } from '../../utils/mapLayoutUtils';
 
@@ -415,6 +415,10 @@ function App() {
   );
 
   const [mapInitialViewBox, setMapInitialViewBox] = useState(mapViewBox);
+  const travelAdjacency: TravelAdjacency = React.useMemo(
+    () => buildTravelAdjacency(mapData),
+    [mapData]
+  );
   const travelPath: Array<TravelStep> | null = React.useMemo(() => {
     // Using globalTurnNumber to force recalculation each turn
     void globalTurnNumber;
@@ -425,8 +429,8 @@ function App() {
     ) {
       return null;
     }
-    return findTravelPath(mapData, currentMapNodeId, destinationNodeId);
-  }, [destinationNodeId, currentMapNodeId, mapData, globalTurnNumber]);
+    return findTravelPath(mapData, currentMapNodeId, destinationNodeId, travelAdjacency);
+  }, [destinationNodeId, currentMapNodeId, mapData, travelAdjacency, globalTurnNumber]);
   const prevMapVisibleRef = useRef(false);
   useEffect(() => {
     if (isMapVisible && !prevMapVisibleRef.current) {

--- a/tests/mapPathfinding.test.ts
+++ b/tests/mapPathfinding.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { buildTravelAdjacency, findTravelPath } from '../utils/mapPathfinding';
+import type { MapData, MapEdgeStatus } from '../types';
+
+const makeNode = (id: string, parentId = 'universe'): MapData['nodes'][number] => ({
+  id,
+  themeName: 'theme',
+  placeName: id,
+  position: { x: 0, y: 0 },
+  data: { description: '', status: 'discovered', nodeType: 'location', parentNodeId: parentId }
+});
+
+const makeEdge = (
+  id: string,
+  source: string,
+  target: string,
+  status: MapEdgeStatus
+): MapData['edges'][number] => ({
+  id,
+  sourceNodeId: source,
+  targetNodeId: target,
+  data: { status }
+});
+
+describe('findTravelPath', () => {
+  const mapData: MapData = {
+    nodes: ['a', 'b', 'c', 'd'].map(id => makeNode(id)),
+    edges: [
+      makeEdge('e1', 'a', 'b', 'open'),
+      makeEdge('e2', 'b', 'c', 'open'),
+      makeEdge('e3', 'c', 'd', 'rumored'),
+      makeEdge('e4', 'd', 'a', 'open')
+    ]
+  };
+
+  it('produces same path with or without prebuilt adjacency', () => {
+    const pathDirect = findTravelPath(mapData, 'a', 'c');
+    const adj = buildTravelAdjacency(mapData);
+    const pathPrebuilt = findTravelPath(mapData, 'a', 'c', adj);
+    expect(pathPrebuilt).toEqual(pathDirect);
+  });
+
+  it('handles hierarchy edges consistently', () => {
+    const map2: MapData = {
+      nodes: [
+        makeNode('parent'),
+        makeNode('x', 'parent'),
+        makeNode('y', 'parent')
+      ],
+      edges: []
+    };
+    const expected = findTravelPath(map2, 'x', 'y');
+    const adj2 = buildTravelAdjacency(map2);
+    const result = findTravelPath(map2, 'x', 'y', adj2);
+    expect(result).toEqual(expected);
+  });
+});

--- a/utils/entityUtils.ts
+++ b/utils/entityUtils.ts
@@ -1,5 +1,5 @@
 import { MapNode, MapData, Character, Item, FullGameState } from '../types';
-import { findTravelPath } from './mapPathfinding';
+import { findTravelPath, buildTravelAdjacency, TravelAdjacency } from './mapPathfinding';
 
 export const generateUniqueId = (base: string): string => {
   const sanitized = base.replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
@@ -19,10 +19,11 @@ export const stripBracketText = (name: string): string =>
 const getHopDistance = (
   mapData: MapData | undefined,
   fromId: string | null | undefined,
-  toId: string
+  toId: string,
+  adj?: TravelAdjacency
 ): number => {
   if (!mapData || !fromId) return Infinity;
-  const path = findTravelPath(mapData, fromId, toId);
+  const path = findTravelPath(mapData, fromId, toId, adj);
   if (!path) return Infinity;
   return path.filter(p => p.step === 'edge').length;
 };
@@ -54,10 +55,13 @@ export const findMapNodeByIdentifier = (
     )
     .filter(n => !nameMatches.includes(n));
 
+  const adjacency: TravelAdjacency | undefined = mapData ? buildTravelAdjacency(mapData) : undefined;
   const sortByDistance = (arr: Array<MapNode>) => {
     if (!mapData || !currentNodeId) return arr;
     return [...arr].sort(
-      (a, b) => getHopDistance(mapData, currentNodeId, a.id) - getHopDistance(mapData, currentNodeId, b.id)
+      (a, b) =>
+        getHopDistance(mapData, currentNodeId, a.id, adjacency) -
+        getHopDistance(mapData, currentNodeId, b.id, adjacency)
     );
   };
 

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -10,7 +10,7 @@ import {
   MapNode,
 } from '../../types';
 import { formatKnownPlacesForPrompt } from './map';
-import { findTravelPath } from '../mapPathfinding';
+import { findTravelPath, buildTravelAdjacency } from '../mapPathfinding';
 
 /**
  * Formats a list of known characters for AI prompts.
@@ -122,7 +122,8 @@ export const formatTravelPlanLine = (
   destinationNodeId: string | null
 ): string | null => {
   if (!currentNodeId || !destinationNodeId || currentNodeId === destinationNodeId) return null;
-  const path = findTravelPath(mapData, currentNodeId, destinationNodeId);
+  const adj = buildTravelAdjacency(mapData);
+  const path = findTravelPath(mapData, currentNodeId, destinationNodeId, adj);
   if (!path || path.length < 3) return null;
   const destination = mapData.nodes.find(n => n.id === destinationNodeId);
   const destName = destination?.placeName ?? destinationNodeId;


### PR DESCRIPTION
## Summary
- factor adjacency construction into `buildTravelAdjacency`
- allow `findTravelPath` to use a prebuilt adjacency
- prebuild adjacency once in the app and entity utilities
- adjust prompt formatter path helper
- test pathfinding against prebuilt adjacency

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6856d512e3088324ba2cd5ab2f96ad65