### PR TITLE
Introduce 'page' item type

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -38,7 +38,7 @@ import { applyNestedCircleLayout } from '../../utils/mapLayoutUtils';
 import {
   FREE_FORM_ACTION_COST,
 } from '../../constants';
-import { ThemePackName } from '../../types';
+import { ThemePackName, Item } from '../../types';
 
 
 function App() {
@@ -121,6 +121,7 @@ function App() {
     mapViewBox,
     handleMapViewBoxChange,
     handleMapNodesPositionChange,
+    updateItemContent,
   } = gameLogic;
 
   useEffect(() => {
@@ -181,11 +182,31 @@ function App() {
     closeLoadGameFromMenuConfirm,
     openNewCustomGameConfirm,
     closeNewCustomGameConfirm,
+    pageItem,
+    isPageVisible,
+    openPageView,
+    closePageView,
   } = useAppModals();
 
   const effectiveIsTitleMenuOpen = userRequestedTitleMenuOpen || (appReady && !hasGameBeenInitialized && !isLoading && !isCustomGameSetupVisible && !isManualShiftThemeSelectionVisible);
 
-  const isAnyModalOrDialogueActive = isVisualizerVisible || isKnowledgeBaseVisible || isSettingsVisible || isInfoVisible || isMapVisible || isHistoryVisible || isDebugViewVisible || !!dialogueState || effectiveIsTitleMenuOpen || shiftConfirmOpen || newGameFromMenuConfirmOpen || loadGameFromMenuConfirmOpen || isCustomGameSetupVisible || newCustomGameConfirmOpen || isManualShiftThemeSelectionVisible;
+  const isAnyModalOrDialogueActive =
+    isVisualizerVisible ||
+    isKnowledgeBaseVisible ||
+    isSettingsVisible ||
+    isInfoVisible ||
+    isMapVisible ||
+    isHistoryVisible ||
+    isDebugViewVisible ||
+    isPageVisible ||
+    !!dialogueState ||
+    effectiveIsTitleMenuOpen ||
+    shiftConfirmOpen ||
+    newGameFromMenuConfirmOpen ||
+    loadGameFromMenuConfirmOpen ||
+    isCustomGameSetupVisible ||
+    newCustomGameConfirmOpen ||
+    isManualShiftThemeSelectionVisible;
 
 
   useEffect(() => {
@@ -251,6 +272,10 @@ function App() {
   const handleRetryClick = useCallback(() => {
     void handleRetry();
   }, [handleRetry]);
+
+  const handleReadPage = useCallback((item: Item) => {
+    openPageView(item);
+  }, [openPageView]);
 
   const handleFreeFormActionChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -590,6 +615,7 @@ function App() {
                 objectiveAnimationType={objectiveAnimationType}
                 onDropItem={gameLogic.handleDropItem}
                 onItemInteract={handleItemInteraction}
+                onReadPage={handleReadPage}
                 onTakeItem={handleTakeLocationItem}
               />
             )}
@@ -690,6 +716,7 @@ function App() {
 
       {hasGameBeenInitialized && currentTheme ? <AppModals
         allCharacters={allCharacters}
+        contextForPage={`${currentScene} ${lastActionLog ?? ''}`}
         currentMapNodeId={currentMapNodeId}
         currentScene={currentScene}
         currentTheme={currentTheme}
@@ -710,6 +737,7 @@ function App() {
         isHistoryVisible={isHistoryVisible}
         isKnowledgeBaseVisible={isKnowledgeBaseVisible}
         isMapVisible={isMapVisible}
+        isPageVisible={isPageVisible}
         isVisualizerVisible={isVisualizerVisible}
         itemPresenceByNode={itemPresenceByNode}
         loadGameFromMenuConfirmOpen={loadGameFromMenuConfirmOpen}
@@ -722,14 +750,17 @@ function App() {
         onCloseHistory={closeHistory}
         onCloseKnowledgeBase={closeKnowledgeBase}
         onCloseMap={closeMap}
+        onClosePage={closePageView}
         onCloseVisualizer={closeVisualizer}
         onLayoutConfigChange={handleMapLayoutConfigChange}
         onNodesPositioned={handleMapNodesPositionChange}
         onSelectDestination={handleSelectDestinationNode}
         onViewBoxChange={handleMapViewBoxChange}
+        pageItem={pageItem}
         setGeneratedImage={setGeneratedImageCache}
         shiftConfirmOpen={shiftConfirmOpen}
         themeHistory={themeHistory}
+        updateItemContent={updateItemContent}
         visualizerImageScene={visualizerImageScene}
         visualizerImageUrl={visualizerImageUrl}
       /> : null}

--- a/components/app/AppModals.tsx
+++ b/components/app/AppModals.tsx
@@ -3,6 +3,7 @@ import MapDisplay from '../map/MapDisplay';
 import ConfirmationDialog from '../ConfirmationDialog';
 import HistoryDisplay from '../modals/HistoryDisplay';
 import ImageVisualizer from '../modals/ImageVisualizer';
+import PageView from '../modals/PageView';
 import {
   AdventureTheme,
   MapData,
@@ -10,6 +11,7 @@ import {
   Character,
   ThemeHistoryState,
   MapNode,
+  Item,
 } from '../../types';
 
 interface AppModalsProps {
@@ -62,6 +64,11 @@ interface AppModalsProps {
   readonly handleConfirmShift: () => void;
   readonly handleCancelShift: () => void;
   readonly isCustomGameModeShift: boolean;
+  readonly pageItem: Item | null;
+  readonly isPageVisible: boolean;
+  readonly onClosePage: () => void;
+  readonly contextForPage: string;
+  readonly updateItemContent: (id: string, actual: string, visible: string) => void;
 }
 
 function AppModals({
@@ -113,6 +120,11 @@ function AppModals({
   handleConfirmShift,
   handleCancelShift,
   isCustomGameModeShift,
+  pageItem,
+  isPageVisible,
+  onClosePage,
+  contextForPage,
+  updateItemContent,
 }: AppModalsProps) {
 
 
@@ -145,6 +157,14 @@ function AppModals({
         isVisible={isHistoryVisible}
         onClose={onCloseHistory}
         themeHistory={themeHistory}
+      />
+
+      <PageView
+        context={contextForPage}
+        isVisible={isPageVisible}
+        item={pageItem}
+        onClose={onClosePage}
+        updateItemContent={updateItemContent}
       />
 
       <MapDisplay

--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -27,6 +27,7 @@ interface GameSidebarProps {
     interactionType: 'generic' | 'specific' | 'inspect',
     knownUse?: KnownUse,
   ) => void;
+  readonly onReadPage: (item: Item) => void;
   readonly onTakeItem: (itemName: string) => void;
   readonly disabled: boolean;
 }
@@ -44,6 +45,7 @@ function GameSidebar({
   objectiveAnimationType,
   onDropItem,
   onItemInteract,
+  onReadPage,
   onTakeItem,
   disabled,
 }: GameSidebarProps) {
@@ -113,6 +115,7 @@ function GameSidebar({
         items={inventory}
         onDropItem={onDropItem}
         onItemInteract={onItemInteract}
+        onReadPage={onReadPage}
       />
     </>
   );

--- a/components/inventory/InventoryDisplay.tsx
+++ b/components/inventory/InventoryDisplay.tsx
@@ -16,10 +16,11 @@ interface InventoryDisplayProps {
     knownUse?: KnownUse
   ) => void;
   readonly onDropItem: (itemName: string) => void;
+  readonly onReadPage: (item: Item) => void;
   readonly disabled: boolean;
 }
 
-function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: InventoryDisplayProps) {
+function InventoryDisplay({ items, onItemInteract, onDropItem, onReadPage, disabled }: InventoryDisplayProps) {
   const {
     displayedItems,
     newlyAddedItemNames,
@@ -34,8 +35,9 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
     handleInspect,
     handleGenericUse,
     handleVehicleToggle,
+    handleRead,
     getApplicableKnownUses,
-  } = useInventoryDisplay({ items, onItemInteract, onDropItem });
+  } = useInventoryDisplay({ items, onItemInteract, onDropItem, onReadPage });
 
   return (
     <div className="bg-slate-800 p-6 rounded-lg shadow-lg border border-slate-700 h-full">
@@ -81,6 +83,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, disabled }: Inven
                 onConfirmDrop={handleConfirmDrop}
                 onGenericUse={handleGenericUse}
                 onInspect={handleInspect}
+                onRead={handleRead}
                 onSpecificUse={handleSpecificUse}
                 onStartConfirmDiscard={handleStartConfirmDiscard}
                 onVehicleToggle={handleVehicleToggle}

--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -16,6 +16,7 @@ interface InventoryItemProps {
   readonly onStartConfirmDiscard: (event: React.MouseEvent<HTMLButtonElement>) => void;
   readonly onConfirmDrop: (event: React.MouseEvent<HTMLButtonElement>) => void;
   readonly onCancelDiscard: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  readonly onRead: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 function InventoryItem({
@@ -31,6 +32,7 @@ function InventoryItem({
   onStartConfirmDiscard,
   onConfirmDrop,
   onCancelDiscard,
+  onRead,
 }: InventoryItemProps) {
   const displayDescription = item.isActive && item.activeDescription ? item.activeDescription : item.description;
   return (
@@ -78,19 +80,32 @@ function InventoryItem({
             preset="teal"
             size="sm"
             title={knownUse.description}
-          />
-        ))}
+        />
+      ))}
 
+      <Button
+        ariaLabel={`Inspect ${item.name}`}
+        data-item-name={item.name}
+        disabled={disabled || isConfirmingDiscard}
+        key={`${item.name}-inspect`}
+        label="Inspect"
+        onClick={onInspect}
+        preset="indigo"
+        size="sm"
+      />
+
+      {item.type === 'page' ? (
         <Button
-          ariaLabel={`Inspect ${item.name}`}
+          ariaLabel={`Read ${item.name}`}
           data-item-name={item.name}
           disabled={disabled || isConfirmingDiscard}
-          key={`${item.name}-inspect`}
-          label="Inspect"
-          onClick={onInspect}
-          preset="indigo"
+          key={`${item.name}-read`}
+          label="Read"
+          onClick={onRead}
+          preset="teal"
           size="sm"
         />
+      ) : null}
 
         {(item.type !== 'knowledge' && item.type !== 'status effect' && item.type !== 'vehicle') && (
           <Button

--- a/components/inventory/ItemTypeDisplay.tsx
+++ b/components/inventory/ItemTypeDisplay.tsx
@@ -21,6 +21,7 @@ export function ItemTypeDisplay({ type }: ItemTypeDisplayProps): React.ReactElem
     vehicle: 'text-indigo-400',
     knowledge: 'text-purple-400',
     'status effect': 'text-pink-400',
+    page: 'text-green-400',
   };
 
   const color = colorMap[type];

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { Item } from '../../types';
+import Button from '../elements/Button';
+import { Icon } from '../elements/icons';
+import LoadingSpinner from '../LoadingSpinner';
+import { generatePageText } from '../../services/page';
+
+interface PageViewProps {
+  readonly item: Item | null;
+  readonly context: string;
+  readonly isVisible: boolean;
+  readonly onClose: () => void;
+  readonly updateItemContent: (itemId: string, actual: string, visible: string) => void;
+}
+
+function PageView({ item, context, isVisible, onClose, updateItemContent }: PageViewProps) {
+  const [text, setText] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isVisible && item) {
+      if (item.visibleContent) {
+        setText(item.visibleContent);
+      } else {
+        setIsLoading(true);
+        void (async () => {
+          const length = item.contentLength ?? 30;
+          const generated = await generatePageText(item.name, item.description, length, context);
+          if (generated) {
+            updateItemContent(item.id, generated, generated);
+            setText(generated);
+          }
+          setIsLoading(false);
+        })();
+      }
+    } else {
+      setText(null);
+    }
+  }, [isVisible, item, context, updateItemContent]);
+
+  return (
+    <div
+      aria-modal="true"
+      className={`animated-frame ${isVisible ? 'open' : ''}`}
+      role="dialog"
+    >
+      <div className="animated-frame-content page-view-content-area">
+        <Button
+          ariaLabel="Close page"
+          icon={(
+            <Icon
+              name="x"
+              size={20}
+            />
+          )}
+          onClick={onClose}
+          size="sm"
+          variant="close"
+        />
+
+        {isLoading ? (
+          <LoadingSpinner loadingReason="page" />
+        ) : text ? (
+          <div className="whitespace-pre-wrap text-slate-200 overflow-y-auto mt-4">
+            {text}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default PageView;

--- a/constants.ts
+++ b/constants.ts
@@ -52,7 +52,7 @@ export const FREE_FORM_ACTION_COST = 5;
 
 export const VALID_ITEM_TYPES = [
   'single-use', 'multi-use', 'equipment',
-  'container', 'key', 'weapon', 'ammunition', 'vehicle', 'knowledge', 'status effect'
+  'container', 'key', 'weapon', 'ammunition', 'vehicle', 'knowledge', 'status effect', 'page'
 ] as const; // 'as const' makes it a tuple of string literals
 
 export const VALID_ITEM_TYPES_STRING = VALID_ITEM_TYPES.map(type => `"${type}"`).join(' | ');
@@ -77,7 +77,8 @@ export const LOADING_REASONS = [
   'dialogue_conclusion_summary',
   'initial_load',
   'reality_shift_load',
-  'visualize'
+  'visualize',
+  'page'
 ] as const;
 
 export const LOADING_REASON_UI_MAP: Record<(typeof LOADING_REASONS)[number], { text: string; icon: string }> = {
@@ -91,7 +92,8 @@ export const LOADING_REASON_UI_MAP: Record<(typeof LOADING_REASONS)[number], { t
   dialogue_conclusion_summary: { text: 'Returning to the world...', icon: '○' },
   initial_load: { text: 'Loading...', icon: '▒▒' },
   reality_shift_load: { text: 'Reality is shifting...', icon: '▒▒' },
-  visualize: { text: 'Visualizing the scene...', icon: '▒▒' }
+  visualize: { text: 'Visualizing the scene...', icon: '▒▒' },
+  page: { text: 'Reading...', icon: '░░' }
 };
 
 // Centralized map node/edge valid values

--- a/hooks/useAppModals.ts
+++ b/hooks/useAppModals.ts
@@ -3,6 +3,7 @@
  * @description Manages visibility state and helper handlers for app modals.
  */
 import { useCallback, useState } from 'react';
+import { Item } from '../types';
 
 export const useAppModals = () => {
   const [isVisualizerVisible, setIsVisualizerVisible] = useState(false);
@@ -22,6 +23,8 @@ export const useAppModals = () => {
   const [newGameFromMenuConfirmOpen, setNewGameFromMenuConfirmOpen] = useState(false);
   const [loadGameFromMenuConfirmOpen, setLoadGameFromMenuConfirmOpen] = useState(false);
   const [newCustomGameConfirmOpen, setNewCustomGameConfirmOpen] = useState(false);
+  const [pageItem, setPageItem] = useState<Item | null>(null);
+  const [isPageVisible, setIsPageVisible] = useState(false);
 
   const openVisualizer = useCallback(() => { setIsVisualizerVisible(true); }, []);
   const closeVisualizer = useCallback(() => { setIsVisualizerVisible(false); }, []);
@@ -50,6 +53,8 @@ export const useAppModals = () => {
   const closeLoadGameFromMenuConfirm = useCallback(() => { setLoadGameFromMenuConfirmOpen(false); }, []);
   const openNewCustomGameConfirm = useCallback(() => { setNewCustomGameConfirmOpen(true); }, []);
   const closeNewCustomGameConfirm = useCallback(() => { setNewCustomGameConfirmOpen(false); }, []);
+  const openPageView = useCallback((item: Item) => { setPageItem(item); setIsPageVisible(true); }, []);
+  const closePageView = useCallback(() => { setIsPageVisible(false); }, []);
 
   return {
     // state
@@ -69,8 +74,10 @@ export const useAppModals = () => {
     shiftConfirmOpen,
     newGameFromMenuConfirmOpen,
     loadGameFromMenuConfirmOpen,
-    newCustomGameConfirmOpen,
-    // setters used outside
+   newCustomGameConfirmOpen,
+   pageItem,
+   isPageVisible,
+   // setters used outside
     setVisualizerImageUrl,
     setVisualizerImageScene,
     setShouldReturnToTitleMenu,
@@ -101,8 +108,10 @@ export const useAppModals = () => {
     closeNewGameFromMenuConfirm,
     openLoadGameFromMenuConfirm,
     closeLoadGameFromMenuConfirm,
-    openNewCustomGameConfirm,
-    closeNewCustomGameConfirm,
+   openNewCustomGameConfirm,
+   closeNewCustomGameConfirm,
+   openPageView,
+   closePageView,
   } as const;
 };
 

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -100,6 +100,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     handleItemInteraction,
     handleDropItem,
     handleTakeLocationItem,
+    updateItemContent,
     handleFreeFormActionSubmit,
     handleUndoTurn,
   } = useGameTurn({
@@ -326,6 +327,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     handleItemInteraction,
     handleDropItem,
     handleTakeLocationItem,
+    updateItemContent,
     handleRetry,
     executeRestartGame,
     executeManualRealityShift,

--- a/hooks/useInventoryActions.ts
+++ b/hooks/useInventoryActions.ts
@@ -121,7 +121,19 @@ export const useInventoryActions = ({
     [getCurrentGameState, commitGameState, isLoading],
   );
 
-  return { handleDropItem, handleTakeLocationItem };
+  const updateItemContent = useCallback(
+    (id: string, actual: string, visible: string) => {
+      const currentFullState = getCurrentGameState();
+      const draftState = structuredCloneGameState(currentFullState);
+      draftState.inventory = draftState.inventory.map(item =>
+        item.id === id ? { ...item, actualContent: actual, visibleContent: visible } : item
+      );
+      commitGameState(draftState);
+    },
+    [getCurrentGameState, commitGameState]
+  );
+
+  return { handleDropItem, handleTakeLocationItem, updateItemContent };
 };
 
 export type InventoryActions = ReturnType<typeof useInventoryActions>;

--- a/hooks/useInventoryDisplay.ts
+++ b/hooks/useInventoryDisplay.ts
@@ -15,12 +15,14 @@ interface UseInventoryDisplayProps {
     knownUse?: KnownUse
   ) => void;
   readonly onDropItem: (itemName: string) => void;
+  readonly onReadPage: (item: Item) => void;
 }
 
 export const useInventoryDisplay = ({
   items,
   onItemInteract,
   onDropItem,
+  onReadPage,
 }: UseInventoryDisplayProps) => {
   const [newlyAddedItemNames, setNewlyAddedItemNames] = useState<Set<string>>(new Set());
   const prevItemsRef = useRef<Array<Item>>(items);
@@ -119,6 +121,15 @@ export const useInventoryDisplay = ({
     [items, onItemInteract]
   );
 
+  const handleRead = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const name = event.currentTarget.dataset.itemName;
+    if (!name) return;
+    const item = items.find(i => i.name === name);
+    if (!item) return;
+    onReadPage(item);
+    event.currentTarget.blur();
+  }, [items, onReadPage]);
+
   useEffect(() => {
     const currentItemNames = new Set(items.map(item => item.name));
     const prevItemNames = new Set(prevItemsRef.current.map(item => item.name));
@@ -205,6 +216,7 @@ export const useInventoryDisplay = ({
     handleInspect,
     handleGenericUse,
     handleVehicleToggle,
+    handleRead,
     getApplicableKnownUses,
   } as const;
 };

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -78,7 +78,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     setGameStateStack,
   });
 
-  const { handleDropItem, handleTakeLocationItem } = useInventoryActions({
+  const { handleDropItem, handleTakeLocationItem, updateItemContent } = useInventoryActions({
     getCurrentGameState,
     commitGameState,
     isLoading,
@@ -335,6 +335,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     handleItemInteraction,
     handleDropItem,
     handleTakeLocationItem,
+    updateItemContent,
     handleFreeFormActionSubmit,
     handleUndoTurn,
   };

--- a/index.css
+++ b/index.css
@@ -138,6 +138,15 @@ body {
   margin-bottom: 1rem;
 }
 
+/* Page View Styles */
+.page-view-content-area {
+  max-width: 600px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
 /* Knowledge Base Styles */
 .knowledge-base-content-area {
   overflow-y: auto;

--- a/resources/itemTypeSynonyms.ts
+++ b/resources/itemTypeSynonyms.ts
@@ -11,7 +11,11 @@ const itemTypeSynonyms = {
     "tool": "equipment",
     "ammo": "ammunition",
     "ammunition": "ammunition",
-    "projectiles": "ammunition"
+    "projectiles": "ammunition",
+    "note": "page",
+    "scrap of paper": "page",
+    "sheet": "page",
+    "page": "page"
   }
 };
 

--- a/services/page/AGENTS.md
+++ b/services/page/AGENTS.md
@@ -1,0 +1,6 @@
+The **page** service generates text for small written items like notes or pages.
+Follow the same request structure as other services: an `api.ts` module exporting
+`generatePageText` which wraps `dispatchAIRequest` with retry logic. Keep prompts
+simple and system instructions concise. Use AUXILIARY_MODEL_NAME first and fall
+back to GEMINI_MODEL_NAME. Add progress symbols before requests and sanitize AI
+responses with the provided JSON helpers when applicable.

--- a/services/page/api.ts
+++ b/services/page/api.ts
@@ -1,0 +1,43 @@
+import { AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME, LOADING_REASON_UI_MAP } from '../../constants';
+import { dispatchAIRequest } from '../modelDispatcher';
+import { retryAiCall } from '../../utils/retry';
+import { addProgressSymbol } from '../../utils/loadingProgress';
+import { isApiConfigured } from '../apiClient';
+
+export const generatePageText = async (
+  itemName: string,
+  itemDescription: string,
+  length: number,
+  context: string,
+): Promise<string | null> => {
+  if (!isApiConfigured()) {
+    console.error('generatePageText: API key not configured.');
+    return null;
+  }
+
+  const prompt = `You are providing the exact handwritten contents of a short note in a text adventure game.\nItem: "${itemName}"\nDescription: "${itemDescription}"\nApproximate length: ${String(length)} words.\nContext: ${context}\nWrite the note contents in first person or as a direct message if appropriate. Avoid mentioning the instructions.`;
+  const systemInstruction = 'Return only the contents of the note.';
+
+  return retryAiCall<string>(async attempt => {
+    try {
+      addProgressSymbol(LOADING_REASON_UI_MAP.page.icon);
+      const { response } = await dispatchAIRequest({
+        modelNames: [AUXILIARY_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        systemInstruction,
+        temperature: 0.8,
+        label: 'PageText',
+      });
+      const text = response.text?.trim() ?? '';
+      if (text !== '') {
+        return { result: text };
+      }
+    } catch (err: unknown) {
+      console.error(`generatePageText error (Attempt ${String(attempt + 1)}):`, err);
+      throw err;
+    }
+    return { result: null };
+  });
+};
+
+export default generatePageText;

--- a/services/page/index.ts
+++ b/services/page/index.ts
@@ -1,0 +1,1 @@
+export { generatePageText } from './api';

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -99,6 +99,18 @@ export function isValidItem(item: unknown, context?: 'gain' | 'update'): item is
     console.warn("isValidItem: 'holderId' is present but invalid.", item);
     return false;
   }
+  if (obj.contentLength !== undefined && typeof obj.contentLength !== 'number') {
+    console.warn("isValidItem: 'contentLength' is present but invalid.", item);
+    return false;
+  }
+  if (obj.actualContent !== undefined && typeof obj.actualContent !== 'string') {
+    console.warn("isValidItem: 'actualContent' is present but invalid.", item);
+    return false;
+  }
+  if (obj.visibleContent !== undefined && typeof obj.visibleContent !== 'string') {
+    console.warn("isValidItem: 'visibleContent' is present but invalid.", item);
+    return false;
+  }
   if (obj.knownUses !== undefined && !(Array.isArray(obj.knownUses) && obj.knownUses.every(isValidKnownUse))) {
     console.warn("isValidItem: 'knownUses' is present but invalid.", item);
     return false;

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -55,6 +55,9 @@ export function isValidItemForSave(item: unknown): item is Item {
     (maybe.activeDescription === undefined || typeof maybe.activeDescription === 'string') &&
     (maybe.isActive === undefined || typeof maybe.isActive === 'boolean') &&
     (maybe.isJunk === undefined || typeof maybe.isJunk === 'boolean') &&
+    (maybe.contentLength === undefined || typeof maybe.contentLength === 'number') &&
+    (maybe.actualContent === undefined || typeof maybe.actualContent === 'string') &&
+    (maybe.visibleContent === undefined || typeof maybe.visibleContent === 'string') &&
     (maybe.knownUses === undefined ||
       (Array.isArray(maybe.knownUses) &&
         maybe.knownUses.every((ku: KnownUse) =>

--- a/types.ts
+++ b/types.ts
@@ -44,6 +44,9 @@ export interface Item {
   knownUses?: Array<KnownUse>; // Discovered specific ways to use the item
   isJunk?: boolean; // Flag for unimportant items
   holderId: string; // ID of the entity holding this item or 'player'
+  contentLength?: number; // Approximate text length for page items
+  actualContent?: string; // Stored content once generated
+  visibleContent?: string; // Player-facing version of the content
   // --- Fields for "update" action payloads ---
   newName?: string;
   addKnownUse?: KnownUse;


### PR DESCRIPTION
## Summary
- add new Item type "page" and synonyms
- manage page contents with a new PageView modal and AI helper
- store generated page text in `actualContent` and `visibleContent`
- wire up modal controls and page reading handlers

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856ecb3fb748324b20c014850046954