### PR TITLE
Restore direct connection item pickup

### DIFF
--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -270,11 +270,8 @@ export const useGameLogic = (props: UseGameLogicProps) => {
         currentFullState.mapData,
         currentFullState.currentMapNodeId
       );
-      const contextText = `${currentFullState.currentScene} ${currentFullState.lastActionLog ?? ''}`.toLowerCase();
-      const nearbyItems = currentFullState.inventory.filter(
-        i =>
-          adjIds.includes(i.holderId) &&
-          contextText.includes(i.name.toLowerCase())
+      const nearbyItems = currentFullState.inventory.filter(i =>
+        adjIds.includes(i.holderId)
       );
       const combined = [...atCurrent];
       nearbyItems.forEach(it => {
@@ -285,8 +282,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
       currentFullState.currentMapNodeId,
       currentFullState.inventory,
       currentFullState.mapData,
-      currentFullState.currentScene,
-      currentFullState.lastActionLog,
     ]),
     itemPresenceByNode,
     gameLog: currentFullState.gameLog,

--- a/tests/adjacentItems.test.ts
+++ b/tests/adjacentItems.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { getAdjacentNodeIds } from '../utils/mapGraphUtils';
+import LocationItemsDisplay from '../components/inventory/LocationItemsDisplay';
 import type { MapData, Item, MapEdgeStatus, MapNodeStatus } from '../types';
 
 const makeNode = (
@@ -53,6 +56,25 @@ describe('getAdjacentNodeIds for item reachability', () => {
     expect(reachableItems.map(i => i.name)).toContain('Log');
     expect(reachableItems.map(i => i.name)).not.toContain('Tablet');
     expect(reachableItems.map(i => i.name)).not.toContain('Stone');
+  });
+
+  it('displays reachable items with Take button', () => {
+    const adj = getAdjacentNodeIds(mapData, 'current');
+    const displayItems = inventory.filter(i => i.holderId === 'current' || adj.includes(i.holderId));
+    const html = renderToStaticMarkup(
+      createElement(LocationItemsDisplay, {
+        currentNodeId: 'current',
+        disabled: false,
+        items: displayItems,
+        mapNodes: mapData.nodes.map(n => ({ id: n.id, placeName: n.placeName })),
+        onTakeItem: vi.fn(),
+      })
+    );
+    expect(html).toContain('Take');
+    expect(html).toContain('Reachable at');
+    expect(html).toContain('Log');
+    expect(html).not.toContain('Tablet');
+    expect(html).not.toContain('Stone');
   });
 });
 

--- a/utils/mapGraphUtils.ts
+++ b/utils/mapGraphUtils.ts
@@ -96,7 +96,16 @@ export const getAdjacentNodeIds = (
   nodeId: string,
 ): Array<string> => {
   const { adjacency } = buildTravelAdjacency(mapData);
-  return (adjacency.get(nodeId) ?? []).map(a => a.to);
+  const edgeMap = new Map(mapData.edges.map(e => [e.id, e]));
+  const allowed: Array<MapEdgeStatus> = ['open', 'accessible', 'active'];
+  return (adjacency.get(nodeId) ?? [])
+    .filter(a => {
+      const edge = edgeMap.get(a.edgeId);
+      if (!edge) return true;
+      const status = edge.data.status ?? 'open';
+      return allowed.includes(status);
+    })
+    .map(a => a.to);
 };
 
 /** Structure describing adjacency for each node. */


### PR DESCRIPTION
## Summary
- use pathfinding adjacency to determine directly connected nodes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857452cfd5c8324b6e9eb9322724be3