### PR TITLE
Isolate page styles and preload fonts

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,9 +1,4 @@
 /* Main stylesheet for Whispers in the Dark */
-@import url('https://fonts.googleapis.com/css2?family=Tektur:wght@400..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Shadows+Into+Light&family=Special+Elite&family=VT323&family=Gloria+Hallelujah&family=IBM+Plex+Serif&family=Press+Start+2P&family=Noto+Sans+Runic&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Oooh+Baby&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Chokokutai&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Eagle+Lake&display=swap');
 
 body {
   font-family: "Georgia", serif; /* Thematic font */
@@ -17,144 +12,6 @@ body {
   font-style: normal;
   font-variation-settings:
     "wdth" 100;
-}
-
-.tag-handwritten {
-  background-color: #f5deb3;
-  color: #1a1a1a;
-  font-family: "Oooh Baby", cursive;
-  font-weight: 600;
-  font-size: 1.5rem !important;
-}
-
-.tag-handwritten strong {
-  color: #7f1d1d;
-  font-size: 1.75rem !important;
-}
-
-.tag-handwritten em {
-  color: #0e124b;
-  text-decoration: underline;
-}
-
-.tag-printed {
-  background-color: #f5deb3;
-  color: #1a1a1a;
-  font-family: "IBM Plex Serif", serif;
-}
-
-.tag-printed strong {
-  color: #000000;
-}
-
-.tag-printed em {
-  text-decoration: underline;
-}
-
-.tag-typed {
-  background-color: #f5deb3;
-  color: #333333;
-  font-family: "Special Elite";
-}
-
-.tag-typed strong {
-  color: #000000;
-}
-
-.tag-typed em {
-  text-decoration: wavy underline;
-}
-
-.tag-digital {
-  background-color: #0c140a;
-  color: #00ff90;
-  font-family: "VT323", monospace;
-  font-size: 1.5rem !important;
-}
-
-.tag-handwritten-foreign {
-  font-family: "Gloria Hallelujah", cursive;
-  background-color: #f5deb3;
-}
-
-.tag-typed-foreign {
-  font-family: "IBM Plex Serif", serif;
-  background-color: #f5deb3;
-}
-
-.tag-printed-foreign {
-  font-family: "Eagle Lake", serif;
-  background-color: #f5deb3;
-}
-
-.tag-printed-foreign strong {
-  color: #880000;
-}
-
-.tag-printed-foreign em {
-  color: #004400;
-  text-decoration: wavy underline;
-}
-
-.tag-digital-foreign {
-  font-family: "Chokokutai", system-ui;
-  color: #7880d6 !important;
-  background-color: #121f0f;
-}
-
-.tag-faded {
-  color: #c0a87b;
-}
-
-.tag-smudged {
-  color: #4b3621;
-  filter: blur(1.1px);
-  text-shadow: 0 0 3px rgba(75, 54, 33, 0.5);
-  font-size-adjust: 0.55;
-}
-
-.tag-torn {
-  border: 3px dashed #a0aec0;
-}
-
-.tag-glitching {
-  color: #00ff90;
-  text-shadow: 1px 2px 0 rgb(255, 0, 255), -8px -9px 0 rgb(0, 225, 255) , 3px -5px 0 rgb(0, 255, 0);
-}
-
-.tag-encrypted {
-  color: #4b3621;
-  font-style: monospace;
-}
-
-.tag-foreign {
-  color: #212553;
-}
-
-.tag-gothic {
-  color: #2b2016;
-  background-color: #aa8a4e;
-  font-size-adjust: 0.75;
-}
-
-.tag-runic {
-  color: #2b2016;
-  background-color: #aa8a4e;
-  font-size-adjust: 0.75;
-}
-
-.tag-bloodstained {
-  background-color: #7f1d1d;
-  color: #fef2f2;
-}
-
-.tag-water-damaged {
-  background-color: #e0f2fe;
-  color: #1e3a8a;
-}
-
-.tag-recovered {
-
 }
 /* Custom scrollbar for a more thematic feel */
 ::-webkit-scrollbar {
@@ -281,14 +138,6 @@ body {
 }
 
 /* Page View Styles */
-.page-view-content-area {
-  max-width: 600px;
-  max-height: 80vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
 /* Knowledge Base Styles */
 .knowledge-base-content-area {
   overflow-y: auto;

--- a/index.html
+++ b/index.html
@@ -18,8 +18,15 @@
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+  rel="preload"
+  href="https://fonts.googleapis.com/css2?family=Tektur:wght@400..900&family=Oooh+Baby&family=IBM+Plex+Serif&family=Special+Elite&family=VT323&family=Gloria+Hallelujah&family=Eagle+Lake&family=Chokokutai&display=swap"
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+/>
 <link rel="stylesheet" href="/index.css">
 <link rel="stylesheet" href="/animations.css">
+<link rel="stylesheet" href="/page.css">
 </head>
   <body class="bg-slate-900 text-slate-100">
     <div id="root"></div>

--- a/page.css
+++ b/page.css
@@ -1,0 +1,147 @@
+/* Styles specific to PageView and page tags */
+
+.page-view-content-area {
+  max-width: 600px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.tag-handwritten {
+  background-color: #f5deb3;
+  color: #1a1a1a;
+  font-family: "Oooh Baby", cursive;
+  font-weight: 600;
+  font-size: 1.5rem !important;
+}
+
+.tag-handwritten strong {
+  color: #7f1d1d;
+  font-size: 1.75rem !important;
+}
+
+.tag-handwritten em {
+  color: #0e124b;
+  text-decoration: underline;
+}
+
+.tag-printed {
+  background-color: #f5deb3;
+  color: #1a1a1a;
+  font-family: "IBM Plex Serif", serif;
+}
+
+.tag-printed strong {
+  color: #000000;
+}
+
+.tag-printed em {
+  text-decoration: underline;
+}
+
+.tag-typed {
+  background-color: #f5deb3;
+  color: #333333;
+  font-family: "Special Elite";
+}
+
+.tag-typed strong {
+  color: #000000;
+}
+
+.tag-typed em {
+  text-decoration: wavy underline;
+}
+
+.tag-digital {
+  background-color: #0c140a;
+  color: #00ff90;
+  font-family: "VT323", monospace;
+  font-size: 1.5rem !important;
+}
+
+.tag-handwritten-foreign {
+  font-family: "Gloria Hallelujah", cursive;
+  background-color: #f5deb3;
+}
+
+.tag-typed-foreign {
+  font-family: "IBM Plex Serif", serif;
+  background-color: #f5deb3;
+}
+
+.tag-printed-foreign {
+  font-family: "Eagle Lake", serif;
+  background-color: #f5deb3;
+}
+
+.tag-printed-foreign strong {
+  color: #880000;
+}
+
+.tag-printed-foreign em {
+  color: #004400;
+  text-decoration: wavy underline;
+}
+
+.tag-digital-foreign {
+  font-family: "Chokokutai", system-ui;
+  color: #7880d6 !important;
+  background-color: #121f0f;
+}
+
+.tag-faded {
+  color: #c0a87b;
+}
+
+.tag-smudged {
+  color: #4b3621;
+  filter: blur(1.1px);
+  text-shadow: 0 0 3px rgba(75, 54, 33, 0.5);
+  font-size-adjust: 0.55;
+}
+
+.tag-torn {
+  border: 3px dashed #a0aec0;
+}
+
+.tag-glitching {
+  color: #00ff90;
+  text-shadow: 1px 2px 0 rgb(255, 0, 255), -8px -9px 0 rgb(0, 225, 255), 3px -5px 0 rgb(0, 255, 0);
+}
+
+.tag-encrypted {
+  color: #4b3621;
+  font-style: monospace;
+}
+
+.tag-foreign {
+  color: #212553;
+}
+
+.tag-gothic {
+  color: #2b2016;
+  background-color: #aa8a4e;
+  font-size-adjust: 0.75;
+}
+
+.tag-runic {
+  color: #2b2016;
+  background-color: #aa8a4e;
+  font-size-adjust: 0.75;
+}
+
+.tag-bloodstained {
+  background-color: #7f1d1d;
+  color: #fef2f2;
+}
+
+.tag-water-damaged {
+  background-color: #e0f2fe;
+  color: #1e3a8a;
+}
+
+.tag-recovered {
+
+}


### PR DESCRIPTION
## Summary
- move page view styles into a new `page.css`
- preload fonts in `index.html`
- remove font `@import`s from `index.css`
- combine font preload links into one

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857fe373aa48324a35df5cecfbf0d09