### PR TITLE
Add sanity check for book chapters in inventory service

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -89,6 +89,12 @@ export interface NewItemSuggestion {
   name: string;
   type: ItemType;
   description: string;
+  activeDescription?: string;
+  isActive?: boolean;
+  tags?: Array<ItemTag>;
+  holderId?: string;
+  chapters?: Array<ItemChapter>;
+  knownUses?: Array<KnownUse>;
 }
 
 export type ItemChange =


### PR DESCRIPTION
## Summary
- extend `NewItemSuggestion` to carry optional book data
- preserve chapters from storyteller suggestions when processing inventory changes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859135fe7f883249d76e5c68b05f09d