### PR TITLE
Refine Inspect cooldown and content retrieval

### DIFF
--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -2,7 +2,7 @@ import { Item, KnownUse } from '../../types';
 import { Icon } from '../elements/icons';
 import ItemTypeDisplay from './ItemTypeDisplay';
 import Button from '../elements/Button';
-import { JOURNAL_WRITE_COOLDOWN } from '../../constants';
+import { JOURNAL_WRITE_COOLDOWN, INSPECT_COOLDOWN } from '../../constants';
 
 interface InventoryItemProps {
   readonly item: Item;
@@ -91,7 +91,14 @@ function InventoryItem({
         <Button
           ariaLabel={`Inspect ${item.name}`}
           data-item-name={item.name}
-          disabled={disabled || isConfirmingDiscard}
+          disabled={
+            disabled ||
+            isConfirmingDiscard ||
+            (item.type === 'journal'
+              ? (item.chapters?.length ?? 0) === 0
+              : (item.chapters?.some(ch => !ch.actualContent) ?? true)) ||
+            (item.lastInspectTurn !== undefined && currentTurn - item.lastInspectTurn < INSPECT_COOLDOWN)
+          }
           key={`${item.name}-inspect`}
           label="Inspect"
           onClick={onInspect}

--- a/constants.ts
+++ b/constants.ts
@@ -52,6 +52,8 @@ export const FREE_FORM_ACTION_COST = 5;
 
 export const JOURNAL_WRITE_COOLDOWN = 5; // Turns before a journal can be written again
 
+export const INSPECT_COOLDOWN = 10; // Turns before the same item can be inspected again
+
 export const VALID_ITEM_TYPES = [
   'single-use', 'multi-use', 'equipment',
   'container', 'key', 'weapon', 'ammunition', 'vehicle', 'knowledge', 'status effect', 'page', 'journal', 'book'

--- a/hooks/useInventoryActions.ts
+++ b/hooks/useInventoryActions.ts
@@ -181,7 +181,21 @@ export const useInventoryActions = ({
     [commitGameState]
   );
 
-  return { handleDropItem, handleTakeLocationItem, updateItemContent, addJournalEntry, addTag };
+  const recordInspect = useCallback(
+    (id: string) => {
+      const currentFullState = getStateRef.current();
+      const draftState = structuredCloneGameState(currentFullState);
+      draftState.inventory = draftState.inventory.map(item =>
+        item.id === id
+          ? { ...item, lastInspectTurn: currentFullState.globalTurnNumber }
+          : item
+      );
+      commitGameState(draftState);
+    },
+    [commitGameState]
+  );
+
+  return { handleDropItem, handleTakeLocationItem, updateItemContent, addJournalEntry, addTag, recordInspect };
 };
 
 export type InventoryActions = ReturnType<typeof useInventoryActions>;

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -78,7 +78,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     setGameStateStack,
   });
 
-  const { handleDropItem, handleTakeLocationItem, updateItemContent, addJournalEntry } = useInventoryActions({
+  const { handleDropItem, handleTakeLocationItem, updateItemContent, addJournalEntry, recordInspect } = useInventoryActions({
     getCurrentGameState,
     commitGameState,
     isLoading,
@@ -287,14 +287,21 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
   const handleItemInteraction = useCallback(
     (item: Item, interactionType: 'generic' | 'specific' | 'inspect', knownUse?: KnownUse) => {
       if (interactionType === 'inspect') {
-        void executePlayerAction(`Inspect: ${item.name}`);
+        const showActual = item.tags?.includes('recovered');
+        const contents = (item.chapters ?? [])
+          .map(ch => `${ch.heading}\n${showActual ? ch.actualContent ?? '' : ch.visibleContent ?? ''}\n\n`)
+          .join('');
+        void executePlayerAction(
+          `Player reads the ${item.name} - ${item.description}. Here's what the player reads:\n${contents}`
+        );
+        recordInspect(item.id);
       } else if (interactionType === 'specific' && knownUse) {
         void executePlayerAction(knownUse.promptEffect);
       } else if (interactionType === 'generic') {
         void executePlayerAction(`Attempt to use: ${item.name}`);
       }
     },
-    [executePlayerAction]
+    [executePlayerAction, recordInspect]
   );
 
 

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -56,6 +56,7 @@ export function isValidItemForSave(item: unknown): item is Item {
     (maybe.isActive === undefined || typeof maybe.isActive === 'boolean') &&
     (maybe.tags === undefined || (Array.isArray(maybe.tags) && maybe.tags.every(t => typeof t === 'string'))) &&
     (maybe.lastWriteTurn === undefined || typeof maybe.lastWriteTurn === 'number') &&
+    (maybe.lastInspectTurn === undefined || typeof maybe.lastInspectTurn === 'number') &&
     ((maybe as { contentLength?: unknown }).contentLength === undefined ||
       typeof (maybe as { contentLength?: unknown }).contentLength === 'number') &&
     ((maybe as { actualContent?: unknown }).actualContent === undefined ||

--- a/types.ts
+++ b/types.ts
@@ -62,6 +62,7 @@ export interface Item {
    */
   chapters?: Array<ItemChapter>;
   lastWriteTurn?: number;
+  lastInspectTurn?: number;
   // --- Fields for "update" action payloads ---
   newName?: string;
   addKnownUse?: KnownUse;


### PR DESCRIPTION
## Summary
- increase `INSPECT_COOLDOWN` to 10 turns
- show `actualContent` when item has `recovered` tag
- keep recorded inspection turn logic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68591edd44c48324af3a492dde734df1