### PR TITLE
Fix update when holderId missing

### DIFF
--- a/utils/inventoryUtils.ts
+++ b/utils/inventoryUtils.ts
@@ -176,7 +176,7 @@ const applyItemActionCore = (
     return newInventory;
   }
 
-  if (fromId !== null && toId !== null && fromId === toId) {
+  if (fromId === toId) {
     const updatePayload = payload as Partial<Omit<Item, 'activeDescription'>> & {
       activeDescription?: string | null;
       contentLength?: number;


### PR DESCRIPTION
## Summary
- treat inventory updates with missing `holderId` as standard updates

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685930be10708324b62eaf4ec9096289