### PR TITLE
Fix inspect cooldown persistence

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -287,14 +287,17 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
   const handleItemInteraction = useCallback(
     (item: Item, interactionType: 'generic' | 'specific' | 'inspect', knownUse?: KnownUse) => {
       if (interactionType === 'inspect') {
+        recordInspect(item.id);
         const showActual = item.tags?.includes('recovered');
         const contents = (item.chapters ?? [])
-          .map(ch => `${ch.heading}\n${showActual ? ch.actualContent ?? '' : ch.visibleContent ?? ''}\n\n`)
+          .map(
+            ch =>
+              `${ch.heading}\n${showActual ? ch.actualContent ?? '' : ch.visibleContent ?? ''}\n\n`,
+          )
           .join('');
         void executePlayerAction(
-          `Player reads the ${item.name} - ${item.description}. Here's what the player reads:\n${contents}`
+          `Player reads the ${item.name} - ${item.description}. Here's what the player reads:\n${contents}`,
         );
-        recordInspect(item.id);
       } else if (interactionType === 'specific' && knownUse) {
         void executePlayerAction(knownUse.promptEffect);
       } else if (interactionType === 'generic') {


### PR DESCRIPTION
## Summary
- record item inspect before executing AI action so the cooldown is kept

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685932142f1c8324bcee4432a6b2453e