### PR TITLE
Fix DebugView close overlay

### DIFF
--- a/components/debug/tabs/PlaygroundTab.tsx
+++ b/components/debug/tabs/PlaygroundTab.tsx
@@ -55,6 +55,7 @@ function PlaygroundTab() {
         {variants.map(variant => {
           const isToggle = variant === 'toggle';
           const isClose = variant === 'close';
+          const buttons = (isClose ? presets.slice(0, 1) : presets);
           return (
             <div
               className="mb-4"
@@ -64,8 +65,8 @@ function PlaygroundTab() {
                 {variant}
               </h4>
 
-              <div className="flex flex-wrap gap-1">
-                {presets.map(preset => {
+              <div className={`flex flex-wrap gap-1${isClose ? ' relative h-12' : ''}`}>
+                {buttons.map(preset => {
                   const id = `${String(variant)}-${String(preset)}`;
                   return (
                     <Button


### PR DESCRIPTION
## Summary
- show demo close button in PlaygroundTab without overlaying the real close button

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859793580d48324b0ef41f185948d7d