### PR TITLE
Fix strict ESLint issues

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -742,8 +742,8 @@ function App() {
         isVisible={isDebugViewVisible}
         onApplyGameState={handleApplyGameState}
         onClose={closeDebugView}
-        onUndoTurn={handleUndoTurn}
         onDistillFacts={handleDistillClick}
+        onUndoTurn={handleUndoTurn}
         travelPath={travelPath}
       />
 

--- a/components/debug/tabs/LoremasterAITab.tsx
+++ b/components/debug/tabs/LoremasterAITab.tsx
@@ -28,8 +28,15 @@ function LoremasterAITab({ debugPacket, onDistillFacts }: LoremasterAITabProps) 
     if (!info) return null;
     const raw = showRaw[modeLabel] ?? true;
     return (
-      <div className="mb-4" key={modeLabel}>
-        <DebugSection content={info.prompt} isJson={false} title={`${modeLabel} Request`} />
+      <div
+        className="mb-4"
+        key={modeLabel}
+      >
+        <DebugSection
+          content={info.prompt}
+          isJson={false}
+          title={`${modeLabel} Request`}
+        />
 
         <div className="my-2 flex flex-wrap gap-2">
           <Button
@@ -60,22 +67,37 @@ function LoremasterAITab({ debugPacket, onDistillFacts }: LoremasterAITabProps) 
             title={`${modeLabel} Response Raw`}
           />
         ) : (
-          <DebugSection content={info.parsedPayload} title={`${modeLabel} Response Parsed`} />
+          <DebugSection
+            content={info.parsedPayload}
+            title={`${modeLabel} Response Parsed`}
+          />
         )}
 
         {info.observations ? (
-          <DebugSection content={info.observations} isJson={false} title={`${modeLabel} Observations`} />
+          <DebugSection
+            content={info.observations}
+            isJson={false}
+            title={`${modeLabel} Observations`}
+          />
         ) : null}
 
         {info.rationale ? (
-          <DebugSection content={info.rationale} isJson={false} title={`${modeLabel} Rationale`} />
+          <DebugSection
+            content={info.rationale}
+            isJson={false}
+            title={`${modeLabel} Rationale`}
+          />
         ) : null}
       </div>
     );
   };
 
   if (!debugPacket?.loremasterDebugInfo) {
-    return <p className="italic text-slate-300">No Loremaster AI interaction debug packet captured.</p>;
+    return (
+      <p className="italic text-slate-300">
+        No Loremaster AI interaction debug packet captured.
+      </p>
+    );
   }
 
   return (
@@ -90,8 +112,11 @@ function LoremasterAITab({ debugPacket, onDistillFacts }: LoremasterAITabProps) 
       />
 
       {renderMode('Collect', debugPacket.loremasterDebugInfo.collect)}
+
       {renderMode('Extract', debugPacket.loremasterDebugInfo.extract)}
+
       {renderMode('Integrate', debugPacket.loremasterDebugInfo.integrate)}
+
       {renderMode('Distill', debugPacket.loremasterDebugInfo.distill)}
     </>
   );

--- a/components/debug/tabs/PlaygroundTab.tsx
+++ b/components/debug/tabs/PlaygroundTab.tsx
@@ -71,7 +71,12 @@ function PlaygroundTab() {
                   return (
                     <Button
                       ariaLabel={id}
-                      icon={isClose ? <Icon name="x" size={16} /> : undefined}
+                      icon={isClose ? (
+                        <Icon
+                          name="x"
+                          size={16}
+                        />
+                      ) : undefined}
                       key={id}
                       label={isClose ? undefined : preset}
                       onClick={isToggle ? handleToggle(id) : noop}


### PR DESCRIPTION
## Summary
- reorder DebugView props alphabetically
- split props in `LoremasterAITab` and add blank lines
- format icon element in `PlaygroundTab`

## Testing
- `npm run lint-strict`
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859fd309f788324b05d02c4605e2954