### PR TITLE
Fix prompts and validation for item holderId and known uses

### DIFF
--- a/hooks/useInventoryDisplay.ts
+++ b/hooks/useInventoryDisplay.ts
@@ -75,6 +75,7 @@ export const useInventoryDisplay = ({
       const knownUse: KnownUse = {
         actionName,
         promptEffect,
+        description: actionName,
       };
       onItemInteract(item, 'specific', knownUse);
       event.currentTarget.blur();
@@ -116,6 +117,7 @@ export const useInventoryDisplay = ({
       const dynamicKnownUse: KnownUse = {
         actionName,
         promptEffect: actionName,
+        description: actionName,
       };
       onItemInteract(item, 'specific', dynamicKnownUse);
       event.currentTarget.blur();

--- a/services/corrections/edgeFixes.ts
+++ b/services/corrections/edgeFixes.ts
@@ -215,8 +215,8 @@ Return ONLY a JSON object strictly matching this structure:
     {
       "placeName": "string", /* A contextually relevant location name, based on Theme and Scene Description */
       "data": {
-        "description": "string", /* ${NODE_STATUS_LIST} */
-        "aliases": ["string"], /* ${EDGE_TYPE_LIST} */
+        "description": "string", /* short text describing the node */
+        "aliases": ["string"], /* alternative names for the node */
         "status": "string", /* ${NODE_STATUS_LIST} */
         "nodeType": "feature", /* ONLY add 'feature' type nodes! */
         "parentNodeId": "string" /* Name of the Parent Node this feature belongs to, or 'Universe' (keyword for root node) if it has no parent */
@@ -230,7 +230,7 @@ Return ONLY a JSON object strictly matching this structure:
       "data": {
         "type": "string", /* ${EDGE_TYPE_LIST} */
         "status": "string", /* ${EDGE_STATUS_LIST} */
-        "description": "string" /* ${EDGE_STATUS_LIST} */
+        "description": "string" /* short text describing the connection */
       }
     }
   ]

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -58,7 +58,7 @@ For "knownUses" (array of objects) or "addKnownUse" (single object): Each "Known
   "type": "(${VALID_ITEM_TYPES_STRING})",
   "description": "string",
   "activeDescription?": "string",
-  "holderId?": "string",
+  "holderId": "string",
   "isActive?": boolean,
   "tags?": ["junk"],
   "chapters"?: [
@@ -81,6 +81,7 @@ For "knownUses" (array of objects) or "addKnownUse" (single object): Each "Known
   specificActionInstructions = `Based *strictly* on Log/Scene and malformed payload:
   - Provide "name", "type", "description" for the gained item. These MUST be non-empty.
   - Choose "type" from: ${VALID_ITEM_TYPES_STRING}. The 'type' CANNOT be 'junk'. If the item is junk, add "junk" to its "tags" array and pick a suitable type.
+  - Provide "holderId" referencing the correct location or character. Use 'player' only if the item goes to the Player's inventory.
   - "isActive" defaults to false. The "tags" array defaults to []. "status effect" items can never have the "junk" tag.
   - For items with type "page", provide a numeric "contentLength" (up to 250 words).
   - "knownUses" is optional.
@@ -95,6 +96,7 @@ Instructions for "update":
     -   Only include fields ("type", "description", "isActive", "tags", "contentLength", "knownUses", "addKnownUse") if they are being explicitly changed or were present in the original payload.
     -   If "type" or "description" are not provided, the item's existing values will be retained.
     -   If "type" is provided, it must be from ${VALID_ITEM_TYPES_STRING} and CANNOT be 'junk'. If the item becomes junk, ensure "tags" includes "junk".
+    -   Always include the current "holderId" of the item.
 2.  **Transformation (Using "newName"):** If the malformed payload contains a "newName" OR the context clearly indicates a transformation:
     -   The corrected payload MUST include the "newName" field.
     -   Optionally include "type" and "description" if they change; otherwise they will be inherited.

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -38,7 +38,7 @@ export function isValidKnownUse(ku: unknown): ku is KnownUse {
   if (typeof obj.promptEffect !== 'string' || obj.promptEffect.trim() === '') return false;
   if (obj.appliesWhenActive !== undefined && typeof obj.appliesWhenActive !== 'boolean') return false;
   if (obj.appliesWhenInactive !== undefined && typeof obj.appliesWhenInactive !== 'boolean') return false;
-  if (obj.description !== undefined && typeof obj.description !== 'string') return false;
+  if (typeof obj.description !== 'string' || obj.description.trim() === '') return false;
   return true;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -31,7 +31,7 @@ export type MapEdgeStatus = typeof VALID_EDGE_STATUS_VALUES[number];
 export interface KnownUse {
   actionName: string; // Text for the button, e.g., "Light Torch"
   promptEffect: string; // What to send to AI, e.g., "Player attempts to light the Torch"
-  description?: string; // Optional: A small hint or detail about this use
+  description: string; // A small hint or detail about this use
   appliesWhenActive?: boolean; // If true, this use is shown when item.isActive is true
   appliesWhenInactive?: boolean; // If true, this use is shown when item.isActive is false (or undefined)
 }


### PR DESCRIPTION
## Summary
- require `description` field for `KnownUse`
- include description when constructing dynamic KnownUse actions
- treat holderId as required for new item corrections and instruct models accordingly
- clarify node and edge comments in connector chain correction prompt

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a7dd601208324b32a7e6c4eb08873