### PR TITLE
Persist last debug packet in browser

### DIFF
--- a/components/debug/tabs/LoremasterAITab.tsx
+++ b/components/debug/tabs/LoremasterAITab.tsx
@@ -92,13 +92,7 @@ function LoremasterAITab({ debugPacket, onDistillFacts }: LoremasterAITabProps) 
     );
   };
 
-  if (!debugPacket?.loremasterDebugInfo) {
-    return (
-      <p className="italic text-slate-300">
-        No Loremaster AI interaction debug packet captured.
-      </p>
-    );
-  }
+  const loremasterInfo = debugPacket?.loremasterDebugInfo;
 
   return (
     <>
@@ -111,13 +105,21 @@ function LoremasterAITab({ debugPacket, onDistillFacts }: LoremasterAITabProps) 
         variant="compact"
       />
 
-      {renderMode('Collect', debugPacket.loremasterDebugInfo.collect)}
+      {loremasterInfo ? (
+        <>
+          {renderMode('Collect', loremasterInfo.collect)}
 
-      {renderMode('Extract', debugPacket.loremasterDebugInfo.extract)}
+          {renderMode('Extract', loremasterInfo.extract)}
 
-      {renderMode('Integrate', debugPacket.loremasterDebugInfo.integrate)}
+          {renderMode('Integrate', loremasterInfo.integrate)}
 
-      {renderMode('Distill', debugPacket.loremasterDebugInfo.distill)}
+          {renderMode('Distill', loremasterInfo.distill)}
+        </>
+      ) : (
+        <p className="italic text-slate-300">
+          No Loremaster AI interaction debug packet captured.
+        </p>
+      )}
     </>
   );
 }

--- a/constants.ts
+++ b/constants.ts
@@ -36,6 +36,7 @@ export const DEVELOPER = "Eliot the Cougar"
 export const CURRENT_GAME_VERSION = "1.4.0 (Ink and Quill)";
 export const CURRENT_SAVE_GAME_VERSION = "6";
 export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
+export const LOCAL_STORAGE_DEBUG_KEY = "whispersInTheDark_debugPacket";
 
 export const DEFAULT_STABILITY_LEVEL = 30; // Number of turns before chaos can occur
 export const DEFAULT_CHAOS_LEVEL = 5;   // Percentage chance of chaos shift

--- a/hooks/useAutosave.ts
+++ b/hooks/useAutosave.ts
@@ -4,7 +4,10 @@
  */
 import { useEffect, useRef } from 'react';
 import { FullGameState } from '../types';
-import { saveGameStateToLocalStorage } from '../services/storage';
+import {
+  saveGameStateToLocalStorage,
+  saveDebugPacketToLocalStorage,
+} from '../services/storage';
 
 export const AUTOSAVE_DEBOUNCE_TIME = 1500;
 
@@ -44,6 +47,7 @@ export function useAutosave({
         gameStateToSave,
         setError ? (msg) => { setError(msg); } : undefined,
       );
+      saveDebugPacketToLocalStorage(gameStateToSave.lastDebugPacket);
     }, AUTOSAVE_DEBOUNCE_TIME);
 
     return () => {

--- a/hooks/useSaveLoad.ts
+++ b/hooks/useSaveLoad.ts
@@ -11,6 +11,8 @@ import {
 import {
   saveGameStateToLocalStorage,
   loadGameStateFromLocalStorage,
+  saveDebugPacketToLocalStorage,
+  loadDebugPacketFromLocalStorage,
 } from '../services/storage';
 import {
   DEFAULT_PLAYER_GENDER,
@@ -49,7 +51,9 @@ export const useSaveLoad = ({
 
   useEffect(() => {
     const loadedState = loadGameStateFromLocalStorage();
+    const loadedDebug = loadDebugPacketFromLocalStorage();
     if (loadedState) {
+      if (loadedDebug) loadedState.lastDebugPacket = loadedDebug;
       setPlayerGender(loadedState.playerGender);
       setEnabledThemePacks(loadedState.enabledThemePacks);
       setStabilityLevel(loadedState.stabilityLevel);
@@ -82,6 +86,7 @@ export const useSaveLoad = ({
           gameStateToSave,
           setError ? (msg) => { setError(msg); } : undefined,
         );
+        saveDebugPacketToLocalStorage(gameStateToSave.lastDebugPacket);
       }
     }, AUTOSAVE_DEBOUNCE_TIME);
 
@@ -136,6 +141,7 @@ export const useSaveLoad = ({
           loadedFullState,
           setError ? (msg) => { setError(msg); } : undefined,
         );
+        saveDebugPacketToLocalStorage(loadedFullState.lastDebugPacket);
       } else {
         setError?.('Failed to load game from file. The file might be corrupted, an incompatible version, or not a valid save file.');
       }

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -3,10 +3,10 @@
  * @description Helper functions for persisting game state to browser localStorage.
  */
 
-import { FullGameState } from '../types';
+import { FullGameState, DebugPacket } from '../types';
 import {
   LOCAL_STORAGE_SAVE_KEY,
-  
+  LOCAL_STORAGE_DEBUG_KEY,
 } from '../constants';
 import {
   prepareGameStateForSaving,
@@ -61,10 +61,46 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
     }
     console.warn('Local save data is invalid or version mismatch for V3. Starting new game.');
     localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);
+    localStorage.removeItem(LOCAL_STORAGE_DEBUG_KEY);
     return null;
   } catch (error: unknown) {
     console.error('Error loading game state from localStorage:', error);
     localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);
+    localStorage.removeItem(LOCAL_STORAGE_DEBUG_KEY);
+    return null;
+  }
+};
+
+export const saveDebugPacketToLocalStorage = (packet: DebugPacket | null): void => {
+  try {
+    if (packet) {
+      localStorage.setItem(
+        LOCAL_STORAGE_DEBUG_KEY,
+        JSON.stringify(packet),
+      );
+    } else {
+      localStorage.removeItem(LOCAL_STORAGE_DEBUG_KEY);
+    }
+  } catch (error: unknown) {
+    console.error('Error saving debug packet to localStorage:', error);
+  }
+};
+
+export const loadDebugPacketFromLocalStorage = (): DebugPacket | null => {
+  try {
+    const savedDataString = localStorage.getItem(LOCAL_STORAGE_DEBUG_KEY);
+    if (!savedDataString) return null;
+    const parsedData: unknown = safeParseJson(savedDataString);
+    if (parsedData === null || typeof parsedData !== 'object') {
+      console.warn(
+        'Saved debug packet found in localStorage could not be parsed.',
+      );
+      return null;
+    }
+    return parsedData as DebugPacket;
+  } catch (error: unknown) {
+    console.error('Error loading debug packet from localStorage:', error);
+    localStorage.removeItem(LOCAL_STORAGE_DEBUG_KEY);
     return null;
   }
 };


### PR DESCRIPTION
## Summary
- preserve last debug packet across reloads using localStorage
- autosave the debug packet whenever the game autosaves
- load stored debug data when restoring a game
- keep `Run Distill` available in the Loremaster tab even when no prior debug info exists

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a87dba0748324a3f0f2d1a2f5b01c