### PR TITLE
Persist full game state stack

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -70,7 +70,7 @@ function App() {
     handleFileInputChange,
     updateSettingsFromLoad,
   } = useSaveLoad({
-    gatherCurrentGameState: () => getGameLogic().gatherCurrentGameState(),
+    gatherGameStateStack: () => getGameLogic().gatherCurrentGameState(),
     applyLoadedGameState: (args) => getGameLogic().applyLoadedGameState(args),
     setError: (msg) => { getGameLogic().setError(msg); },
     setIsLoading: (val) => { getGameLogic().setIsLoading(val); },
@@ -104,7 +104,7 @@ function App() {
     cancelManualShiftThemeSelection,
     isAwaitingManualShiftThemeSelection,
     startCustomGame,
-    gatherCurrentGameState, hasGameBeenInitialized, handleStartNewGameFromButton,
+    gatherCurrentGameState: gatherGameStateStack, hasGameBeenInitialized, handleStartNewGameFromButton,
     localTime, localEnvironment, localPlace,
     dialogueState,
     handleDialogueOptionSelect,
@@ -245,7 +245,7 @@ function App() {
   }, [currentScene, setVisualizerImageUrl, setVisualizerImageScene]);
 
   useAutosave({
-    gatherCurrentGameState,
+    gatherGameStateStack,
     isLoading,
     hasGameBeenInitialized,
     appReady,

--- a/components/debug/tabs/CharactersTab.tsx
+++ b/components/debug/tabs/CharactersTab.tsx
@@ -6,11 +6,13 @@ interface CharactersTabProps {
 }
 
 function CharactersTab({ characters }: CharactersTabProps) {
-  return (<DebugSection
-    content={characters}
-    maxHeightClass="max-h-[70vh]"
-    title="Current Characters"
-  />)
+  return (
+    <DebugSection
+      content={characters}
+      maxHeightClass="max-h-[70vh]"
+      title="Current Characters"
+    />
+  );
 }
 
 export default CharactersTab;

--- a/components/debug/tabs/GameLogTab.tsx
+++ b/components/debug/tabs/GameLogTab.tsx
@@ -5,11 +5,13 @@ interface GameLogTabProps {
 }
 
 function GameLogTab({ gameLog }: GameLogTabProps) {
-  return (<DebugSection
-    content={gameLog}
-    maxHeightClass="max-h-[70vh]"
-    title="Current Game Log"
-  />)
+  return (
+    <DebugSection
+      content={gameLog}
+      maxHeightClass="max-h-[70vh]"
+      title="Current Game Log"
+    />
+  );
 }
 
 export default GameLogTab;

--- a/components/debug/tabs/GameStateTab.tsx
+++ b/components/debug/tabs/GameStateTab.tsx
@@ -37,7 +37,8 @@ function GameStateTab({ currentState, onUndoTurn, onApplyGameState, previousStat
     }
   }, [editableText, onApplyGameState]);
 
-  return (<>
+  return (
+    <>
     <Button
       ariaLabel="Undo last turn"
       disabled={!previousState || currentState.globalTurnNumber <= 1}
@@ -92,7 +93,7 @@ function GameStateTab({ currentState, onUndoTurn, onApplyGameState, previousStat
         title="Previous Game State (Stack[1] - Bottom)"
       />
     ) : null}
-  </>
+    </>
   );
 }
 

--- a/components/debug/tabs/InventoryTab.tsx
+++ b/components/debug/tabs/InventoryTab.tsx
@@ -6,11 +6,13 @@ interface InventoryTabProps {
 }
 
 function InventoryTab({ inventory }: InventoryTabProps) {
-  return (<DebugSection
-    content={inventory}
-    maxHeightClass="max-h-[70vh]"
-    title="Current Inventory"
-  />)
+  return (
+    <DebugSection
+      content={inventory}
+      maxHeightClass="max-h-[70vh]"
+      title="Current Inventory"
+    />
+  );
 }
 
 export default InventoryTab;

--- a/components/debug/tabs/MapDataFullTab.tsx
+++ b/components/debug/tabs/MapDataFullTab.tsx
@@ -6,11 +6,13 @@ interface MapDataFullTabProps {
 }
 
 function MapDataFullTab({ mapData }: MapDataFullTabProps) {
-  return (<DebugSection
-    content={mapData}
-    maxHeightClass="max-h-[70vh]"
-    title="Current Map Data (Full)"
-  />)
+  return (
+    <DebugSection
+      content={mapData}
+      maxHeightClass="max-h-[70vh]"
+      title="Current Map Data (Full)"
+    />
+  );
 }
 
 export default MapDataFullTab;

--- a/components/debug/tabs/MiscStateTab.tsx
+++ b/components/debug/tabs/MiscStateTab.tsx
@@ -6,7 +6,8 @@ interface MiscStateTabProps {
 }
 
 function MiscStateTab({ currentState }: MiscStateTabProps) {
-  return (<DebugSection
+  return (
+    <DebugSection
     content={{
       currentMapNodeId: currentState.currentMapNodeId,
       currentObjective: currentState.currentObjective,
@@ -31,7 +32,8 @@ function MiscStateTab({ currentState }: MiscStateTabProps) {
     }}
     maxHeightClass="max-h-[70vh]"
     title="Miscellaneous State Values"
-  />)
+  />
+  );
 }
 
 export default MiscStateTab;

--- a/components/debug/tabs/ThemeHistoryTab.tsx
+++ b/components/debug/tabs/ThemeHistoryTab.tsx
@@ -6,11 +6,13 @@ interface ThemeHistoryTabProps {
 }
 
 function ThemeHistoryTab({ themeHistory }: ThemeHistoryTabProps) {
-  return (<DebugSection
-    content={themeHistory}
-    maxHeightClass="max-h-[70vh]"
-    title="Current Theme History"
-  />)
+  return (
+    <DebugSection
+      content={themeHistory}
+      maxHeightClass="max-h-[70vh]"
+      title="Current Theme History"
+    />
+  );
 }
 
 export default ThemeHistoryTab;

--- a/constants.ts
+++ b/constants.ts
@@ -34,7 +34,7 @@ export const MAX_LOG_MESSAGES = 50; // Maximum number of messages to keep in the
 
 export const DEVELOPER = "Eliot the Cougar"
 export const CURRENT_GAME_VERSION = "1.4.0 (Ink and Quill)";
-export const CURRENT_SAVE_GAME_VERSION = "6";
+export const CURRENT_SAVE_GAME_VERSION = "7";
 export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
 export const LOCAL_STORAGE_DEBUG_KEY = "whispersInTheDark_debugPacket";
 

--- a/hooks/useAutosave.ts
+++ b/hooks/useAutosave.ts
@@ -3,7 +3,7 @@
  * @description Provides debounced autosave functionality for App.
  */
 import { useEffect, useRef } from 'react';
-import { FullGameState } from '../types';
+import { GameStateStack } from '../types';
 import {
   saveGameStateToLocalStorage,
   saveDebugPacketToLocalStorage,
@@ -12,7 +12,7 @@ import {
 export const AUTOSAVE_DEBOUNCE_TIME = 1500;
 
 export interface UseAutosaveOptions {
-  readonly gatherCurrentGameState: () => FullGameState;
+  readonly gatherGameStateStack: () => GameStateStack;
   readonly isLoading: boolean;
   readonly hasGameBeenInitialized: boolean;
   readonly appReady: boolean;
@@ -22,7 +22,7 @@ export interface UseAutosaveOptions {
 }
 
 export function useAutosave({
-  gatherCurrentGameState,
+  gatherGameStateStack,
   isLoading,
   hasGameBeenInitialized,
   appReady,
@@ -42,12 +42,12 @@ export function useAutosave({
       clearTimeout(autosaveTimeoutRef.current);
     }
     autosaveTimeoutRef.current = window.setTimeout(() => {
-      const gameStateToSave = gatherCurrentGameState();
+      const gameStateStack = gatherGameStateStack();
       saveGameStateToLocalStorage(
-        gameStateToSave,
+        gameStateStack,
         setError ? (msg) => { setError(msg); } : undefined,
       );
-      saveDebugPacketToLocalStorage(gameStateToSave.lastDebugPacket);
+      saveDebugPacketToLocalStorage(gameStateStack[0].lastDebugPacket);
     }, AUTOSAVE_DEBOUNCE_TIME);
 
     return () => {
@@ -56,7 +56,7 @@ export function useAutosave({
       }
     };
   }, [
-    gatherCurrentGameState,
+    gatherGameStateStack,
     isLoading,
     hasGameBeenInitialized,
     appReady,

--- a/hooks/useRealityShift.ts
+++ b/hooks/useRealityShift.ts
@@ -20,7 +20,7 @@ import { getInitialGameStates } from '../utils/initialStates';
 export interface UseRealityShiftProps {
   getCurrentGameState: () => FullGameState;
   setGameStateStack: Dispatch<SetStateAction<GameStateStack>>;
-  loadInitialGame: (options: { explicitThemeName?: string | null; isRestart?: boolean; isTransitioningFromShift?: boolean; customGameFlag?: boolean; savedStateToLoad?: FullGameState | null; }) => void;
+  loadInitialGame: (options: { explicitThemeName?: string | null; isRestart?: boolean; isTransitioningFromShift?: boolean; customGameFlag?: boolean; savedStateToLoad?: GameStateStack | null; }) => void;
   enabledThemePacksProp: Array<ThemePackName>;
   playerGenderProp: string;
   stabilityLevelProp: number;

--- a/services/saveLoad/fileOps.ts
+++ b/services/saveLoad/fileOps.ts
@@ -2,10 +2,14 @@
  * @file fileOps.ts
  * @description Helpers for saving to and loading from external files.
  */
-import { FullGameState } from '../../types';
+import { GameStateStack } from '../../types';
 import { CURRENT_SAVE_GAME_VERSION } from '../../constants';
 import { safeParseJson } from '../../utils/jsonUtils';
-import { prepareGameStateForSaving, expandSavedDataToFullState, normalizeLoadedSaveData } from './migrations';
+import {
+  prepareGameStateStackForSaving,
+  expandSavedStackToFullStates,
+  normalizeLoadedSaveDataStack,
+} from './migrations';
 
 const triggerDownload = (data: string, filename: string, type: string): void => {
   const blob = new Blob([data], { type });
@@ -20,11 +24,11 @@ const triggerDownload = (data: string, filename: string, type: string): void => 
 };
 
 export const saveGameStateToFile = (
-  gameState: FullGameState,
+  stack: GameStateStack,
   onError?: (message: string) => void,
 ): boolean => {
   try {
-    const dataToSave = prepareGameStateForSaving(gameState);
+    const dataToSave = prepareGameStateStackForSaving(stack);
     const jsonString = JSON.stringify(dataToSave, null, 2);
     triggerDownload(jsonString, `WhispersInTheDark_Save_V${CURRENT_SAVE_GAME_VERSION}_${new Date().toISOString().slice(0,10)}.json`, 'application/json');
     return true;
@@ -35,7 +39,7 @@ export const saveGameStateToFile = (
   }
 };
 
-export const loadGameStateFromFile = async (file: File): Promise<FullGameState | null> => {
+export const loadGameStateFromFile = async (file: File): Promise<GameStateStack | null> => {
   return new Promise((resolve) => {
     const reader = new FileReader();
     reader.onload = (event) => {
@@ -46,9 +50,9 @@ export const loadGameStateFromFile = async (file: File): Promise<FullGameState |
             resolve(null);
             return;
           }
-          const processed = normalizeLoadedSaveData(parsedData as Record<string, unknown>, 'file');
+          const processed = normalizeLoadedSaveDataStack(parsedData as Record<string, unknown>, 'file');
           if (processed) {
-            resolve(expandSavedDataToFullState(processed));
+            resolve(expandSavedStackToFullStates(processed));
             return;
           }
         }

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -3,25 +3,25 @@
  * @description Helper functions for persisting game state to browser localStorage.
  */
 
-import { FullGameState, DebugPacket } from '../types';
+import { DebugPacket, GameStateStack } from '../types';
 import {
   LOCAL_STORAGE_SAVE_KEY,
   LOCAL_STORAGE_DEBUG_KEY,
 } from '../constants';
 import {
-  prepareGameStateForSaving,
-  expandSavedDataToFullState,
-  normalizeLoadedSaveData,
+  prepareGameStateStackForSaving,
+  expandSavedStackToFullStates,
+  normalizeLoadedSaveDataStack,
 } from './saveLoad';
 import { safeParseJson } from '../utils/jsonUtils';
 
 /** Saves the current game state to localStorage. */
 export const saveGameStateToLocalStorage = (
-  gameState: FullGameState,
+  stack: GameStateStack,
   onError?: (message: string) => void,
 ): boolean => {
   try {
-    const dataToSave = prepareGameStateForSaving(gameState);
+    const dataToSave = prepareGameStateStackForSaving(stack);
     localStorage.setItem(LOCAL_STORAGE_SAVE_KEY, JSON.stringify(dataToSave));
     return true;
   } catch (error: unknown) {
@@ -40,7 +40,7 @@ export const saveGameStateToLocalStorage = (
  * Loads the latest saved game from localStorage if available.
  * Handles version conversion and validation steps.
  */
-export const loadGameStateFromLocalStorage = (): FullGameState | null => {
+export const loadGameStateFromLocalStorage = (): GameStateStack | null => {
   try {
     const savedDataString = localStorage.getItem(LOCAL_STORAGE_SAVE_KEY);
     if (!savedDataString) return null;
@@ -55,9 +55,9 @@ export const loadGameStateFromLocalStorage = (): FullGameState | null => {
       return null;
     }
 
-    const processed = normalizeLoadedSaveData(parsedData as Record<string, unknown>, 'localStorage');
+    const processed = normalizeLoadedSaveDataStack(parsedData as Record<string, unknown>, 'localStorage');
     if (processed) {
-      return expandSavedDataToFullState(processed);
+      return expandSavedStackToFullStates(processed);
     }
     console.warn('Local save data is invalid or version mismatch for V3. Starting new game.');
     localStorage.removeItem(LOCAL_STORAGE_SAVE_KEY);

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -132,7 +132,7 @@ describe('game start sequence', () => {
     state.currentMapNodeId = parsed.currentMapNodeId ?? null;
     state.globalTurnNumber = 1;
 
-    const result = saveGameStateToLocalStorage(state);
+    const result = saveGameStateToLocalStorage([state, undefined]);
     expect(result).toBe(true);
     expect(setItem).toHaveBeenCalledWith(
       LOCAL_STORAGE_SAVE_KEY,
@@ -140,8 +140,9 @@ describe('game start sequence', () => {
     );
     const savedString = saved[LOCAL_STORAGE_SAVE_KEY];
     const parsedSaved = JSON.parse(savedString) as Record<string, unknown>;
-    expect(parsedSaved.currentThemeName).toBe(theme.name);
-    expect(parsedSaved.currentScene).toBe(parsed.sceneDescription);
-    expect(Array.isArray(parsedSaved.actionOptions)).toBe(true);
+    const current = parsedSaved.current as Record<string, unknown>;
+    expect(current.currentThemeName).toBe(theme.name);
+    expect(current.currentScene).toBe(parsed.sceneDescription);
+    expect(Array.isArray(current.actionOptions)).toBe(true);
   });
 });

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -55,7 +55,7 @@ const mapData: MapData = {
 };
 
 const baseState: FullGameState = {
-  saveGameVersion: '6',
+  saveGameVersion: '7',
   currentThemeName: theme.name,
   currentThemeObject: theme,
   currentScene: '',

--- a/types.ts
+++ b/types.ts
@@ -596,6 +596,11 @@ export type SavedGameDataShape = Pick<
 
 export type GameStateStack = [FullGameState, FullGameState?];
 
+export interface SavedGameStack {
+  current: SavedGameDataShape;
+  previous: SavedGameDataShape | null;
+}
+
 
 
 // Payload for a validated character update, used in parsing


### PR DESCRIPTION
## Summary
- bump savegame version to 7
- add `SavedGameStack` and stack migration helpers
- persist both game states in localStorage and file saves
- handle loading and saving of the stack in hooks
- adjust tests for new save format
- ensure JSX starts on its own line in debug tabs

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685a8dfc9b648324932bb36e5934cc8c