### PR TITLE
Fix map hierarchy on load

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -27,6 +27,7 @@ import { getDefaultMapLayoutConfig } from './useMapUpdates';
 import { buildInitialGamePrompt } from './initPromptHelpers';
 import { DEFAULT_VIEWBOX } from '../constants';
 import { ProcessAiResponseFn } from './useProcessAiResponse';
+import { repairFeatureHierarchy } from '../utils/mapHierarchyUpgradeUtils';
 
 export interface LoadInitialGameOptions {
   isRestart?: boolean;
@@ -107,7 +108,13 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
           setError(`Failed to apply loaded state: Theme "${currentSaved.currentThemeName}" not found. Game state may be unstable.`);
         }
 
-        const mapDataToApply = currentSaved.mapData;
+        let mapDataToApply = currentSaved.mapData;
+        if (themeForLoadedState) {
+          mapDataToApply = await repairFeatureHierarchy(
+            mapDataToApply,
+            themeForLoadedState,
+          );
+        }
         const currentMapNodeIdToApply = currentSaved.currentMapNodeId;
         const destinationToApply = currentSaved.destinationNodeId;
         const mapLayoutConfigToApply = currentSaved.mapLayoutConfig;

--- a/utils/mapHierarchyUpgradeUtils.ts
+++ b/utils/mapHierarchyUpgradeUtils.ts
@@ -129,3 +129,16 @@ export const upgradeFeaturesWithChildren = async (
 
   return { updatedMapData: working, addedNodes, addedEdges };
 };
+
+export const repairFeatureHierarchy = async (
+  mapData: MapData,
+  currentTheme: AdventureTheme,
+): Promise<MapData> => {
+  try {
+    const result = await upgradeFeaturesWithChildren(mapData, currentTheme);
+    return result.updatedMapData;
+  } catch (error: unknown) {
+    console.error('repairFeatureHierarchy error:', error);
+    return mapData;
+  }
+};

--- a/utils/mapLayoutUtils.ts
+++ b/utils/mapLayoutUtils.ts
@@ -60,7 +60,7 @@ export const applyNestedCircleLayout = (
     if (!node) throw new Error(`Node ${nodeId} missing in layout`);
     const childIds = childrenByParent.get(nodeId) ?? [];
 
-    if (node.data.nodeType === 'feature' || childIds.length === 0) {
+    if (childIds.length === 0) {
       node.data.visualRadius = BASE_FEATURE_RADIUS;
       node.position = { x: 0, y: 0 };
       return node.data.visualRadius;


### PR DESCRIPTION
## Summary
- repair feature hierarchy when loading a saved game
- add helper that upgrades features with children

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bfc471f848324adf45a026bce942e