### PR TITLE
Fix inventory item shift on modal close

### DIFF
--- a/index.css
+++ b/index.css
@@ -2,6 +2,8 @@
 
 body {
   font-family: "Georgia", serif; /* Thematic font */
+  /* Prevent layout shifts when modals toggle body overflow */
+  overflow-y: scroll;
 }
 
 /* Font used for the main game title */


### PR DESCRIPTION
## Summary
- ensure scrollbar is always visible on the page

This prevents small layout shifts that moved item cards when modals were closed.

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c03dd2ea48324ab096fbe3b189d8f