### PR TITLE
Add heading support to markup parser

### DIFF
--- a/tests/markup.test.ts
+++ b/tests/markup.test.ts
@@ -20,6 +20,15 @@ describe('applyBasicMarkup', () => {
       .join('');
     expect(html).toBe('<ul class="list-disc list-inside ml-4 space-y-1"><li>First</li><li>Second <strong>bold</strong></li></ul>');
   });
+
+  it('formats headings as strong', () => {
+    const text = '# Heading 1';
+    const nodes = applyBasicMarkup(text);
+    const html = nodes
+      .map(n => renderToStaticMarkup(n as React.ReactElement))
+      .join('');
+    expect(html).toBe('<p><strong>Heading 1</strong></p>');
+  });
 });
 
 export default {};

--- a/utils/markup.tsx
+++ b/utils/markup.tsx
@@ -33,6 +33,7 @@ export const applyBasicMarkup = (text: string): Array<ReactNode> => {
   const result: Array<ReactNode> = [];
   const listStack: Array<{ level: number; items: Array<ReactNode> }> = [];
   let paragraphLines: Array<string> = [];
+  const headingRegex = /^(#+)\s+(.*)$/;
 
   const flushParagraph = () => {
     if (paragraphLines.length === 0) {
@@ -89,6 +90,22 @@ export const applyBasicMarkup = (text: string): Array<ReactNode> => {
 
   const bulletRegex = /^(\s*)\*\s+(.*)$/;
   lines.forEach(rawLine => {
+    const headingMatch = headingRegex.exec(rawLine);
+    if (headingMatch) {
+      flushParagraph();
+      flushLists(-1);
+      const content = headingMatch[2];
+      const key = `h-${String(result.length)}`;
+      const inline = parseInline(content, key);
+      result.push(
+        <p key={key}>
+          <strong>
+            {inline}
+          </strong>
+        </p>,
+      );
+      return;
+    }
     const bulletMatch = bulletRegex.exec(rawLine);
     if (bulletMatch) {
       flushParagraph();


### PR DESCRIPTION
## Summary
- expand markup parser to detect heading lines and render them as `<strong>`
- test heading rendering in markup

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685c31edb8f0832490f5323cd1afbea1