### PR TITLE
Add tag info to items

### DIFF
--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -185,7 +185,7 @@ const handleInventoryHints = async ({
     return npcs
       .map((npc) => {
         const items = baseState.inventory.filter((i) => i.holderId === npc.id);
-        return `ID: ${npc.id} - ${npc.name}: ${itemsToString(items, ' - ')}`;
+        return `ID: ${npc.id} - ${npc.name}: ${itemsToString(items, ' - ', true, true, false, true)}`;
       })
       .join('\n');
   };
@@ -206,8 +206,8 @@ const handleInventoryHints = async ({
       'npcItemsHint' in aiData ? aiData.npcItemsHint : undefined,
       'newItems' in aiData && Array.isArray(aiData.newItems) ? aiData.newItems : [],
       playerActionText ?? '',
-      itemsToString(baseInventoryForPlayer, ' - '),
-      itemsToString(locationInventory, ' - '),
+      itemsToString(baseInventoryForPlayer, ' - ', true, true, false, true),
+      itemsToString(locationInventory, ' - ', true, true, false, true),
       baseState.currentMapNodeId ?? null,
       formatNPCInventoryList(companionNPCs),
       formatNPCInventoryList(nearbyNPCs),

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -57,7 +57,7 @@ export const buildNewThemePostShiftPrompt = (
   inventory: Array<Item>,
   playerGender: string
 ): string => {
-  const inventoryStrings = itemsToString(inventory, ' - ');
+  const inventoryStrings = itemsToString(inventory, ' - ', true, true, false, false, true);
   const prompt = `The player is entering a NEW theme "${theme.name}" after a reality shift.
 Player's Character Gender: "${playerGender}"
 Initial Scene: "${theme.initialSceneDescriptionSeed}" (adapt to an arrival scene describing the disorienting transition).
@@ -89,7 +89,15 @@ export const buildReturnToThemePostShiftPrompt = (
   mapDataForTheme: MapData,
   currentThemeNPCs: Array<NPC>
 ): string => {
-  const inventoryPrompt = itemsToString(inventory, ' - ');
+  const inventoryPrompt = itemsToString(
+    inventory,
+    ' - ',
+    true,
+    true,
+    false,
+    false,
+    true,
+  );
   const currentThemeMainMapNodes = mapDataForTheme.nodes.filter(
     node => node.themeName === theme.name && node.data.nodeType !== 'feature' && node.data.nodeType !== 'room'
   );
@@ -166,10 +174,22 @@ export const buildMainGameTurnPrompt = (
   fullMapData: MapData,
   destinationNodeId: string | null
 ): string => {
-  const inventoryStrings = 
-    inventory.length > 0 ? itemsToString(inventory, ' - ') : `There are no items in player's inventory.`;
+  const inventoryStrings =
+    inventory.length > 0
+      ? itemsToString(inventory, ' - ', true, true, false, false, true)
+      : `There are no items in player's inventory.`;
   const locationItemsStrings =
-    locationItems.length > 0 ? `There are items at this location: \n${itemsToString(locationItems, ' - ')}` : `There are no visible items at this location.`;
+    locationItems.length > 0
+      ? `There are items at this location: \n${itemsToString(
+          locationItems,
+          ' - ',
+          true,
+          true,
+          false,
+          false,
+          true,
+        )}`
+      : `There are no visible items at this location.`;
   const placesContext = formatKnownPlacesForPrompt(currentThemeMainMapNodes, true);
   // Filter NPCs that are companions, as they are traveling with the player
   const companions = currentThemeNPCs.filter(npc => npc.presenceStatus === 'companion');

--- a/utils/promptFormatters/inventory.ts
+++ b/utils/promptFormatters/inventory.ts
@@ -4,7 +4,26 @@
  * @description Functions for formatting player inventory for AI prompts.
  */
 
-import { Item } from '../../types';
+import { Item, ItemTag } from '../../types';
+
+const TAG_MEANINGS: Partial<Record<ItemTag, { notRecovered: string; recovered: string }>> = {
+  foreign: {
+    notRecovered: 'The text appears to be in an unfamiliar language and might be translated',
+    recovered: 'The foreign text has been translated',
+  },
+  runic: {
+    notRecovered: 'The text is written in strange runes and might be translated',
+    recovered: 'The runic text has been translated',
+  },
+  glitching: {
+    notRecovered: 'The text is glitching or corrupted and might be restored',
+    recovered: 'The previously corrupted text has been restored',
+  },
+  encrypted: {
+    notRecovered: 'The text is encoded and might be decoded',
+    recovered: 'The text has been decoded',
+  },
+} as const;
 
 /**
  * Formats a list of items for use in AI prompts.
@@ -15,6 +34,8 @@ export const itemsToString = (
   addDescription = true,
   addKnownUses = true,
   singleLine = false,
+  includeTags = false,
+  includeTagMeaning = false,
 ): string => {
   const itemList = Array.isArray(items) ? items : [items];
   if (itemList.length === 0) return 'Empty.';
@@ -23,12 +44,48 @@ export const itemsToString = (
   return itemList
     .map(item => {
       let itemStr = `${prefix}${item.id} - "${item.name}"`;
+      const detailParts: Array<string> = [];
       if (addDescription) {
-        itemStr += ` (Type: "${item.type}", Description: "${
-          item.isActive && item.activeDescription
-            ? item.activeDescription
-            : item.description
-        }"${item.isActive ? ', It is active' : ''})`;
+        detailParts.push(`Type: "${item.type}"`);
+        if (includeTags && item.tags && item.tags.length > 0) {
+          detailParts.push(`Tags: ${item.tags.join(', ')}`);
+        }
+        if (includeTagMeaning && item.tags && item.tags.length > 0) {
+          const hasRecovered = item.tags.includes('recovered');
+            const meanings = item.tags
+            .map(tag => {
+              const entry = TAG_MEANINGS[tag];
+              if (!entry) return null;
+              return hasRecovered ? entry.recovered : entry.notRecovered;
+            })
+            .filter((v): v is string => !!v);
+          if (meanings.length > 0) detailParts.push(meanings.join(' '));
+        }
+        detailParts.push(
+          `Description: "${
+            item.isActive && item.activeDescription
+              ? item.activeDescription
+              : item.description
+          }"${item.isActive ? ', It is active' : ''}`,
+        );
+        itemStr += ` (${detailParts.join(', ')})`;
+      } else {
+        const extras: Array<string> = [];
+        if (includeTags && item.tags && item.tags.length > 0) {
+          extras.push(`Tags: ${item.tags.join(', ')}`);
+        }
+        if (includeTagMeaning && item.tags && item.tags.length > 0) {
+          const hasRecovered = item.tags.includes('recovered');
+            const meanings = item.tags
+            .map(tag => {
+              const entry = TAG_MEANINGS[tag];
+              if (!entry) return null;
+              return hasRecovered ? entry.recovered : entry.notRecovered;
+            })
+            .filter((v): v is string => !!v);
+          if (meanings.length > 0) extras.push(meanings.join(' '));
+        }
+        if (extras.length > 0) itemStr += ` (${extras.join(', ')})`;
       }
 
       if (addKnownUses && item.knownUses && item.knownUses.length > 0) {


### PR DESCRIPTION
## Summary
- expand `itemsToString` with tag info and descriptions
- surface item tags when sending data to Inventory AI
- provide tag meaning to Storyteller AI for richer context

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c40d3d7e48324b570e3b42cb40823