### PR TITLE
Fix investigate action incorrectly reading items

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -351,18 +351,27 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       if (interactionType === 'inspect') {
         const updatedState = recordInspect(item.id, stateOverride);
 
-        const showActual = item.tags?.includes('recovered');
-        const contents = (item.chapters ?? [])
-          .map(
-            ch =>
-              `${ch.heading}\n${showActual ? ch.actualContent ?? '' : ch.visibleContent ?? ''}\n\n`,
-          )
-          .join('');
-        void executePlayerAction(
-          `Player reads the ${item.name} - ${item.description}. Here's what the player reads:\n${contents}`,
-          false,
-          updatedState,
-        );
+        if (item.type === 'book' || item.type === 'page') {
+          const showActual = item.tags?.includes('recovered');
+          const contents = (item.chapters ?? [])
+            .map(
+              ch =>
+                `${ch.heading}\n${showActual ? ch.actualContent ?? '' : ch.visibleContent ?? ''}\n\n`,
+            )
+            .join('');
+
+          void executePlayerAction(
+            `Player reads the ${item.name} - ${item.description}. Here's what the player reads:\n${contents}`,
+            false,
+            updatedState,
+          );
+        } else {
+          void executePlayerAction(
+            `Player investigates the ${item.name} - ${item.description}.`,
+            false,
+            updatedState,
+          );
+        }
       } else if (interactionType === 'specific' && knownUse) {
         void executePlayerAction(knownUse.promptEffect);
       } else if (interactionType === 'generic') {


### PR DESCRIPTION
## Summary
- ensure investigating items that aren't books or pages doesn't create a reading action

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dd5c501dc832495820987601f0a30