### PR TITLE
Run strict lint and fix warnings

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -858,10 +858,10 @@ function App() {
                 onDropItem={gameLogic.handleDropItem}
                 onItemInteract={handleItemInteraction}
                 onReadPage={handleReadPage}
+                onReadPlayerJournal={handleReadPlayerJournal}
                 onStashToggle={gameLogic.handleStashToggle}
                 onTakeItem={handleTakeLocationItem}
                 onWriteJournal={handleWriteJournal}
-                onReadPlayerJournal={handleReadPlayerJournal}
               />
             )}
           </div>
@@ -905,18 +905,18 @@ function App() {
       />
 
       <DebugView
+        badFacts={debugBadFacts}
+        debugLore={debugLore}
         debugPacket={lastDebugPacket}
         gameStateStack={gameStateStack}
+        goodFacts={debugGoodFacts}
         isVisible={isDebugViewVisible}
         onApplyGameState={handleApplyGameState}
+        onClearFacts={handleClearFacts}
         onClose={closeDebugView}
         onDistillFacts={handleDistillClick}
-        debugLore={debugLore}
-        goodFacts={debugGoodFacts}
-        badFacts={debugBadFacts}
-        onToggleDebugLore={toggleDebugLore}
-        onClearFacts={handleClearFacts}
         onSaveFacts={handleSaveFacts}
+        onToggleDebugLore={toggleDebugLore}
         onUndoTurn={handleUndoTurn}
         travelPath={travelPath}
       />
@@ -976,6 +976,8 @@ function App() {
 
       {hasGameBeenInitialized && currentTheme ? <AppModals
         allNPCs={allNPCs}
+        canInspectJournal={canInspectPlayerJournal}
+        canWriteJournal={canWritePlayerJournal}
         currentMapNodeId={currentMapNodeId}
         currentQuest={mainQuest}
         currentScene={currentScene}
@@ -994,15 +996,15 @@ function App() {
         initialLayoutConfig={mapLayoutConfig}
         initialViewBox={mapInitialViewBox}
         inventory={inventory}
-        playerJournal={playerJournal}
-        lastJournalWriteTurn={lastJournalWriteTurn}
         isCustomGameModeShift={isCustomGameMode}
         isHistoryVisible={isHistoryVisible}
         isKnowledgeBaseVisible={isKnowledgeBaseVisible}
         isMapVisible={isMapVisible}
         isPageVisible={isPageVisible}
         isVisualizerVisible={isVisualizerVisible}
+        isWritingJournal={isPlayerJournalWriting}
         itemPresenceByNode={itemPresenceByNode}
+        lastJournalWriteTurn={lastJournalWriteTurn}
         loadGameFromMenuConfirmOpen={loadGameFromMenuConfirmOpen}
         localEnvironment={localEnvironment}
         localPlace={localPlace}
@@ -1015,25 +1017,23 @@ function App() {
         onCloseMap={closeMap}
         onClosePage={closePageView}
         onCloseVisualizer={closeVisualizer}
+        onInventoryWriteJournal={handleWriteJournalFromPage}
+        onItemInspect={handleInspectFromPage}
         onLayoutConfigChange={handleMapLayoutConfigChange}
         onNodesPositioned={handleMapNodesPositionChange}
+        onReadJournal={handleReadPlayerJournal}
         onSelectDestination={handleSelectDestinationNode}
         onViewBoxChange={handleMapViewBoxChange}
+        onWriteJournal={handleWritePlayerJournal}
         pageItemId={pageItemId}
         pageStartChapterIndex={pageStartChapterIndex}
+        playerJournal={playerJournal}
         setGeneratedImage={setGeneratedImageCache}
         shiftConfirmOpen={shiftConfirmOpen}
         storytellerThoughts={lastDebugPacket?.storytellerThoughts?.slice(-1)[0] ?? ''}
         themeHistory={themeHistory}
         updateItemContent={updateItemContent}
         updatePlayerJournalContent={updatePlayerJournalContent}
-        onReadJournal={handleReadPlayerJournal}
-        onWriteJournal={handleWritePlayerJournal}
-        onInventoryWriteJournal={handleWriteJournalFromPage}
-        onItemInspect={handleInspectFromPage}
-        canWriteJournal={canWritePlayerJournal}
-        canInspectJournal={canInspectPlayerJournal}
-        isWritingJournal={isPlayerJournalWriting}
         visualizerImageScene={visualizerImageScene}
         visualizerImageUrl={visualizerImageUrl}
       /> : null}

--- a/components/app/AppModals.tsx
+++ b/components/app/AppModals.tsx
@@ -208,22 +208,25 @@ function AppModals({
       />
 
       <HistoryDisplay
+        canWriteJournal={canWriteJournal}
         gameLog={gameLog}
         isVisible={isHistoryVisible}
+        isWritingJournal={isWritingJournal}
         onClose={onCloseHistory}
         onReadJournal={onReadJournal}
         onWriteJournal={onWriteJournal}
-        canWriteJournal={canWriteJournal}
-        isWritingJournal={isWritingJournal}
         themeHistory={themeHistory}
       />
 
       <PageView
         allNPCs={allNPCs}
+        canInspectJournal={canInspectJournal}
+        canWriteJournal={canWriteJournal}
         currentQuest={currentQuest}
         currentScene={currentScene}
         currentTheme={currentTheme}
         isVisible={isPageVisible}
+        isWritingJournal={isWritingJournal}
         item={
           pageItemId === PLAYER_JOURNAL_ID
             ? {
@@ -240,14 +243,11 @@ function AppModals({
         }
         mapData={mapData}
         onClose={onClosePage}
+        onInspect={pageItemId ? inspectHandler : undefined}
+        onWriteJournal={pageItemId ? writeJournalHandler : undefined}
         startIndex={pageStartChapterIndex}
         storytellerThoughts={storytellerThoughts}
         updateItemContent={updateContentHandler}
-        onInspect={pageItemId ? inspectHandler : undefined}
-        onWriteJournal={pageItemId ? writeJournalHandler : undefined}
-        canWriteJournal={canWriteJournal}
-        canInspectJournal={canInspectJournal}
-        isWritingJournal={isWritingJournal}
       />
 
       <MapDisplay

--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -76,13 +76,17 @@ function GameSidebar({
         <Button
           ariaLabel="Open journal"
           disabled={disabled}
-          icon={<Icon name="journalPen" size={24} />}
+          icon={<Icon
+            name="journalPen"
+            size={24}
+          />}
           onClick={onReadPlayerJournal}
           preset="blue"
           size="lg"
           variant="toolbarLarge"
         />
       </div>
+
       {mainQuest ? (
         <TextBox
           backgroundColorClass="bg-purple-800/50"

--- a/components/debug/tabs/InventoryAITab.tsx
+++ b/components/debug/tabs/InventoryAITab.tsx
@@ -50,26 +50,26 @@ function InventoryAITab({ debugPacket }: InventoryAITabProps) {
           />
 
           <div className="my-2 flex flex-wrap gap-2">
-          <Button
-            ariaLabel="Show raw inventory response"
-            label="Raw"
-            onClick={handleShowRaw}
-            preset={showRaw ? 'sky' : 'slate'}
-            pressed={showRaw}
-            size="sm"
-            variant="toggle"
-          />
+            <Button
+              ariaLabel="Show raw inventory response"
+              label="Raw"
+              onClick={handleShowRaw}
+              preset={showRaw ? 'sky' : 'slate'}
+              pressed={showRaw}
+              size="sm"
+              variant="toggle"
+            />
 
-        <Button
-          ariaLabel="Show parsed inventory response"
-          label="Parsed"
-          onClick={handleShowParsed}
-          preset={showRaw ? 'slate' : 'sky'}
-          pressed={!showRaw}
-          size="sm"
-          variant="toggle"
-        />
-      </div>
+            <Button
+              ariaLabel="Show parsed inventory response"
+              label="Parsed"
+              onClick={handleShowParsed}
+              preset={showRaw ? 'slate' : 'sky'}
+              pressed={!showRaw}
+              size="sm"
+              variant="toggle"
+            />
+          </div>
 
           {showRaw ? (
             <DebugSection

--- a/components/debug/tabs/LoremasterAITab.tsx
+++ b/components/debug/tabs/LoremasterAITab.tsx
@@ -44,26 +44,26 @@ function LoremasterAITab({ debugPacket, onDistillFacts }: LoremasterAITabProps) 
             />
 
             <div className="my-2 flex flex-wrap gap-2">
-          <Button
-            ariaLabel={`Show raw ${modeLabel} response`}
-            label="Raw"
-            onClick={handleShowRaw(modeLabel)}
-            preset={raw ? 'sky' : 'slate'}
-            pressed={raw}
-            size="sm"
-            variant="toggle"
-          />
+              <Button
+                ariaLabel={`Show raw ${modeLabel} response`}
+                label="Raw"
+                onClick={handleShowRaw(modeLabel)}
+                preset={raw ? 'sky' : 'slate'}
+                pressed={raw}
+                size="sm"
+                variant="toggle"
+              />
 
-          <Button
-            ariaLabel={`Show parsed ${modeLabel} response`}
-            label="Parsed"
-            onClick={handleShowParsed(modeLabel)}
-            preset={raw ? 'slate' : 'sky'}
-            pressed={!raw}
-            size="sm"
-            variant="toggle"
-          />
-        </div>
+              <Button
+                ariaLabel={`Show parsed ${modeLabel} response`}
+                label="Parsed"
+                onClick={handleShowParsed(modeLabel)}
+                preset={raw ? 'slate' : 'sky'}
+                pressed={!raw}
+                size="sm"
+                variant="toggle"
+              />
+            </div>
 
             {raw ? (
               <DebugSection

--- a/components/debug/tabs/MapLocationAITab.tsx
+++ b/components/debug/tabs/MapLocationAITab.tsx
@@ -68,26 +68,26 @@ function MapLocationAITab({ debugPacket }: MapLocationAITabProps) {
               />
 
               <div className="my-2 flex flex-wrap gap-2">
-              <Button
-                ariaLabel="Show raw map response"
-                label="Raw"
-                onClick={handleShowRaw}
-                preset={showRaw ? 'sky' : 'slate'}
-                pressed={showRaw}
-                size="sm"
-                variant="toggle"
-              />
+                <Button
+                  ariaLabel="Show raw map response"
+                  label="Raw"
+                  onClick={handleShowRaw}
+                  preset={showRaw ? 'sky' : 'slate'}
+                  pressed={showRaw}
+                  size="sm"
+                  variant="toggle"
+                />
 
-            <Button
-              ariaLabel="Show parsed map response"
-              label="Parsed"
-              onClick={handleShowParsed}
-              preset={showRaw ? 'slate' : 'sky'}
-              pressed={!showRaw}
-              size="sm"
-              variant="toggle"
-            />
-          </div>
+                <Button
+                  ariaLabel="Show parsed map response"
+                  label="Parsed"
+                  onClick={handleShowParsed}
+                  preset={showRaw ? 'slate' : 'sky'}
+                  pressed={!showRaw}
+                  size="sm"
+                  variant="toggle"
+                />
+              </div>
 
               {showRaw ? (
                 <DebugSection

--- a/components/debug/tabs/SettingsTab.tsx
+++ b/components/debug/tabs/SettingsTab.tsx
@@ -50,6 +50,7 @@ function SettingsTab({
           size="sm"
           variant="toggle"
         />
+
         <Button
           ariaLabel="View collected facts"
           label={showFacts ? 'Hide Facts' : 'View Facts'}
@@ -58,6 +59,7 @@ function SettingsTab({
           size="sm"
           variant="compact"
         />
+
         {showFacts ? (
           <Button
             ariaLabel="Save facts to file"
@@ -68,6 +70,7 @@ function SettingsTab({
             variant="compact"
           />
         ) : null}
+
         {showFacts ? (
           <Button
             ariaLabel="Clear collected facts"

--- a/components/elements/icons/JournalPen.tsx
+++ b/components/elements/icons/JournalPen.tsx
@@ -15,6 +15,7 @@ function SvgJournalPen({ height = '1em', width = '1em' }: SVGProps<SVGSVGElement
         strokeLinecap="round"
         strokeLinejoin="round"
       />
+
       <path
         d="M19.5 10.5V18A2.25 2.25 0 0 1 17.25 20.25H6.75A2.25 2.25 0 0 1 4.5 18V6.75A2.25 2.25 0 0 1 6.75 4.5H14.25"
         strokeLinecap="round"

--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -180,7 +180,13 @@ function InventoryItem({
         ariaLabel={`Discard ${item.name}`}
         data-item-name={item.name}
         disabled={disabled}
-        icon={<Icon color="white" inline marginRight={4} name="trash" size={16} />}
+        icon={<Icon
+          color="white"
+          inline
+          marginRight={4}
+          name="trash"
+          size={16}
+        />}
         key={`${item.name}-discard`}
         label="Discard"
         onClick={onStartConfirmDiscard}
@@ -252,7 +258,10 @@ function InventoryItem({
 
   if (isConfirmingDiscard) {
     actionButtons.push(
-      <div className="grid grid-cols-2 gap-2 mt-2" key={`${item.name}-confirm-group`}>
+      <div
+        className="grid grid-cols-2 gap-2 mt-2"
+        key={`${item.name}-confirm-group`}
+      >
         <Button
           ariaLabel={`Confirm drop of ${item.name}`}
           data-item-name={item.name}

--- a/components/modals/DebugLoreModal.tsx
+++ b/components/modals/DebugLoreModal.tsx
@@ -66,20 +66,32 @@ function DebugLoreModal({ isVisible, facts, onSubmit, onClose }: DebugLoreModalP
       <div className="animated-frame-content">
         <Button
           ariaLabel="Close debug lore"
-          icon={<Icon name="x" size={20} />}
+          icon={<Icon
+            name="x"
+            size={20}
+          />}
           onClick={onClose}
           size="sm"
           variant="close"
         />
 
-        <h1 className="text-2xl font-bold text-amber-400 mb-3 text-center" id="debug-lore-title">
+        <h1
+          className="text-2xl font-bold text-amber-400 mb-3 text-center"
+          id="debug-lore-title"
+        >
           Evaluate Extracted Facts
         </h1>
 
         <ul className="mb-4 space-y-2">
           {facts.map((fact, idx) => (
-            <li className="flex items-start gap-2" key={fact}>
-              <span className="flex-grow text-slate-300">{fact}</span>
+            <li
+              className="flex items-start gap-2"
+              key={fact}
+            >
+              <span className="flex-grow text-slate-300">
+                {fact}
+              </span>
+
               <Button
                 ariaLabel="Mark good"
                 label="Good"
@@ -89,6 +101,7 @@ function DebugLoreModal({ isVisible, facts, onSubmit, onClose }: DebugLoreModalP
                 size="sm"
                 variant="toggle"
               />
+
               <Button
                 ariaLabel="Mark bad"
                 label="Bad"
@@ -103,8 +116,21 @@ function DebugLoreModal({ isVisible, facts, onSubmit, onClose }: DebugLoreModalP
         </ul>
 
         <div className="flex justify-end gap-2">
-          <Button ariaLabel="Skip" label="Skip" onClick={handleSkip} preset="stone" size="sm" />
-          <Button ariaLabel="OK" label="OK" onClick={handleOk} preset="sky" size="sm" />
+          <Button
+            ariaLabel="Skip"
+            label="Skip"
+            onClick={handleSkip}
+            preset="stone"
+            size="sm"
+          />
+
+          <Button
+            ariaLabel="OK"
+            label="OK"
+            onClick={handleOk}
+            preset="sky"
+            size="sm"
+          />
         </div>
       </div>
     </div>

--- a/components/modals/HistoryDisplay.tsx
+++ b/components/modals/HistoryDisplay.tsx
@@ -114,27 +114,27 @@ function HistoryDisplay({
             </ul>
             )}
 
-            <div className="flex justify-center gap-2 mt-4">
-              <Button
-                ariaLabel="Read journal"
-                label="Read"
-                onClick={onReadJournal}
-                preset="blue"
-                size="sm"
-                variant="toolbar"
-              />
+          <div className="flex justify-center gap-2 mt-4">
+            <Button
+              ariaLabel="Read journal"
+              label="Read"
+              onClick={onReadJournal}
+              preset="blue"
+              size="sm"
+              variant="toolbar"
+            />
 
-              <Button
-                ariaLabel="Write journal entry"
-                disabled={!canWriteJournal || isWritingJournal}
-                label="Write"
-                onClick={onWriteJournal}
-                preset="blue"
-                size="sm"
-                variant="toolbar"
-              />
-            </div>
+            <Button
+              ariaLabel="Write journal entry"
+              disabled={!canWriteJournal || isWritingJournal}
+              label="Write"
+              onClick={onWriteJournal}
+              preset="blue"
+              size="sm"
+              variant="toolbar"
+            />
           </div>
+        </div>
       </div>
     </div>
   );

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -474,10 +474,10 @@ function PageView({
 export default PageView;
 
 PageView.defaultProps = {
-  startIndex: 0,
+  canInspectJournal: true,
+  canWriteJournal: true,
+  isWritingJournal: false,
   onInspect: undefined,
   onWriteJournal: undefined,
-  canWriteJournal: true,
-  canInspectJournal: true,
-  isWritingJournal: false,
+  startIndex: 0,
 };

--- a/services/loremaster/api.ts
+++ b/services/loremaster/api.ts
@@ -119,9 +119,9 @@ export const refineLore_Service = async (
       integrate: {
         prompt: integratePrompt,
         rawResponse: integration?.raw,
-        parsedPayload: integration?.parsed ?? undefined,
-        observations: integration?.parsed?.observations,
-        rationale: integration?.parsed?.rationale,
+        parsedPayload: integration?.parsed,
+        observations: integration?.parsed.observations,
+        rationale: integration?.parsed.rationale,
         thoughts: integration?.thoughts,
       },
     },
@@ -272,9 +272,9 @@ export const distillFacts_Service = async (
     debugInfo: {
       prompt,
       rawResponse: result?.raw,
-      parsedPayload: result?.parsed ?? undefined,
-      observations: result?.parsed?.observations,
-      rationale: result?.parsed?.rationale,
+      parsedPayload: result?.parsed,
+      observations: result?.parsed.observations,
+      rationale: result?.parsed.rationale,
       thoughts: result?.thoughts,
     },
   };


### PR DESCRIPTION
## Summary
- apply alphabetical sorting for `PageView` defaults
- fix automatic lint violations across UI components
- sanitize null values when collecting and refining lore

## Testing
- `npm run lint`
- `npm run lint-strict`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dd8a146788324aba38493397e04ab