### PR TITLE
Support new item change actions

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -78,6 +78,9 @@ export const VALID_ITEM_TYPES = [
 
 export const VALID_ITEM_TYPES_STRING = VALID_ITEM_TYPES.map(type => `"${type}"`).join(' | ');
 
+export const VALID_ACTIONS = ['gain', 'destroy', 'update', 'addChapter', 'put', 'give', 'take'] as const;
+export const VALID_ACTIONS_STRING = VALID_ACTIONS.map(action => `"${action}"`).join(' | ');
+
 export const COMMON_TAGS = [
   'junk',
   'recovered',

--- a/services/corrections/inventory.ts
+++ b/services/corrections/inventory.ts
@@ -6,6 +6,7 @@ import { AdventureTheme, ItemChange } from '../../types';
 import {
   MAX_RETRIES,
   VALID_ITEM_TYPES_STRING,
+  VALID_ACTIONS_STRING,
   PLAYER_HOLDER_ID,
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
@@ -17,9 +18,6 @@ import { isApiConfigured } from '../apiClient';
 import { retryAiCall } from '../../utils/retry';
 import { parseInventoryResponse } from '../inventory/responseParser';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
-
-const VALID_ACTIONS = ['gain', 'destroy', 'update', 'put', 'give', 'take'] as const;
-const VALID_ACTIONS_STRING = VALID_ACTIONS.map(a => `"${a}"`).join(' | ');
 
 /**
  * Attempts to correct a malformed array of ItemChange objects returned by the

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -6,6 +6,8 @@ import { Item, AdventureTheme, ItemChange, ItemChapter, ItemTag } from '../../ty
 import {
   MAX_RETRIES,
   VALID_ITEM_TYPES_STRING,
+  VALID_ACTIONS,
+  VALID_ACTIONS_STRING,
   MINIMAL_MODEL_NAME,
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
@@ -187,7 +189,7 @@ export const fetchCorrectedItemAction_Service = async (
     const parsed = safeParseJson<Record<string, unknown>>(malformedItemChangeString);
     if (parsed && typeof parsed === 'object') {
       const rawAction = parsed.action;
-      if (typeof rawAction === 'string' && ['gain', 'destroy', 'update', "addChapter", 'put', 'give', 'take'].includes(rawAction)) {
+      if (typeof rawAction === 'string' && VALID_ACTIONS.includes(rawAction as ItemChange['action'])) {
         return rawAction as ItemChange['action'];
       }
     }
@@ -197,7 +199,7 @@ export const fetchCorrectedItemAction_Service = async (
 
   const prompt = `
 You are an AI assistant specialized in determining the correct 'action' for an ItemChange object in a text adventure game, based on narrative context and a potentially malformed ItemChange object.
-Valid 'action' types are: "gain", "destroy", "update", "addChapter", "put", "give", "take".
+Valid 'action' types are: ${VALID_ACTIONS_STRING}.
 
 Malformed ItemChange Object:
 \`\`\`json
@@ -221,7 +223,7 @@ Task: Based on the Log Message, Scene Description, and the 'item' details in the
 Respond ONLY with the single corrected action string.
 If no action can be confidently determined, respond with an empty string.`;
 
-  const systemInstruction = `Determine the correct item 'action' ("gain", "destroy", "update", "addChapter", "put", "give", "take") from narrative context and a malformed item object. Respond ONLY with the action string or an empty string if unsure.`;
+  const systemInstruction = `Determine the correct item 'action' (${VALID_ACTIONS_STRING}) from narrative context and a malformed item object. Respond ONLY with the action string or an empty string if unsure.`;
 
   return retryAiCall<ItemChange['action']>(async attempt => {
     try {
@@ -236,7 +238,7 @@ If no action can be confidently determined, respond with an empty string.`;
       const aiResponse = response.text?.trim() ?? null;
       if (aiResponse !== null) {
         const candidateAction = aiResponse.trim().toLowerCase();
-        if (['gain', 'destroy', 'update', "addChapter", 'put', 'give', 'take'].includes(candidateAction)) {
+        if (VALID_ACTIONS.includes(candidateAction as ItemChange['action'])) {
           console.warn(`fetchCorrectedItemAction_Service: Returned corrected itemAction `, candidateAction, ".");
           return { result: candidateAction as ItemChange['action'] };
         }

--- a/services/corrections/placeDetails.ts
+++ b/services/corrections/placeDetails.ts
@@ -3,7 +3,14 @@
  * @description Helpers for correcting or inferring map node details.
  */
 
-import { AdventureTheme, MapNode, MapNodeData, MapEdge, MinimalModelCallRecord } from '../../types';
+import {
+  AdventureTheme,
+  MapNode,
+  MapNodeData,
+  MapEdge,
+  MapNodeType,
+  MinimalModelCallRecord,
+} from '../../types';
 import {
   MAX_RETRIES,
   NODE_DESCRIPTION_INSTRUCTION,
@@ -18,6 +25,7 @@ import { retryAiCall } from '../../utils/retry';
 import { isApiConfigured } from '../apiClient';
 import {
   VALID_NODE_TYPE_VALUES,
+  NODE_TYPE_LEVELS,
   MINIMAL_MODEL_NAME,
   AUXILIARY_MODEL_NAME,
   GEMINI_MODEL_NAME,
@@ -381,8 +389,12 @@ export const fetchLikelyParentNode_Service = async (
     if (setB) setB.add(e.sourceNodeId);
   });
 
+  const proposedNodeType = (proposedNode.nodeType ?? 'feature') as MapNodeType;
+  const proposedLevel = NODE_TYPE_LEVELS[proposedNodeType];
+
   const nodeLines = context.themeNodes
-    .map(n => `- ${n.id} ("${n.placeName}")`) // TODO: list only nodes that are higher in the hierarchy that the proposed node
+    .filter(n => NODE_TYPE_LEVELS[n.data.nodeType] < proposedLevel)
+    .map(n => `- ${n.id} ("${n.placeName}")`)
     .join('\n');
 
   const edgeLines = context.themeEdges


### PR DESCRIPTION
## Summary
- include `addChapter` in corrections inventory action list
- filter candidate nodes by hierarchy when inferring parent nodes
- centralize `VALID_ACTIONS` and `VALID_ACTIONS_STRING` constants

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e738d77348324b55054fdfc618174