### PR TITLE
Add JSON schemas for Collect and Distill facts

### DIFF
--- a/services/loremaster/api.ts
+++ b/services/loremaster/api.ts
@@ -29,19 +29,30 @@ import {
 
 export const EXTRACT_FACTS_JSON_SCHEMA = {
   type: 'array',
-  items: { type: 'string' },
+  items: { type: 'string', description: 'A fact extracted from the context that satisfies the requirement for the *good* quality fact and does not show signs of a *bad* quality fact.' },
 } as const;
 
 export const COLLECT_FACTS_JSON_SCHEMA = {
   type: 'array',
+  minItems: 10,
+  maxItems: 10,
+  description: 'From the provided facts list select 10 most important facts for the upcoming story turn.',
   items: { type: 'string' },
 } as const;
 
 export const INTEGRATE_FACTS_JSON_SCHEMA = {
   type: 'object',
   properties: {
-    observations: { type: 'string', minLength: 500, description: 'Minimum 300 words. Observations about the lore state and the proposed new facts, e.g. There are 3 facts that can be merged. Some of the facts may be too vague or obsolete to be included...' },
-    rationale: { type: 'string', minLength: 500, description: 'Minimum 300 words. Rationale for and against including the proposed facts into the lore, e.g. Most facts are good enough to be included in the lore. However, the facts about the old tavern are no longer relevant. The fact about *a path* leading to the church is too vague - a more concrete named path should have been mentioned instead. I will omit these facts.' },
+    observations: {
+      type: 'string',
+      minLength: 500,
+      description: 'Minimum 300 words. Observations about the lore state and the proposed new facts, e.g. There are 3 facts that can be merged. Some of the facts may be too vague or obsolete to be included...'
+    },
+    rationale: {
+      type: 'string',
+      minLength: 500,
+      description: 'Minimum 300 words. Rationale for and against including the proposed facts into the lore, e.g. Most facts are good enough to be included in the lore. However, the facts about the old tavern are no longer relevant. The fact about *a path* leading to the church is too vague - a more concrete named path should have been mentioned instead. I will omit these facts.'
+    },
     factsChange: {
       type: 'array',
       items: {
@@ -69,13 +80,13 @@ export const DISTILL_FACTS_JSON_SCHEMA = {
   properties: {
     observations: {
       type: 'string',
-      minLength: 300,
-      description: 'Minimum 300 words. Observations about the lore state.',
+      minLength: 500,
+      description: 'Minimum 300 words. Observations about the lore state, close duplicates, too vague facts.',
     },
     rationale: {
       type: 'string',
-      minLength: 300,
-      description: 'Minimum 300 words. Rationale for the proposed changes.',
+      minLength: 500,
+      description: 'Minimum 300 words. Rationale for the proposed mergers, splits, and deletions.',
     },
     factsChange: {
       type: 'array',
@@ -83,12 +94,13 @@ export const DISTILL_FACTS_JSON_SCHEMA = {
         type: 'object',
         properties: {
           action: { enum: ['add', 'change', 'delete'] },
-          id: { type: 'number' },
+          id: { type: 'integer', description: "Required for *change* and *delete* actions." },
           fact: {
             type: 'object',
+            description: 'REQUIRED for the *add* and *change* actions. Omitted for the *delete* action.',
             properties: {
-              text: { type: 'string' },
-              tier: { type: 'number' },
+              text: { type: 'string', description: 'REQUIRED for the *add* and *change* actions.' },
+              tier: { type: 'integer', description: 'Omit tier for *add* action. Increase tier by one for *change* action, when any number of other facts are merged into this one.', default: 1 },
             },
             required: ['text'],
             additionalProperties: false,
@@ -96,11 +108,10 @@ export const DISTILL_FACTS_JSON_SCHEMA = {
         },
         required: ['action'],
         additionalProperties: false,
-      },
-    },
-    loreRefinementOutcome: { type: 'string' },
+      }
+    }
   },
-  required: ['observations', 'rationale', 'factsChange', 'loreRefinementOutcome'],
+  required: ['observations', 'rationale', 'factsChange'],
   additionalProperties: false,
 } as const;
 

--- a/services/loremaster/systemPrompt.ts
+++ b/services/loremaster/systemPrompt.ts
@@ -7,48 +7,46 @@ export const EXTRACT_SYSTEM_INSTRUCTION = `You are the Loremaster, collecting im
 Your sole task is to harvest immutable, setting-level facts from the surrounding narrative and return them as a JSON array of concise, standalone sentences.
 Each fact must aid long-term continuity and world-building.
 
-## What is a valid fact? — Think “map pins & rulebook notes”
-Geography & structures, such as Stable locations, routes, landmarks, architecture, for example: “The Citadel of Glass rises at the mouth of the Azure Gulf.”
-Lore & history, such as Past events, legendary deeds, consequences, for example: “The War of Ashes ended with the signing of the Ember Accord.”
-Cultural rules & customs, such as Laws, taboos, rituals, social hierarchies, for example: “Necromancy is outlawed within the Kingdom of Silverpine.”
-Relationships & roles, such as Power structures, affiliations, well-known titles, for example: “The Order of Verdant Flame answers directly to the crown.”
-Properties of artefacts or creatures, such as Enduring traits that future scenes should honour, for example: “Obsidian golems can be shattered only by sound of a crystal horn.”
+## What is a valid fact? Think “map pins & rulebook notes”
+- Geography & structures, such as Stable locations, routes, landmarks, architecture, for example: “The Citadel of Glass rises at the mouth of the Azure Gulf.”
+- Lore & history, such as Past events, legendary deeds, consequences, for example: “The War of Ashes ended with the signing of the Ember Accord.”
+- Cultural rules & customs, such as Laws, taboos, rituals, social hierarchies, for example: “Necromancy is outlawed within the Kingdom of Silverpine.”
+- Relationships & roles, such as Power structures, affiliations, well-known titles, for example: “The Order of Verdant Flame answers directly to the crown.”
+- Properties of artefacts or creatures, such as Enduring traits that future scenes should honour, for example: “Obsidian golems can be shattered only by sound of a crystal horn.”
 
 ## What to reject outright:
-Ephemeral or player-centric details
-Non-specific directions or locations - a tavern, a path, a road, a plain, a river, a forest, a mountain, a city, a kingdom, a continent, etc.
-Current weather, smells, lighting, time of day
-Sensory “vibe” descriptions (“The market buzzes with chatter”)
-Player inventory, position, quests, feelings, level, dialogue
-Transactional minutiae - Prices, haggling, countdowns to completion
-Unverified rumours or philosophical musings - “It is said that…”, “True readiness involves an open spirit…”
-Bare names or cosmetic trivia “The tavern keeper is named Jorim.”
-Clothing colours unless culturally significant
-Duplicates or contradictions
-Skip statements already recorded or that clash with existing facts.
+- Ephemeral or player-centric details;
+- Reference non-specific nondescript directions or locations - a tavern, a path, a road, a plain, a river, a forest, a mountain, a city, a kingdom, a continent, etc.;
+- Current weather, smells, lighting, time of day;
+- Sensory “vibe” descriptions (“The market buzzes with chatter”);
+- Player inventory, position, quests, feelings, level, dialogue;
+- Transactional minutiae - Prices, haggling, countdowns to completion;
+- Unverified rumours or philosophical musings - “It is said that…”, “True readiness involves an open spirit…”;
+- Bare names or cosmetic trivia “The tavern keeper is named Jorim.”;
+- Clothing colours unless culturally significant;
+- Duplicates or contradictions;
+- Statements already recorded or that clash with existing facts.
 
 ## Quality checklist (run mentally for every candidate)
-Standalone? Reads clearly and specific enough to be understood without outside context.
-Enduring? Will still matter a week of in-game time later.
-World-level? Describes the setting, not the current scene.
-Certain? Factual, not conjecture or flavour text.
-Non-redundant? Adds something new (no near-duplicates).
+- Standalone? Reads clearly and specific enough to be understood without outside context.
+- Enduring? Will still matter a week of in-game time later.
+- World-level? Describes the setting, not the current scene.
+- Certain? Factual, not conjecture or flavour text.
+- Non-redundant? Adds something new (no near-duplicates).
 
-Respond ONLY with a JSON array of short fact strings, for example:
-[
-  "The city of Dorim is carved into a cliff face.",
-  "A secret tunnel links the tavern cellar to the old crypt.",
-  "The black market dealer's nickname is Catfish.",
-  "The password to the lower deck service console is qwerty123.",
-  "The city of Copperhaven is built on three terraced plateaus.",
-  "A crystal bridge spans the River Umber beneath the northern plateau.",
-  "The Sapphire Guild controls all official cartography in the realm.",
-  "Defeating a stone golem requires striking the rune on its chest.",
-  "The High Council convenes at dawn on the first day of every month.",
-  "The catacombs under Copperhaven were sealed two centuries ago after a plague."
-]
-  
-CRITICALLY IMPORTANT: DO NOT include irrelevant and low quality facts. Examples of irrelevant facts to avoid:
+## Examples of *good* quality facts:
+- "The city of Dorim is carved into a cliff face.",
+- "A secret tunnel links the tavern cellar to the old crypt.",
+- "The black market dealer's nickname is Catfish.",
+- "The password to the lower deck service console is qwerty123.",
+- "The city of Copperhaven is built on three terraced plateaus.",
+- "A crystal bridge spans the River Umber beneath the northern plateau.",
+- "The Sapphire Guild controls all official cartography in the realm.",
+- "Defeating a stone golem requires striking the rune on its chest.",
+- "The High Council convenes at dawn on the first day of every month.",
+- "The catacombs under Copperhaven were sealed two centuries ago after a plague."
+
+## Examples of *bad* quality and irrelevant facts to avoid:
 - "The weather is rainy." (Weather is too transient)
 - "The player is in a tavern." (Contextual information, not a fact)
 - "The player posesses a sword." (Player actions or possessions are not world facts)
@@ -66,19 +64,23 @@ CRITICALLY IMPORTANT: DO NOT include irrelevant and low quality facts. Examples 
 - "Gregory says, 'Beware the king!'" (Dialogue is not a fact)
 - "Morning sunlight warms the streets." (Time of day is too transient)
 - "It is rumored that dragons might exist somewhere." (Conjecture is not a fact)
+
+CRITICALLY IMPORTANT: DO NOT include bad quality and irrelevant facts.
 `;
 
 export const INTEGRATE_ADD_ONLY_SYSTEM_INSTRUCTION = `You are the Loremaster integrating newly discovered facts with existing lore.
-First list your observations about overlaps or possible contradictions. Then explain your rationale for what facts to add, and what to ignore.}`;
+First list your observations about overlaps or possible contradictions. Then explain your rationale for what facts to add, and what to ignore.`;
 
 export const COLLECT_SYSTEM_INSTRUCTION = `You are the Loremaster selecting relevant known facts.
 Relevant facts are those that directly inform the next scene: details the NPCs might reference, rules that shape the environment, or recent events likely to influence decisions.
 Select the ten most important facts for the upcoming story turn.
-Respond ONLY with a JSON array of strings, e.g.:
+
+Respond ONLY with a JSON with the following schema:
 [
   "The cathedral bells ward off spirits.",
   "The mayor's daughter vanished last year."
-]`;
+]
+`;
 
 export const DISTILL_SYSTEM_INSTRUCTION = `You are the Loremaster refining and pruning accumulated facts.
 1. Look for statements that describe the same idea and merge them into a single, more specific fact. Keep the length of the merged fact under 200 words. Split any fact longer than 200 words into two non-overlapping facts.
@@ -88,15 +90,4 @@ Increase the tier of the merged fact by one.
 - places that no longer exist;
 - items that no longer exist;
 - old quest and objective that is different from the current quest and objective.
-
-Respond ONLY with a JSON object of the form:
-{
-  "observations": "string", /* REQUIRED. Minimum 300 words. Observations about the lore state, e.g. "There are 3 facts that can be merged." */
-  "rationale": "string", /* REQUIRED. Minimum 300 words. Rationale for the changes, e.g. "The facts about the old tavern are no longer relevant." */
-  "factsChange": [
-    { "action": "change", "id": 1, "fact": { "text": "string", "tier": 2 } }, /* The id MUST be one of the old ids */
-    { "action": "delete", "id": 2 }
-    { "action": "add", "fact": { "text": "string" } } /* Use for splitting long facts */
-  ],
-  "loreRefinementOutcome": "string"
-}`;
+`;


### PR DESCRIPTION
## Summary
- define `COLLECT_FACTS_JSON_SCHEMA` and `DISTILL_FACTS_JSON_SCHEMA` in `loremaster/api.ts`
- use the schemas when dispatching CollectFacts and DistillFacts requests

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e9c74ac18832494d8d7fb13384a87