### PR TITLE
Improve Connector Chain deduplication

### DIFF
--- a/services/cartographer/connectorChains.ts
+++ b/services/cartographer/connectorChains.ts
@@ -67,3 +67,86 @@ export function buildChainRequest(
     edgeData,
   };
 }
+
+function buildParentChainIds(request: EdgeChainRequest): Array<string> {
+  const visited = new Set<string>();
+  const ordered: Array<string> = [];
+  [...request.sourceChain, ...request.targetChain.slice().reverse()].forEach(p => {
+    if (p.data.nodeType !== 'feature' && !visited.has(p.id)) {
+      ordered.push(p.id);
+      visited.add(p.id);
+    }
+  });
+  if (ordered.length === 0) {
+    if (!visited.has(request.originalSource.id)) {
+      ordered.push(request.originalSource.id);
+      visited.add(request.originalSource.id);
+    }
+    if (!visited.has(request.originalTarget.id)) {
+      ordered.push(request.originalTarget.id);
+    }
+  }
+  return ordered;
+}
+
+function isSubchain(shorter: Array<string>, longer: Array<string>): boolean {
+  if (shorter.length > longer.length) return false;
+  for (let i = 0; i <= longer.length - shorter.length; i++) {
+    let match = true;
+    for (let j = 0; j < shorter.length; j++) {
+      if (shorter[j] !== longer[i + j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) return true;
+  }
+  return false;
+}
+
+export function filterEdgeChainRequests(
+  requests: Array<EdgeChainRequest>,
+): Array<EdgeChainRequest> {
+  const filtered: Array<EdgeChainRequest> = [];
+  const paths: Array<Array<string>> = [];
+
+  requests.forEach(req => {
+    const path = buildParentChainIds(req);
+    const reversed = [...path].reverse();
+    let skip = false;
+
+    for (let idx = 0; idx < paths.length; idx++) {
+      const existing = paths[idx];
+      const existingRev = [...existing].reverse();
+      const isSame =
+        (path.length === existing.length && path.every((v, i) => v === existing[i])) ||
+        (path.length === existing.length && reversed.every((v, i) => v === existing[i]));
+      if (isSame) {
+        skip = true;
+        break;
+      }
+
+      const isSub =
+        (path.length <= existing.length &&
+          (isSubchain(path, existing) || isSubchain(reversed, existing))) ||
+        (path.length > existing.length &&
+          (isSubchain(existing, path) || isSubchain(existingRev, path)));
+
+      if (isSub) {
+        if (path.length > existing.length) {
+          filtered[idx] = req;
+          paths[idx] = path;
+        }
+        skip = true;
+        break;
+      }
+    }
+
+    if (!skip) {
+      filtered.push(req);
+      paths.push(path);
+    }
+  });
+
+  return filtered;
+}


### PR DESCRIPTION
## Summary
- prevent redundant connector chains by filtering reverse and sub-chains
- use new `filterEdgeChainRequests` helper when refining connector chains

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685edbd381948324a26f0476d0fbda27