### PR TITLE
Improve partial ID handling in map updates

### DIFF
--- a/services/cartographer/applyUpdates.ts
+++ b/services/cartographer/applyUpdates.ts
@@ -103,6 +103,20 @@ export const applyMapUpdates = async ({
       referenceMapNodeId,
     ) as MapNode | undefined;
     if (!node) {
+      const idPattern = /^(.*)_([a-zA-Z0-9]{4})$/;
+      const m = idPattern.exec(identifier);
+      if (m) {
+        const base = m[1].toLowerCase();
+        const candidates = Object.values(newNodesInBatchIdNameMap).filter(entry =>
+          entry.id.toLowerCase().startsWith(`${base}_`)
+        );
+        if (candidates.length === 1) {
+          node = newMapData.nodes.find(n => n.id === candidates[0].id);
+          if (!node) return undefined;
+        }
+      }
+    }
+    if (!node) {
       const corrected = await fetchCorrectedNodeIdentifier_Service(
         identifier,
         {

--- a/tests/applyUpdatesPartialId.test.ts
+++ b/tests/applyUpdatesPartialId.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../services/corrections/placeDetails', async () => {
+  const actual = await vi.importActual('../services/corrections/placeDetails');
+  return { ...actual, fetchCorrectedNodeIdentifier_Service: vi.fn() };
+});
+
+vi.mock('../services/corrections/edgeFixes', async () => {
+  const actual = await vi.importActual('../services/corrections/edgeFixes');
+  return { ...actual, fetchConnectorChains_Service: vi.fn().mockResolvedValue({ payload: null }) };
+});
+
+import { applyMapUpdates } from '../services/cartographer/applyUpdates';
+import type {
+  AdventureTheme,
+  MapData,
+  MapNode,
+  AIMapUpdatePayload,
+  GameStateFromAI,
+} from '../types';
+import { fetchCorrectedNodeIdentifier_Service } from '../services/corrections/placeDetails';
+
+const theme: AdventureTheme = { name: 'TestTheme' } as AdventureTheme;
+
+const existingFeature: MapNode = {
+  id: 'node_gate_real1',
+  themeName: theme.name,
+  placeName: 'Ancient Gate',
+  position: { x: 0, y: 0 },
+  data: {
+    description: '',
+    aliases: [],
+    status: 'discovered',
+    nodeType: 'feature',
+    parentNodeId: 'Universe',
+  },
+};
+
+const baseMap: MapData = {
+  nodes: [existingFeature],
+  edges: [],
+};
+
+const payload: AIMapUpdatePayload = {
+  nodesToAdd: [
+    {
+      placeName: 'Side Tunnel',
+      data: {
+        description: '',
+        aliases: [],
+        status: 'rumored',
+        parentNodeId: 'Universe',
+        nodeType: 'location',
+      },
+    },
+    {
+      placeName: 'Hidden Door',
+      data: {
+        description: '',
+        aliases: [],
+        status: 'rumored',
+        parentNodeId: 'node_side_tunnel_fake',
+        nodeType: 'feature',
+      },
+    },
+  ],
+  edgesToAdd: [
+    {
+      sourcePlaceName: existingFeature.id,
+      targetPlaceName: 'node_hidden_door_fake',
+      data: { type: 'path', status: 'rumored', description: '' },
+    },
+  ],
+};
+
+describe('applyMapUpdates partial id handling', () => {
+  it('resolves bogus suffix references without corrections', async () => {
+    const result = await applyMapUpdates({
+      payload,
+      currentMapData: baseMap,
+      currentTheme: theme,
+      previousMapNodeId: null,
+      inventoryItems: [],
+      knownNPCs: [],
+      aiData: { currentMapNodeId: null } as unknown as GameStateFromAI,
+      minimalModelCalls: [],
+      debugInfo: {} as unknown as import('../services/cartographer/types').MapUpdateDebugInfo,
+    });
+
+    const sideTunnel = result.updatedMapData.nodes.find(n => n.placeName === 'Side Tunnel');
+    const hiddenDoor = result.updatedMapData.nodes.find(n => n.placeName === 'Hidden Door');
+    expect(sideTunnel).toBeDefined();
+    expect(hiddenDoor).toBeDefined();
+    if (!sideTunnel || !hiddenDoor) throw new Error('Missing nodes');
+    expect(hiddenDoor.data.parentNodeId).toBe(sideTunnel.id);
+
+    const edge = result.updatedMapData.edges.find(e =>
+      (e.sourceNodeId === existingFeature.id && e.targetNodeId === hiddenDoor.id) ||
+      (e.targetNodeId === existingFeature.id && e.sourceNodeId === hiddenDoor.id)
+    );
+    expect(edge).toBeDefined();
+    expect(vi.mocked(fetchCorrectedNodeIdentifier_Service)).not.toHaveBeenCalled();
+  });
+});

--- a/utils/entityUtils.ts
+++ b/utils/entityUtils.ts
@@ -89,7 +89,12 @@ export const findMapNodeByIdentifier = (
     if (m) {
       const baseStr = m[1];
       base = baseStr;
-      partialMatch = nodes.find(node => node.id.toLowerCase().includes(baseStr.toLowerCase()));
+      const baseCandidates = nodes.filter(n =>
+        n.id.toLowerCase().startsWith(`${baseStr.toLowerCase()}_`)
+      );
+      if (baseCandidates.length === 1) {
+        partialMatch = baseCandidates[0];
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- preassign IDs for all nodes in incoming update batches
- prefer partial ID matches from update batch before calling correction service
- add unit test for bogus-suffix references

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685efcc5ae0483248326ca8488485909