### PR TITLE
Retry on transient network errors

### DIFF
--- a/utils/aiErrorUtils.ts
+++ b/utils/aiErrorUtils.ts
@@ -42,3 +42,29 @@ export const isServerOrClientError = (err: unknown): boolean => {
   const status = extractStatusFromError(err);
   return status !== null && status >= 400 && status < 600;
 };
+
+/**
+ * Determines if the error is likely transient (e.g. network hiccups).
+ * Currently checks for common messages like net::ERR_SSL_PROTOCOL_ERROR.
+ *
+ * @param err - The caught error.
+ * @returns True if the error message suggests a transient network failure.
+ */
+export const isTransientNetworkError = (err: unknown): boolean => {
+  if (!err) return false;
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string' ||
+          typeof err === 'number' ||
+          typeof err === 'boolean'
+        ? String(err)
+        : '';
+  return (
+    message.includes('ERR_SSL_PROTOCOL_ERROR') ||
+    message.includes('ECONNRESET') ||
+    message.includes('ETIMEDOUT') ||
+    message.includes('EAI_AGAIN') ||
+    message.includes('Failed to fetch')
+  );
+};


### PR DESCRIPTION
## Summary
- add `isTransientNetworkError` helper
- retry for SSL or other network hiccups in `dispatchAIRequest`
- extend `retryAiCall` to use transient error handling

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ef6e29c908324b6278c01e39a3e72