### PR TITLE
Improve cartographer prompt with item/NPC names

### DIFF
--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -79,6 +79,37 @@ export const updateMapFromAIData_Service = async (
       ? allKnownMainMapNodesForTheme.map(p => `"${p.placeName}"`).join(', ')
       : 'No important places are known yet.';
 
+  const itemNameSet = new Set<string>();
+  inventoryItems.forEach(item => {
+    if (item.type !== 'vehicle') itemNameSet.add(item.name);
+  });
+  if ('newItems' in aiData && aiData.newItems) {
+    aiData.newItems.forEach(item => {
+      if (item.type !== 'vehicle') itemNameSet.add(item.name);
+    });
+  }
+  const itemNames = Array.from(itemNameSet);
+
+  const npcNameSet = new Set<string>();
+  knownNPCs.forEach(npc => {
+    npcNameSet.add(npc.name);
+    (npc.aliases ?? []).forEach(a => npcNameSet.add(a));
+  });
+  if ('npcsAdded' in aiData && aiData.npcsAdded) {
+    aiData.npcsAdded.forEach(npc => {
+      npcNameSet.add(npc.name);
+      (npc.aliases ?? []).forEach(a => npcNameSet.add(a));
+    });
+  }
+  if ('npcsUpdated' in aiData && aiData.npcsUpdated) {
+    aiData.npcsUpdated.forEach(npc => {
+      npcNameSet.add(npc.name);
+      (npc.newAliases ?? []).forEach(a => npcNameSet.add(a));
+      if (npc.addAlias) npcNameSet.add(npc.addAlias);
+    });
+  }
+  const npcNames = Array.from(npcNameSet);
+
   const basePrompt = buildMapUpdatePrompt(
     sceneDesc,
     logMsg,
@@ -88,6 +119,8 @@ export const updateMapFromAIData_Service = async (
     previousMapNodeContext,
     existingMapContext,
     allKnownMainPlacesString,
+    itemNames,
+    npcNames,
   );
 
   const { payload, debugInfo } = await fetchMapUpdatePayload(

--- a/services/cartographer/promptBuilder.ts
+++ b/services/cartographer/promptBuilder.ts
@@ -32,17 +32,25 @@ export const buildMapUpdatePrompt = (
   previousMapNodeContext: string,
   existingMapContext: string,
   allKnownMainPlaces: string,
+  itemNames: Array<string>,
+  npcNames: Array<string>,
 ): string => `## Narrative Context for Map Update:
-- Current Theme: "${currentTheme.name}";
-- System Modifier for Theme: "${currentTheme.systemInstructionModifier}";
-- Scene Description: "${sceneDesc}";
-- Log Message (outcome of last action): "${logMsg}";
-- Player's Current Location Description (localPlace): "${localPlace}".
+  - Current Theme: "${currentTheme.name}";
+  - System Modifier for Theme: "${currentTheme.systemInstructionModifier}";
+  - Scene Description: "${sceneDesc}";
+  - Log Message (outcome of last action): "${logMsg}";
+  - Player's Current Location Description (localPlace): "${localPlace}".
 
 ## Map Context:
-- All Known Main Locations: ${allKnownMainPlaces};
-- Player's Previous Location was: ${previousMapNodeContext};
-- Map Hint from Storyteller: "${mapHint}".
+  - All Known Main Locations: ${allKnownMainPlaces};
+  - Player's Previous Location was: ${previousMapNodeContext};
+  - Map Hint from Storyteller: "${mapHint}".
+  - Item Names to avoid as nodes: ${
+    itemNames.length > 0 ? itemNames.map(n => `"${n}"`).join(', ') : 'None'
+  };
+  - NPC Names to avoid as nodes: ${
+    npcNames.length > 0 ? npcNames.map(n => `"${n}"`).join(', ') : 'None'
+  }.
 
 ${existingMapContext}
 ---


### PR DESCRIPTION
## Summary
- include a list of item names and NPC names when requesting map updates
- teach Cartographer AI which names correspond to items or characters so it avoids adding them as nodes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ff13f24088324b4b6ed2034712373