### PR TITLE
Fix feature hierarchy conflict handling

### DIFF
--- a/services/cartographer/processNodeAdds.ts
+++ b/services/cartographer/processNodeAdds.ts
@@ -125,11 +125,9 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
                 resolvedParentId = parent.id;
               } else {
                 sameTypeParent = parent;
-                resolvedParentId = findClosestAllowedParent(
-                  parent,
-                  childType,
-                  context.themeNodeIdMap,
-                );
+                // Temporarily allow the invalid hierarchy; it will be
+                // corrected during conflict resolution.
+                resolvedParentId = parent.id;
               }
             } else {
               resolvedParentId = findClosestAllowedParent(

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -17,7 +17,6 @@ import { updateMapFromAIData_Service, MapUpdateServiceResult } from '../services
 import { fetchFullPlaceDetailsForNewMapNode_Service } from '../services/corrections';
 import { selectBestMatchingMapNode, attemptMatchAndSetNode } from './mapNodeMatcher';
 import { buildNPCChangeRecords, applyAllNPCChanges } from './gameLogicUtils';
-import { upgradeFeaturesWithChildren } from './mapHierarchyUpgradeUtils';
 import {
   existsNonRumoredPath,
   getAncestors,
@@ -114,18 +113,8 @@ export const handleMapUpdates = async (
     }
 
 
-  // Upgrade any feature nodes that now have children into regions or adjust hierarchy
-  const upgradeResult = await upgradeFeaturesWithChildren(draftState.mapData, themeContextForResponse);
-  if (upgradeResult.addedNodes.length > 0 || upgradeResult.addedEdges.length > 0) {
-    draftState.mapData = upgradeResult.updatedMapData;
-    turnChanges.mapDataChanged = true;
-  }
-
   const newlyAddedEdgeIds = new Set(
-    [
-      ...upgradeResult.addedEdges,
-      ...(mapUpdateResult?.newlyAddedEdges ?? []),
-    ].map(e => e.id)
+    (mapUpdateResult?.newlyAddedEdges ?? []).map(e => e.id)
   );
 
   const themeName = themeContextForResponse.name;


### PR DESCRIPTION
## Summary
- keep new nodes assigned under same-type parents to allow conflict resolution
- remove duplicate feature hierarchy repair in map update handler

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68601eee78308324bcd279e3ec8117cd