### PR TITLE
Remove dialogue transcript from game log

### DIFF
--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -19,8 +19,7 @@ import {
   executeDialogueSummary,
   executeMemorySummary,
 } from '../services/dialogue';
-import { MAX_LOG_MESSAGES, MAX_DIALOGUE_SUMMARIES_PER_NPC, PLAYER_HOLDER_ID } from '../constants';
-import { addLogMessageToList } from '../utils/gameLogicUtils';
+import { MAX_DIALOGUE_SUMMARIES_PER_NPC, PLAYER_HOLDER_ID } from '../constants';
 import { structuredCloneGameState } from '../utils/cloneUtils';
 
 const DIALOGUE_EXIT_READ_DELAY_MS = 5000;
@@ -160,11 +159,8 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
       thoughts: summaryThoughts,
     } = await executeDialogueSummary(summaryContextForUpdates);
 
-    const participantsForLog = [...finalParticipants];
-    const dialogueBlock =
-      `Conversation transcript with ${participantsForLog.join(', ')}:\n` +
-      finalHistory.map((entry) => `  ${entry.speaker}: ${entry.line}`).join('\n');
-    workingGameState.gameLog = addLogMessageToList(workingGameState.gameLog, dialogueBlock, MAX_LOG_MESSAGES);
+    // Dialogue transcript previously logged to the game history is now omitted
+    // since the Loremaster maintains summaries of key exchanges.
 
     workingGameState.dialogueState = null;
 


### PR DESCRIPTION
## Summary
- stop logging full dialogue transcripts when a conversation ends

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686041f2e97c8324812d5f6350401bd9