### PR TITLE
Add book contents to AI prompts when actions mention written items

### DIFF
--- a/utils/highlightHelper.tsx
+++ b/utils/highlightHelper.tsx
@@ -44,6 +44,11 @@ export interface HighlightableEntity {
   type: 'item' | 'place' | 'npc';
   description: string;
   aliases?: Array<string>;
+  /**
+   * When the entity represents an item, include the full Item object so
+   * additional data like its type or chapters can be accessed by callers.
+   */
+  item?: Item;
 }
 
 interface HighlightRegex {
@@ -203,6 +208,7 @@ export const buildHighlightableEntities = (
     type: 'item',
     description:
       item.isActive && item.activeDescription ? item.activeDescription : item.description,
+    item,
   }));
 
   const places: Array<HighlightableEntity> = currentThemeName


### PR DESCRIPTION
## Summary
- extend `HighlightableEntity` with an optional `item` field
- include the item when building highlightable entities
- detect highlighted book/page items in selected actions and append their text

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860452115008324a2520b2030242488