### PR TITLE
Fix journal write cooldown logic

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -43,6 +43,7 @@ import {
   RECENT_LOG_COUNT_FOR_PROMPT,
   PLAYER_HOLDER_ID,
   PLAYER_JOURNAL_ID,
+  JOURNAL_WRITE_COOLDOWN,
   INSPECT_COOLDOWN,
 } from '../../constants';
 import { ThemePackName, Item, ItemChapter, FullGameState } from '../../types';
@@ -356,7 +357,9 @@ function App() {
   const [isPlayerJournalWriting, setIsPlayerJournalWriting] = useState(false);
 
   const canWritePlayerJournal =
-    lastJournalWriteTurn !== globalTurnNumber && !isPlayerJournalWriting;
+    (lastJournalWriteTurn === 0 ||
+      globalTurnNumber - lastJournalWriteTurn >= JOURNAL_WRITE_COOLDOWN) &&
+    !isPlayerJournalWriting;
   const canInspectPlayerJournal =
     playerJournal.length > 0 &&
     (lastJournalInspectTurn === 0 ||
@@ -368,7 +371,10 @@ function App() {
   }, [openPageView, playerJournal.length]);
 
   const handleWritePlayerJournal = useCallback(() => {
-    if (lastJournalWriteTurn === globalTurnNumber || isPlayerJournalWriting) return;
+    const cooldownOver =
+      lastJournalWriteTurn === 0 ||
+      globalTurnNumber - lastJournalWriteTurn >= JOURNAL_WRITE_COOLDOWN;
+    if (!cooldownOver || isPlayerJournalWriting) return;
     setIsPlayerJournalWriting(true);
     openPageView(PLAYER_JOURNAL_ID, playerJournal.length);
     void (async () => {


### PR DESCRIPTION
## Summary
- ensure JOURNAL_WRITE_COOLDOWN is respected before enabling write actions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686054d9d6e083249f797ddebbbf0626