### PR TITLE
Fix lore distillation check timing

### DIFF
--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -388,8 +388,9 @@ export const useGameLogic = (props: UseGameLogicProps) => {
       return;
     if (
       currentFullState.globalTurnNumber > 0 &&
-      (currentFullState.globalTurnNumber - 1) % DISTILL_LORE_INTERVAL === 0 &&
-      currentFullState.lastLoreDistillTurn !== currentFullState.globalTurnNumber
+      currentFullState.globalTurnNumber % DISTILL_LORE_INTERVAL === 0 &&
+      currentFullState.lastLoreDistillTurn !==
+        currentFullState.globalTurnNumber
     ) {
       void handleDistillFacts();
     }


### PR DESCRIPTION
## Summary
- fix automatic lore distillation condition so it only triggers at the end of the correct turn

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686057a9d75083248f77ac000dac86c6