### PR TITLE
Add imageData support for item chapters

### DIFF
--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -150,7 +150,9 @@ export function isValidItem(item: unknown, context?: 'gain' | 'update'): item is
         typeof ch === 'object' &&
         typeof (ch as ItemChapter).heading === 'string' &&
         typeof (ch as ItemChapter).description === 'string' &&
-        typeof (ch as ItemChapter).contentLength === 'number'
+        typeof (ch as ItemChapter).contentLength === 'number' &&
+        ((ch as ItemChapter).imageData === undefined ||
+          typeof (ch as ItemChapter).imageData === 'string')
     );
 
   if (obj.type === 'page' || obj.type === 'book') {
@@ -231,7 +233,8 @@ export function isValidAddChapterPayload(obj: unknown): obj is AddChapterPayload
     return (
       typeof ch.heading === 'string' &&
       typeof ch.description === 'string' &&
-      typeof ch.contentLength === 'number'
+      typeof ch.contentLength === 'number' &&
+      (ch.imageData === undefined || typeof ch.imageData === 'string')
     );
   }
   return false;

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -65,6 +65,8 @@ export function isValidItemForSave(item: unknown): item is Item {
       typeof (maybe as { actualContent?: unknown }).actualContent === 'string') &&
     ((maybe as { visibleContent?: unknown }).visibleContent === undefined ||
       typeof (maybe as { visibleContent?: unknown }).visibleContent === 'string') &&
+    ((maybe as { imageData?: unknown }).imageData === undefined ||
+      typeof (maybe as { imageData?: unknown }).imageData === 'string') &&
     (maybe.knownUses === undefined ||
       (Array.isArray(maybe.knownUses) &&
         maybe.knownUses.every((ku: KnownUse) =>

--- a/types.ts
+++ b/types.ts
@@ -42,6 +42,7 @@ export interface ItemChapter {
   contentLength: number;
   actualContent?: string;
   visibleContent?: string;
+  imageData?: string;
 }
 
 export interface Item {

--- a/utils/inventoryUtils.ts
+++ b/utils/inventoryUtils.ts
@@ -28,6 +28,7 @@ const applyItemActionCore = (
       contentLength?: number;
       actualContent?: string;
       visibleContent?: string;
+      imageData?: string;
     };
     const existing = findItemByIdentifier(
       [itemData.id, itemData.name],
@@ -53,17 +54,20 @@ const applyItemActionCore = (
                 {
                   heading: itemData.name,
                   description: itemData.description,
-                  contentLength:
-                    (itemData as { contentLength?: number }).contentLength ??
-                    existing.chapters?.[0]?.contentLength ??
-                    30,
-                  actualContent:
-                    (itemData as { actualContent?: string }).actualContent ??
-                    existing.chapters?.[0]?.actualContent,
-                  visibleContent:
-                    (itemData as { visibleContent?: string }).visibleContent ??
-                    existing.chapters?.[0]?.visibleContent,
-                },
+                contentLength:
+                  (itemData as { contentLength?: number }).contentLength ??
+                  existing.chapters?.[0]?.contentLength ??
+                  30,
+                actualContent:
+                  (itemData as { actualContent?: string }).actualContent ??
+                  existing.chapters?.[0]?.actualContent,
+                visibleContent:
+                  (itemData as { visibleContent?: string }).visibleContent ??
+                  existing.chapters?.[0]?.visibleContent,
+                imageData:
+                  (itemData as { imageData?: string }).imageData ??
+                  existing.chapters?.[0]?.imageData,
+              },
               ]
             : existing.chapters),
         knownUses: itemData.knownUses ?? existing.knownUses ?? [],
@@ -88,7 +92,7 @@ const applyItemActionCore = (
         itemData.chapters ??
         (itemData.type === 'page'
           ? [
-              {
+              { 
                 heading: itemData.name,
                 description: itemData.description,
                 contentLength:
@@ -97,6 +101,7 @@ const applyItemActionCore = (
                   (itemData as { actualContent?: string }).actualContent,
                 visibleContent:
                   (itemData as { visibleContent?: string }).visibleContent,
+                imageData: (itemData as { imageData?: string }).imageData,
               },
             ]
           : undefined),
@@ -117,6 +122,7 @@ const applyItemActionCore = (
       contentLength?: number;
       actualContent?: string;
       visibleContent?: string;
+      imageData?: string;
     };
     const existing = findItemByIdentifier(
       [itemData.id, itemData.name],
@@ -148,6 +154,7 @@ const applyItemActionCore = (
                   (itemData as { actualContent?: string }).actualContent,
                 visibleContent:
                   (itemData as { visibleContent?: string }).visibleContent,
+                imageData: (itemData as { imageData?: string }).imageData,
               },
             ]
           : undefined),
@@ -182,6 +189,7 @@ const applyItemActionCore = (
       contentLength?: number;
       actualContent?: string;
       visibleContent?: string;
+      imageData?: string;
     };
     const existingItem = findItemByIdentifier(
       [updatePayload.id, updatePayload.name],
@@ -219,6 +227,10 @@ const applyItemActionCore = (
     if (updatePayload.visibleContent !== undefined && updated.chapters) {
       const ch = updated.chapters[0];
       updated.chapters[0] = { ...ch, visibleContent: updatePayload.visibleContent };
+    }
+    if (updatePayload.imageData !== undefined && updated.chapters) {
+      const ch = updated.chapters[0];
+      updated.chapters[0] = { ...ch, imageData: updatePayload.imageData };
     }
     if (updatePayload.knownUses !== undefined) updated.knownUses = updatePayload.knownUses;
     if (updatePayload.holderId !== undefined && updatePayload.holderId.trim() !== '') {
@@ -393,15 +405,16 @@ export const buildItemChangeRecords = (
             (gainedItemData.type === 'page'
               ? [
                   {
-                    heading: gainedItemData.name,
-                    description: gainedItemData.description,
-                    contentLength:
-                      (gainedItemData as { contentLength?: number }).contentLength ?? 30,
-                    actualContent:
-                      (gainedItemData as { actualContent?: string }).actualContent,
-                    visibleContent:
-                      (gainedItemData as { visibleContent?: string }).visibleContent,
-                  },
+                heading: gainedItemData.name,
+                description: gainedItemData.description,
+                contentLength:
+                  (gainedItemData as { contentLength?: number }).contentLength ?? 30,
+                actualContent:
+                  (gainedItemData as { actualContent?: string }).actualContent,
+                visibleContent:
+                  (gainedItemData as { visibleContent?: string }).visibleContent,
+                imageData: (gainedItemData as { imageData?: string }).imageData,
+              },
                 ]
               : undefined),
           knownUses: gainedItemData.knownUses ?? [],
@@ -436,6 +449,7 @@ export const buildItemChangeRecords = (
         contentLength?: number;
         actualContent?: string;
         visibleContent?: string;
+        imageData?: string;
       } = change.item;
       const oldItem = findItemByIdentifier(
         [updatePayload.id, updatePayload.name],
@@ -490,6 +504,9 @@ export const buildItemChangeRecords = (
                     visibleContent:
                       updatePayload.visibleContent ??
                       (oldItemCopy.chapters?.[0] as ItemChapter | undefined)?.visibleContent,
+                    imageData:
+                      updatePayload.imageData ??
+                      (oldItemCopy.chapters?.[0] as ItemChapter | undefined)?.imageData,
                   },
                 ]
               : undefined),


### PR DESCRIPTION
## Summary
- extend `ItemChapter` with `imageData` field
- update parser and save/load validators
- preserve `imageData` when manipulating inventory

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68605e91607883248a2bda80ef9685c8