### PR TITLE
Render chapter images in PageView

### DIFF
--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -304,6 +304,14 @@ function PageView({
     return text;
   }, [showDecoded, item, text, chapterIndex, chapters, isJournal]);
 
+  const currentChapter = useMemo(() => {
+    if (!item) return null;
+    const idx =
+      item.type === 'book' && !isJournal ? chapterIndex - 1 : chapterIndex;
+    if (idx < 0 || idx >= chapters.length) return null;
+    return chapters[idx];
+  }, [item, chapterIndex, chapters, isJournal]);
+
   const pendingWrite = useMemo(
     () => isJournal && isWritingJournal,
     [isJournal, isWritingJournal]
@@ -474,6 +482,14 @@ function PageView({
               variant="toggle"
             />
           </div>
+        ) : null}
+
+        {currentChapter?.imageData && (item?.type === 'picture' || item?.type === 'map') ? (
+          <img
+            alt={currentChapter.description}
+            className="mb-4 self-center max-h-60"
+            src={`data:image/png;base64,${currentChapter.imageData}`}
+          />
         ) : null}
 
         {pendingWrite ? (


### PR DESCRIPTION
## Summary
- add `currentChapter` memo in `PageView`
- render chapter image before the contents with chapter description as alt text
- only show images for `picture` or `map` items
- build `src` from base64 data

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860648584f08324b3b89d2a6dfec6a9