### PR TITLE
Fix chapter image handling

### DIFF
--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -317,7 +317,7 @@ function PageView({
     }
     const chapter = chapters[idx];
     if (chapter.imageData) {
-      setImageUrl(chapter.imageData);
+      setImageUrl(`data:image/jpeg;base64,${chapter.imageData}`);
       return;
     }
     setIsLoading(true);
@@ -325,7 +325,7 @@ function PageView({
       const img = await generateChapterImage(item, currentTheme, idx);
       if (img) {
         updateItemContent(item.id, undefined, undefined, idx, img);
-        setImageUrl(img);
+        setImageUrl(`data:image/jpeg;base64,${img}`);
       }
       setIsLoading(false);
     })();
@@ -350,13 +350,6 @@ function PageView({
     return text;
   }, [showDecoded, item, text, chapterIndex, chapters, isJournal]);
 
-  const currentChapter = useMemo(() => {
-    if (!item) return null;
-    const idx =
-      item.type === 'book' && !isJournal ? chapterIndex - 1 : chapterIndex;
-    if (idx < 0 || idx >= chapters.length) return null;
-    return chapters[idx];
-  }, [item, chapterIndex, chapters, isJournal]);
 
   const pendingWrite = useMemo(
     () => isJournal && isWritingJournal,
@@ -530,13 +523,6 @@ function PageView({
           </div>
         ) : null}
 
-        {currentChapter?.imageData && (item?.type === 'picture' || item?.type === 'map') ? (
-          <img
-            alt={currentChapter.description}
-            className="mb-4 self-center max-h-60"
-            src={`data:image/png;base64,${currentChapter.imageData}`}
-          />
-        ) : null}
 
         {pendingWrite ? (
           <LoadingSpinner loadingReason="journal" />

--- a/services/image/api.ts
+++ b/services/image/api.ts
@@ -80,7 +80,7 @@ export const generateChapterImage = async (
       });
       const bytes = response.generatedImages?.[0]?.image?.imageBytes;
       if (bytes) {
-        return { result: `data:image/jpeg;base64,${bytes}` };
+        return { result: bytes };
       }
     } catch (err: unknown) {
       console.error(`generateChapterImage error (Attempt ${String(attempt + 1)}):`, err);
@@ -100,7 +100,7 @@ export const generateChapterImage = async (
             const inlinePart = candidate?.content?.parts?.find(isInlinePart);
             const inlineData = inlinePart?.inlineData;
             if (inlineData?.data) {
-              return { result: `data:${inlineData.mimeType ?? 'image/png'};base64,${inlineData.data}` };
+              return { result: inlineData.data };
             }
           }
         } catch (fallbackErr: unknown) {


### PR DESCRIPTION
## Summary
- update `generateChapterImage` to return base64 jpeg data
- ensure page images are prefixed with jpeg data URL when displayed
- remove duplicate rendering of chapter images in `PageView`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68606fae42d08324b178466719566ec5