### PR TITLE
Fix save button behaviour on errors

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -568,8 +568,10 @@ function App() {
   }, [closeLoadGameFromMenuConfirm, handleLoadFromFileClick]);
 
   const handleSaveGameFromMenu = useCallback(() => {
-    closeTitleMenu();
-    handleSaveToFile();
+    const success = handleSaveToFile();
+    if (success) {
+      closeTitleMenu();
+    }
   }, [closeTitleMenu, handleSaveToFile]);
 
   const openSettingsFromMenu = useCallback(() => {

--- a/hooks/useSaveLoad.ts
+++ b/hooks/useSaveLoad.ts
@@ -114,18 +114,21 @@ export const useSaveLoad = ({
     setError,
   ]);
 
-  const handleSaveToFile = useCallback(() => {
+  const handleSaveToFile = useCallback((): boolean => {
     if (isLoading || !!dialogueState) {
       setError?.('Cannot save to file while loading or in dialogue.');
-      return;
+      return false;
     }
     if (gatherGameStateStack) {
       const gameState = gatherGameStateStack();
-      saveGameStateToFile(
+      return saveGameStateToFile(
         gameState,
-        setError ? (msg) => { setError(msg); } : undefined,
+        setError ? (msg) => {
+          setError(msg);
+        } : undefined,
       );
     }
+    return false;
   }, [gatherGameStateStack, isLoading, dialogueState, setError]);
 
   const handleLoadFromFileClick = () => {


### PR DESCRIPTION
## Summary
- keep title menu open if saving fails
- return success flag from handleSaveToFile

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68607308da508324a5d69ed258a73e32