### PR TITLE
Separate debug packets from game state

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -69,6 +69,7 @@ function App() {
     chaosLevel,
     setChaosLevel,
     initialSavedState,
+    initialDebugStack,
     appReady,
     fileInputRef,
     handleSaveToFile,
@@ -77,6 +78,7 @@ function App() {
     updateSettingsFromLoad,
   } = useSaveLoad({
     gatherGameStateStack: () => getGameLogic().gatherCurrentGameState(),
+    gatherDebugPacketStack: () => getGameLogic().gatherDebugPacketStack(),
     applyLoadedGameState: (args) => getGameLogic().applyLoadedGameState(args),
     setError: (msg) => { getGameLogic().setError(msg); },
     setIsLoading: (val) => { getGameLogic().setIsLoading(val); },
@@ -154,6 +156,7 @@ function App() {
     chaosLevelProp: chaosLevel,
     onSettingsUpdateFromLoad: updateSettingsFromLoad,
     initialSavedStateFromApp: initialSavedState,
+    initialDebugStackFromApp: initialDebugStack,
     isAppReady: appReady,
     openDebugLoreModal,
   });
@@ -172,7 +175,10 @@ function App() {
     cancelManualShiftThemeSelection,
     isAwaitingManualShiftThemeSelection,
     startCustomGame,
-    gatherCurrentGameState: gatherGameStateStack, hasGameBeenInitialized, handleStartNewGameFromButton,
+    gatherCurrentGameState: gatherGameStateStack,
+    gatherDebugPacketStack,
+    hasGameBeenInitialized,
+    handleStartNewGameFromButton,
     localTime, localEnvironment, localPlace,
     dialogueState,
     handleDialogueOptionSelect,
@@ -184,6 +190,7 @@ function App() {
     globalTurnNumber,
     isCustomGameMode,
     gameStateStack,
+    debugPacketStack,
     handleMapLayoutConfigChange,
     loadingReason,
     handleUndoTurn,
@@ -299,6 +306,7 @@ function App() {
 
   useAutosave({
     gatherGameStateStack,
+    gatherDebugPacketStack,
     isLoading,
     hasGameBeenInitialized,
     appReady,
@@ -852,7 +860,7 @@ function App() {
       <DebugView
         badFacts={debugBadFacts}
         debugLore={debugLore}
-        debugPacket={lastDebugPacket}
+        debugPacket={debugPacketStack[0]}
         gameStateStack={gameStateStack}
         goodFacts={debugGoodFacts}
         isVisible={isDebugViewVisible}

--- a/components/debug/tabs/GameStateTab.tsx
+++ b/components/debug/tabs/GameStateTab.tsx
@@ -21,6 +21,7 @@ function GameStateTab({ currentState, onUndoTurn, onApplyGameState, previousStat
 
   useEffect(() => {
     const sanitized = cloneGameStateWithoutImages(currentState);
+    delete (sanitized as Partial<FullGameState>).lastDebugPacket;
     setEditableText(JSON.stringify(sanitized, null, 2));
   }, [currentState]);
 
@@ -114,7 +115,7 @@ function GameStateTab({ currentState, onUndoTurn, onApplyGameState, previousStat
 
       {previousState ? (
         <DebugSection
-          content={cloneGameStateWithoutImages(previousState)}
+          content={(() => { const tmp = cloneGameStateWithoutImages(previousState); delete (tmp as Partial<FullGameState>).lastDebugPacket; return tmp; })()}
           maxHeightClass="max-h-[30vh]"
           title="Previous Game State (Stack[1] - Bottom)"
         />

--- a/hooks/useAutosave.ts
+++ b/hooks/useAutosave.ts
@@ -3,10 +3,10 @@
  * @description Provides debounced autosave functionality for App.
  */
 import { useEffect, useRef } from 'react';
-import { GameStateStack } from '../types';
+import { GameStateStack, DebugPacketStack } from '../types';
 import {
   saveGameStateToLocalStorage,
-  saveDebugPacketToLocalStorage,
+  saveDebugPacketStackToLocalStorage,
   saveDebugLoreToLocalStorage,
 } from '../services/storage';
 
@@ -14,6 +14,7 @@ export const AUTOSAVE_DEBOUNCE_TIME = 1500;
 
 export interface UseAutosaveOptions {
   readonly gatherGameStateStack: () => GameStateStack;
+  readonly gatherDebugPacketStack: () => DebugPacketStack;
   readonly isLoading: boolean;
   readonly hasGameBeenInitialized: boolean;
   readonly appReady: boolean;
@@ -24,6 +25,7 @@ export interface UseAutosaveOptions {
 
 export function useAutosave({
   gatherGameStateStack,
+  gatherDebugPacketStack,
   isLoading,
   hasGameBeenInitialized,
   appReady,
@@ -44,11 +46,12 @@ export function useAutosave({
     }
     autosaveTimeoutRef.current = window.setTimeout(() => {
       const gameStateStack = gatherGameStateStack();
+      const debugStack = gatherDebugPacketStack();
       saveGameStateToLocalStorage(
         gameStateStack,
         setError ? (msg) => { setError(msg); } : undefined,
       );
-      saveDebugPacketToLocalStorage(gameStateStack[0].lastDebugPacket);
+      saveDebugPacketStackToLocalStorage(debugStack);
       saveDebugLoreToLocalStorage({
         debugLore: gameStateStack[0].debugLore,
         debugGoodFacts: gameStateStack[0].debugGoodFacts,
@@ -63,6 +66,7 @@ export function useAutosave({
     };
   }, [
     gatherGameStateStack,
+    gatherDebugPacketStack,
     isLoading,
     hasGameBeenInitialized,
     appReady,

--- a/hooks/useSaveLoad.ts
+++ b/hooks/useSaveLoad.ts
@@ -3,7 +3,7 @@
  * @description Hook managing save/load operations and related state for App.
  */
 import { useState, useEffect, useCallback, useRef, Dispatch, SetStateAction } from 'react';
-import { FullGameState, ThemePackName, GameStateStack } from '../types';
+import { FullGameState, ThemePackName, GameStateStack, DebugPacketStack } from '../types';
 import {
   saveGameStateToFile,
   loadGameStateFromFile,
@@ -11,8 +11,8 @@ import {
 import {
   saveGameStateToLocalStorage,
   loadGameStateFromLocalStorage,
-  saveDebugPacketToLocalStorage,
-  loadDebugPacketFromLocalStorage,
+  saveDebugPacketStackToLocalStorage,
+  loadDebugPacketStackFromLocalStorage,
   saveDebugLoreToLocalStorage,
   loadDebugLoreFromLocalStorage,
 } from '../services/storage';
@@ -25,6 +25,7 @@ import {
 
 export interface UseSaveLoadOptions {
   gatherGameStateStack?: () => GameStateStack;
+  gatherDebugPacketStack?: () => DebugPacketStack;
   applyLoadedGameState?: (opts: {
     savedStateToLoad: GameStateStack;
     clearImages?: boolean;
@@ -40,6 +41,7 @@ const AUTOSAVE_DEBOUNCE_TIME = 1500;
 
 export const useSaveLoad = ({
   gatherGameStateStack,
+  gatherDebugPacketStack,
   applyLoadedGameState,
   setError,
   setIsLoading,
@@ -52,14 +54,15 @@ export const useSaveLoad = ({
   const [stabilityLevel, setStabilityLevel] = useState<number>(DEFAULT_STABILITY_LEVEL);
   const [chaosLevel, setChaosLevel] = useState<number>(DEFAULT_CHAOS_LEVEL);
   const [initialSavedState, setInitialSavedState] = useState<GameStateStack | null>(null);
+  const [initialDebugStack, setInitialDebugStack] = useState<DebugPacketStack | null>(null);
   const [appReady, setAppReady] = useState(false);
 
   useEffect(() => {
     const loadedState = loadGameStateFromLocalStorage();
-    const loadedDebug = loadDebugPacketFromLocalStorage();
+    const loadedDebug = loadDebugPacketStackFromLocalStorage();
     const loadedDebugLore = loadDebugLoreFromLocalStorage();
     if (loadedState) {
-      if (loadedDebug) loadedState[0].lastDebugPacket = loadedDebug;
+      if (loadedDebug) setInitialDebugStack(loadedDebug);
       if (loadedDebugLore) {
         loadedState[0].debugLore = loadedDebugLore.debugLore;
         loadedState[0].debugGoodFacts = loadedDebugLore.debugGoodFacts;
@@ -92,13 +95,14 @@ export const useSaveLoad = ({
     if (autosaveTimeoutRef.current) clearTimeout(autosaveTimeoutRef.current);
 
     autosaveTimeoutRef.current = window.setTimeout(() => {
-      if (gatherGameStateStack) {
+      if (gatherGameStateStack && gatherDebugPacketStack) {
         const stack = gatherGameStateStack();
+        const debugStack = gatherDebugPacketStack();
         saveGameStateToLocalStorage(
           stack,
           setError ? (msg) => { setError(msg); } : undefined,
         );
-        saveDebugPacketToLocalStorage(stack[0].lastDebugPacket);
+        saveDebugPacketStackToLocalStorage(debugStack);
         saveDebugLoreToLocalStorage({
           debugLore: stack[0].debugLore,
           debugGoodFacts: stack[0].debugGoodFacts,
@@ -110,6 +114,7 @@ export const useSaveLoad = ({
     return () => { if (autosaveTimeoutRef.current) clearTimeout(autosaveTimeoutRef.current); };
   }, [
     gatherGameStateStack,
+    gatherDebugPacketStack,
     isLoading,
     hasGameBeenInitialized,
     appReady,
@@ -122,14 +127,16 @@ export const useSaveLoad = ({
       setError?.('Cannot save to file while loading or in dialogue.');
       return;
     }
-    if (gatherGameStateStack) {
+    if (gatherGameStateStack && gatherDebugPacketStack) {
       const gameState = gatherGameStateStack();
+      const debugStack = gatherDebugPacketStack();
       await saveGameStateToFile(
         gameState,
+        debugStack,
         setError ? msg => { setError(msg); } : undefined,
       );
     }
-  }, [gatherGameStateStack, isLoading, dialogueState, setError]);
+  }, [gatherGameStateStack, gatherDebugPacketStack, isLoading, dialogueState, setError]);
 
   const handleLoadFromFileClick = () => {
     if (isLoading || !!dialogueState) {
@@ -149,8 +156,9 @@ export const useSaveLoad = ({
     if (file) {
       setIsLoading?.(true);
       setError?.(null);
-      const loadedStack = await loadGameStateFromFile(file);
-      if (loadedStack) {
+      const loaded = await loadGameStateFromFile(file);
+      if (loaded) {
+        const { gameStateStack: loadedStack, debugPacketStack: loadedDebug } = loaded;
         const existingLore = loadDebugLoreFromLocalStorage();
         if (existingLore) {
           loadedStack[0].debugLore = existingLore.debugLore;
@@ -167,7 +175,7 @@ export const useSaveLoad = ({
           loadedStack,
           setError ? (msg) => { setError(msg); } : undefined,
         );
-        saveDebugPacketToLocalStorage(loadedStack[0].lastDebugPacket);
+        saveDebugPacketStackToLocalStorage(loadedDebug);
         if (existingLore) {
           saveDebugLoreToLocalStorage(existingLore);
         } else {
@@ -199,6 +207,7 @@ export const useSaveLoad = ({
     chaosLevel,
     setChaosLevel,
     initialSavedState,
+    initialDebugStack,
     appReady,
     fileInputRef,
     handleSaveToFile,

--- a/types.ts
+++ b/types.ts
@@ -656,6 +656,8 @@ export type SavedGameDataShape = Pick<
 
 export type GameStateStack = [FullGameState, FullGameState?];
 
+export type DebugPacketStack = [DebugPacket | null, (DebugPacket | null)?];
+
 export interface SavedGameStack {
   current: SavedGameDataShape;
   previous: SavedGameDataShape | null;


### PR DESCRIPTION
## Summary
- keep debug packets in a dedicated 2-item stack
- persist the new debug packet stack to file and local storage
- pass sanitized game state (without debug packet) to Debug View

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686113afafc48324b20ce1495e3230fb