### PR TITLE
Fix Inspect conditions for items

### DIFF
--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -48,8 +48,8 @@ function InventoryItem({
   registerRef,
 }: InventoryItemProps) {
   const displayDescription = item.isActive && item.activeDescription ? item.activeDescription : item.description;
-  const isWrittenItem =
-    item.type === 'page' || item.type === 'book';
+  const isWrittenItem = item.type === 'page' || item.type === 'book';
+  const isImageItem = item.type === 'picture' || item.type === 'map';
   const canShowGenericUse =
     item.type !== 'status effect' && item.type !== 'vehicle';
   const canEverDrop =
@@ -82,20 +82,24 @@ function InventoryItem({
     );
   });
 
+  const inspectDisabled =
+    disabled ||
+    isConfirmingDiscard ||
+    (isWrittenItem
+      ? item.id === PLAYER_JOURNAL_ID
+        ? (item.chapters?.length ?? 0) === 0
+        : (item.chapters?.some(ch => !ch.actualContent) ?? true)
+      : isImageItem
+        ? (item.chapters?.some(ch => !ch.imageData) ?? true)
+        : false) ||
+    (item.lastInspectTurn !== undefined &&
+      currentTurn - item.lastInspectTurn < INSPECT_COOLDOWN);
+
   actionButtons.push(
     <Button
       ariaLabel={`Inspect ${item.name}`}
       data-item-name={item.name}
-      disabled={
-        disabled ||
-        isConfirmingDiscard ||
-        (isWrittenItem
-          ? item.id === PLAYER_JOURNAL_ID
-            ? (item.chapters?.length ?? 0) === 0
-            : (item.chapters?.some(ch => !ch.actualContent) ?? true)
-          : false) ||
-        (item.lastInspectTurn !== undefined && currentTurn - item.lastInspectTurn < INSPECT_COOLDOWN)
-      }
+      disabled={inspectDisabled}
       key={`${item.name}-inspect`}
       label="Inspect"
       onClick={onInspect}

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -440,7 +440,7 @@ function PageView({
 
         {isBook || isJournal ? (
           <div className="flex justify-center items-center gap-2 mb-2">
-            {onInspect ? (
+            {isJournal && onInspect ? (
               <Button
                 ariaLabel="Inspect"
                 disabled={!canInspectItem}
@@ -525,21 +525,7 @@ function PageView({
           </div>
         ) : null}
 
-        {isPage ? (
-          <div className="flex justify-center items-center gap-2 mb-2">
-            {onInspect ? (
-              <Button
-                ariaLabel="Inspect"
-                disabled={!canInspectItem}
-                label="Inspect"
-                onClick={handleInspectClick}
-                preset="indigo"
-                size="sm"
-                variant="compact"
-              />
-            ) : null}
-          </div>
-        ) : null}
+
 
         {item?.tags?.includes('recovered') ? (
           <div className="flex justify-center">


### PR DESCRIPTION
## Summary
- disable Inspect for maps and pictures until generated
- only allow Inspect button in PageView for the player's journal

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68612c2fed148324bb72757798390004