### PR TITLE
Fix filtering of knownUses

### DIFF
--- a/utils/knownUseUtils.ts
+++ b/utils/knownUseUtils.ts
@@ -27,8 +27,7 @@ export function isBlockedKnownUseText(text: string): boolean {
 }
 
 export function isBlockedKnownUse(ku: KnownUse): boolean {
-  const combined = `${ku.actionName} ${ku.description} ${ku.promptEffect}`;
-  return isBlockedKnownUseText(combined);
+  return isBlockedKnownUseText(ku.actionName);
 }
 
 export function filterBlockedKnownUses(


### PR DESCRIPTION
## Summary
- change the blocked knownUse check to look only at the action name

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68615a66b9f48324aa2d57600db2978d