### PR TITLE
Fix Inspect availability after reload

### DIFF
--- a/hooks/useSaveLoad.ts
+++ b/hooks/useSaveLoad.ts
@@ -11,7 +11,7 @@ import {
 import { clearAllImages } from '../services/imageDb';
 import {
   saveGameStateToLocalStorage,
-  loadGameStateFromLocalStorage,
+  loadGameStateFromLocalStorageWithImages,
   saveDebugPacketStackToLocalStorage,
   loadDebugPacketStackFromLocalStorage,
   saveDebugLoreToLocalStorage,
@@ -59,26 +59,28 @@ export const useSaveLoad = ({
   const [appReady, setAppReady] = useState(false);
 
   useEffect(() => {
-    const loadedState = loadGameStateFromLocalStorage();
-    const loadedDebug = loadDebugPacketStackFromLocalStorage();
-    const loadedDebugLore = loadDebugLoreFromLocalStorage();
-    if (loadedState) {
-      if (loadedDebug) setInitialDebugStack(loadedDebug);
-      if (loadedDebugLore) {
-        loadedState[0].debugLore = loadedDebugLore.debugLore;
-        loadedState[0].debugGoodFacts = loadedDebugLore.debugGoodFacts;
-        loadedState[0].debugBadFacts = loadedDebugLore.debugBadFacts;
+    void (async () => {
+      const loadedState = await loadGameStateFromLocalStorageWithImages();
+      const loadedDebug = loadDebugPacketStackFromLocalStorage();
+      const loadedDebugLore = loadDebugLoreFromLocalStorage();
+      if (loadedState) {
+        if (loadedDebug) setInitialDebugStack(loadedDebug);
+        if (loadedDebugLore) {
+          loadedState[0].debugLore = loadedDebugLore.debugLore;
+          loadedState[0].debugGoodFacts = loadedDebugLore.debugGoodFacts;
+          loadedState[0].debugBadFacts = loadedDebugLore.debugBadFacts;
+        }
+        const current = loadedState[0];
+        setPlayerGender(current.playerGender);
+        setEnabledThemePacks(current.enabledThemePacks);
+        setStabilityLevel(current.stabilityLevel);
+        setChaosLevel(current.chaosLevel);
+        setInitialSavedState(loadedState);
+      } else {
+        setInitialSavedState(null);
       }
-      const current = loadedState[0];
-      setPlayerGender(current.playerGender);
-      setEnabledThemePacks(current.enabledThemePacks);
-      setStabilityLevel(current.stabilityLevel);
-      setChaosLevel(current.chaosLevel);
-      setInitialSavedState(loadedState);
-    } else {
-      setInitialSavedState(null);
-    }
-    setAppReady(true);
+      setAppReady(true);
+    })();
   }, []);
 
   const updateSettingsFromLoad = useCallback((loadedSettings: Partial<Pick<FullGameState, 'playerGender' | 'enabledThemePacks' | 'stabilityLevel' | 'chaosLevel'>>) => {

--- a/services/imageDb.ts
+++ b/services/imageDb.ts
@@ -110,3 +110,34 @@ export const expandRefsToImages = async (
   );
   return cloned;
 };
+
+export const attachImageRefsFromDb = async (
+  state: FullGameState,
+): Promise<FullGameState> => {
+  const cloned = structuredCloneGameState(state);
+  await Promise.all(
+    cloned.inventory.map(async item => {
+      await Promise.all(
+        item.chapters?.map(async (ch, idx) => {
+          if (!ch.imageData) {
+            const existing = await loadChapterImage(item.id, idx);
+            if (existing) {
+              ch.imageData = makeImageRef(item.id, idx);
+            }
+          }
+        }) ?? [],
+      );
+    }),
+  );
+  await Promise.all(
+    cloned.playerJournal.map(async (ch, idx) => {
+      if (!ch.imageData) {
+        const existing = await loadChapterImage(PLAYER_JOURNAL_ID, idx);
+        if (existing) {
+          ch.imageData = makeImageRef(PLAYER_JOURNAL_ID, idx);
+        }
+      }
+    }),
+  );
+  return cloned;
+};

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -72,6 +72,16 @@ export const loadGameStateFromLocalStorage = (): GameStateStack | null => {
   }
 };
 
+export const loadGameStateFromLocalStorageWithImages = async (): Promise<GameStateStack | null> => {
+  const loaded = loadGameStateFromLocalStorage();
+  if (!loaded) return null;
+  const [current, previous] = loaded;
+  const { attachImageRefsFromDb } = await import('./imageDb');
+  const withImagesCurrent = await attachImageRefsFromDb(current);
+  const withImagesPrevious = previous ? await attachImageRefsFromDb(previous) : undefined;
+  return [withImagesCurrent, withImagesPrevious];
+};
+
 export const saveDebugPacketStackToLocalStorage = (
   stack: DebugPacketStack,
 ): void => {

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import 'fake-indexeddb/auto';
 import {
   buildNewGameFirstTurnPrompt,
   parseAIResponse,

--- a/tests/imageStorage.test.ts
+++ b/tests/imageStorage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import 'fake-indexeddb/auto';
 import { LOCAL_STORAGE_SAVE_KEY } from '../constants';
-import { saveGameStateToLocalStorage } from '../services/storage';
+import { saveGameStateToLocalStorage, loadGameStateFromLocalStorageWithImages } from '../services/storage';
 import { saveChapterImage, loadChapterImage } from '../services/imageDb';
 import { getInitialGameStates } from '../utils/initialStates';
 import type { FullGameState } from '../types';
@@ -66,5 +66,23 @@ describe('image storage', () => {
     await saveChapterImage('itemX', 0, 'imgdata');
     const data = await loadChapterImage('itemX', 0);
     expect(data).toBe('imgdata');
+  });
+
+  it('restores image refs when loading from localStorage', async () => {
+    const state: FullGameState = getInitialGameStates();
+    state.inventory.push({
+      id: 'pic1',
+      name: 'Picture',
+      type: 'picture',
+      description: 'd',
+      holderId: 'player',
+      chapters: [
+        { heading: 'h', description: 'd', contentLength: 1 },
+      ],
+    });
+    await saveChapterImage('pic1', 0, 'imgdata');
+    saveGameStateToLocalStorage([state, undefined]);
+    const loaded = await loadGameStateFromLocalStorageWithImages();
+    expect(loaded?.[0].inventory[0].chapters?.[0].imageData).toBe('idb:pic1_0');
   });
 });


### PR DESCRIPTION
## Summary
- add `attachImageRefsFromDb` helper to restore image refs
- expose `loadGameStateFromLocalStorageWithImages` using the helper
- ensure save/load hook loads images before setting initial state
- update tests for indexedDB usage and add coverage for image restore

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68616599e3488324bd29686398e3baaa