### PR TITLE
Fix cartographer splitFamily schema

### DIFF
--- a/services/cartographer/request.ts
+++ b/services/cartographer/request.ts
@@ -197,7 +197,7 @@ export const MAP_UPDATE_JSON_SCHEMA = {
       type: 'object',
       properties: {
         originalNodeId: { type: 'string', description: `The nodeId to be split into two nodes.` },
-        newNodeName: { type: 'string', description: `The new node Name` },
+        newNodeId: { type: 'string', description: `The new node ID` },
         newNodeType: { enum: VALID_NODE_TYPE_VALUES, description: `One of ${VALID_NODE_TYPE_STRING}` },
         newConnectorNodeId: { type: 'string', description: `The nodeId of the node that will recieve the old external edge.`},
         originalChildren: { type: 'array', items: { type: 'string' }, minItems: 1, description: `nodeIds of the nodes that remain with the old parent node.` },


### PR DESCRIPTION
## Summary
- revert splitFamily `newNodeName` field back to `newNodeId`
- this fixes cartographer request validation and prevents 500 errors

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686193ac2ff08324896f03971b961173