### PR TITLE
Remove splitFamily processing

### DIFF
--- a/services/cartographer/mapUpdateUtils.ts
+++ b/services/cartographer/mapUpdateUtils.ts
@@ -1,7 +1,5 @@
-import type { AIMapUpdatePayload, MapNodeData } from '../../types';
-import { VALID_NODE_TYPE_VALUES } from '../../constants';
+import type { AIMapUpdatePayload } from '../../types';
 import {
-  NODE_TYPE_SYNONYMS,
   NODE_REMOVAL_SYNONYMS,
   EDGE_REMOVAL_SYNONYMS,
 } from '../../utils/mapSynonyms';
@@ -101,15 +99,6 @@ export function normalizeStatusAndTypeSynonyms(payload: AIMapUpdatePayload): Arr
   (payload.edgesToAdd ?? []).forEach((e, idx) => { applyEdgeDataFix(e.data, errors, `edgesToAdd[${String(idx)}]`); });
   (payload.edgesToUpdate ?? []).forEach((e, idx) => { applyEdgeDataFix(e.newData, errors, `edgesToUpdate[${String(idx)}].newData`); });
 
-  if (payload.splitFamily) {
-    const mapped = (NODE_TYPE_SYNONYMS as Record<string, MapNodeData['nodeType'] | undefined>)[
-      payload.splitFamily.newNodeType.toLowerCase()
-    ];
-    if (mapped) payload.splitFamily.newNodeType = mapped;
-    if (!VALID_NODE_TYPE_VALUES.includes(payload.splitFamily.newNodeType)) {
-      errors.push(`splitFamily.newNodeType invalid "${payload.splitFamily.newNodeType}"`);
-    }
-  }
 
   return errors;
 }

--- a/services/cartographer/mapUpdateValidation.ts
+++ b/services/cartographer/mapUpdateValidation.ts
@@ -251,17 +251,6 @@ function isValidAIEdgeRemovalInternal(edgeRemove: unknown): boolean {
   return true;
 }
 
-function isValidSplitFamilyOperationInternal(op: unknown): boolean {
-  if (typeof op !== 'object' || op === null) return false;
-  const o = op as Record<string, unknown>;
-  if (typeof o.originalNodeId !== 'string' || o.originalNodeId.trim() === '') return false;
-  if (typeof o.newNodeId !== 'string' || o.newNodeId.trim() === '') return false;
-  if (typeof o.newConnectorNodeId !== 'string' || o.newConnectorNodeId.trim() === '') return false;
-  if (typeof o.newNodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(o.newNodeType as MapNodeData['nodeType'])) return false;
-  if (!Array.isArray(o.originalChildren) || !o.originalChildren.every(id => typeof id === 'string')) return false;
-  if (!Array.isArray(o.newChildren) || !o.newChildren.every(id => typeof id === 'string')) return false;
-  return true;
-}
 
 /**
  * Validates a full AIMapUpdatePayload object received from the map AI service.
@@ -307,12 +296,6 @@ export function isValidAIMapUpdatePayload(payload: AIMapUpdatePayload | null): p
   if (payload.suggestedCurrentMapNodeId != null && typeof payload.suggestedCurrentMapNodeId !== 'string') {
     console.warn("Validation Error (AIMapUpdatePayload): 'suggestedCurrentMapNodeId' must be a string or null if present. Value:", payload.suggestedCurrentMapNodeId);
     return false;
-  }
-  if (payload.splitFamily != null) {
-    if (!isValidSplitFamilyOperationInternal(payload.splitFamily)) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'splitFamily' is invalid.");
-      return false;
-    }
   }
   return true;
 }

--- a/services/cartographer/refineConnectorChains.ts
+++ b/services/cartographer/refineConnectorChains.ts
@@ -2,7 +2,6 @@ import { generateUniqueId, findMapNodeByIdentifier } from '../../utils/entityUti
 import { isEdgeConnectionAllowed, addEdgeWithTracking } from './edgeUtils';
 import { buildChainRequest, filterEdgeChainRequests } from './connectorChains';
 import { fetchConnectorChains_Service } from '../corrections/edgeFixes';
-import { resolveSplitFamilyOrphans_Service } from '../corrections/hierarchyUpgrade';
 import { MAX_RETRIES, MAX_CHAIN_REFINEMENT_ROUNDS } from '../../constants';
 import type { MapNode } from '../../types';
 import type { ConnectorChainsServiceResult, EdgeChainRequest } from '../corrections/edgeFixes';
@@ -141,53 +140,4 @@ export async function refineConnectorChains(ctx: ApplyUpdatesContext): Promise<v
     ctx.debugInfo.connectorChainsDebugInfo = null;
   }
 
-  if (ctx.payload.splitFamily) {
-    const sf = ctx.payload.splitFamily;
-    const originalParent = ctx.themeNodeIdMap.get(sf.originalNodeId);
-    const newParent = ctx.themeNodeIdMap.get(sf.newNodeId);
-    const connector = ctx.themeNodeIdMap.get(sf.newConnectorNodeId);
-    if (originalParent && newParent && connector) {
-      newParent.data.nodeType = sf.newNodeType;
-      newParent.data.parentNodeId = originalParent.data.parentNodeId;
-      connector.data.parentNodeId = newParent.id;
-      ctx.newMapData.edges.forEach(edge => {
-        if (edge.sourceNodeId === newParent.id) edge.sourceNodeId = connector.id;
-        if (edge.targetNodeId === newParent.id) edge.targetNodeId = connector.id;
-      });
-      const originalSet = new Set(sf.originalChildren);
-      const newSet = new Set(sf.newChildren);
-      const orphans: Array<MapNode> = [];
-      ctx.newMapData.nodes.forEach(n => {
-        if (n.data.parentNodeId === originalParent.id && n.id !== newParent.id && n.id !== connector.id) {
-          if (newSet.has(n.id)) {
-            n.data.parentNodeId = newParent.id;
-          } else if (originalSet.has(n.id)) {
-            n.data.parentNodeId = originalParent.id;
-          } else {
-            orphans.push(n);
-          }
-        }
-      });
-      if (orphans.length > 0) {
-        const resolution = await resolveSplitFamilyOrphans_Service({
-          sceneDescription: ctx.sceneDesc,
-          logMessage: ctx.logMsg,
-          originalParent,
-          newParent,
-          orphanNodes: orphans,
-          currentTheme: ctx.currentTheme,
-        });
-        resolution.originalChildren.forEach(id => {
-          const node = ctx.themeNodeIdMap.get(id);
-          if (node) node.data.parentNodeId = originalParent.id;
-        });
-        resolution.newChildren.forEach(id => {
-          const node = ctx.themeNodeIdMap.get(id);
-          if (node) node.data.parentNodeId = newParent.id;
-        });
-      }
-    } else {
-      console.warn('splitFamily references unknown node ids');
-    }
-  }
 }

--- a/services/cartographer/request.ts
+++ b/services/cartographer/request.ts
@@ -193,26 +193,6 @@ export const MAP_UPDATE_JSON_SCHEMA = {
         additionalProperties: false,
       },
     },
-    splitFamily: {
-      type: 'object',
-      properties: {
-        originalNodeId: { type: 'string', description: `The nodeId to be split into two nodes.` },
-        newNodeId: { type: 'string', description: `The new node ID` },
-        newNodeType: { enum: VALID_NODE_TYPE_VALUES, description: `One of ${VALID_NODE_TYPE_STRING}` },
-        newConnectorNodeId: { type: 'string', description: `The nodeId of the node that will recieve the old external edge.`},
-        originalChildren: { type: 'array', items: { type: 'string' }, minItems: 1, description: `nodeIds of the nodes that remain with the old parent node.` },
-        newChildren: { type: 'array', items: { type: 'string' }, minItems: 1, description: `nodeIds of the nodes that migrate to the new parent node.` },
-      },
-      required: [
-        'originalNodeId',
-        'newNodeId',
-        'newNodeType',
-        'newConnectorNodeId',
-        'originalChildren',
-        'newChildren',
-      ],
-      additionalProperties: false,
-    },
     suggestedCurrentMapNodeId: {
       type: 'string',
       description:

--- a/services/cartographer/responseParser.ts
+++ b/services/cartographer/responseParser.ts
@@ -81,9 +81,6 @@ export const parseAIMapUpdateResponse = (
           ) {
             acc.suggestedCurrentMapNodeId = maybeObj.suggestedCurrentMapNodeId;
           }
-          if (maybeObj.splitFamily && !acc.splitFamily) {
-            acc.splitFamily = maybeObj.splitFamily;
-          }
           if (maybeObj.observations && !acc.observations) {
             acc.observations = maybeObj.observations;
           }

--- a/types.ts
+++ b/types.ts
@@ -458,15 +458,6 @@ export interface AINodeUpdate {
   initialPosition?: { x: number; y: number };
 }
 
-export interface AISplitFamilyOperation {
-  originalNodeId: string;
-  newNodeId: string;
-  newNodeType: MapNodeData['nodeType'];
-  newConnectorNodeId: string;
-  originalChildren: Array<string>;
-  newChildren: Array<string>;
-}
-
 export interface AIMapUpdatePayload {
   // parentNodeId is mandatory for each entry in nodesToAdd. The value is a NAME
   // of the intended parent node (use "Universe" for the root node).
@@ -485,7 +476,6 @@ export interface AIMapUpdatePayload {
   edgesToUpdate?: Array<AIEdgeUpdate> | null;
   edgesToRemove?: Array<{ edgeId: string; sourceId?: string; targetId?: string; }> | null;
   suggestedCurrentMapNodeId?: string | null | undefined;
-  splitFamily?: AISplitFamilyOperation | null | undefined;
 }
 // --- End Map Update Service Payload ---
 


### PR DESCRIPTION
## Summary
- eliminate unused splitFamily fields and logic in cartographer services
- drop resolveSplitFamilyOrphans service
- update schema and utilities after removal

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686197bd7e948324a9fe3ec7e6a3de02