### PR TITLE
Allow dialogue prompts to omit map node IDs

### DIFF
--- a/services/dialogue/promptBuilder.ts
+++ b/services/dialogue/promptBuilder.ts
@@ -68,7 +68,11 @@ export const buildDialogueTurnPrompt = (
       inventory.length > 0
         ? inventory.map(item => `${item.name} (Type: ${item.type}, Active: ${String(!!item.isActive)})`).join(', ')
         : 'Empty';
-  const knownPlacesString = formatKnownPlacesForPrompt(knownMainMapNodesInTheme, true);
+  const knownPlacesString = formatKnownPlacesForPrompt(
+    knownMainMapNodesInTheme,
+    true,
+    false,
+  );
 
   let npcContextString = '### Known NPCs: ';
   if (knownNPCsInTheme.length > 0) {
@@ -152,8 +156,11 @@ export const buildDialogueSummaryPrompt = (
       ? summaryContext.inventory.map(item => `${item.name} (Type: ${item.type})`).join(', ')
       : 'Empty';
   const knownPlacesString = formatKnownPlacesForPrompt(
-    summaryContext.mapDataForTheme.nodes.filter(n => n.data.nodeType !== 'feature'),
+    summaryContext.mapDataForTheme.nodes.filter(
+      n => n.data.nodeType !== 'feature',
+    ),
     true,
+    false,
   );
 
   let knownNPCsString = 'Known NPCs: ';

--- a/tests/formatKnownPlacesForPrompt.test.ts
+++ b/tests/formatKnownPlacesForPrompt.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { formatKnownPlacesForPrompt } from '../utils/promptFormatters/map';
+import type { MapNode } from '../types';
+
+const baseNodes: Array<MapNode> = [
+  {
+    id: 'loc1',
+    themeName: 'theme',
+    placeName: 'Town',
+    position: { x: 0, y: 0 },
+    data: { description: 'Desc', status: 'discovered', nodeType: 'location' },
+  },
+  {
+    id: 'loc2',
+    themeName: 'theme',
+    placeName: 'Forest',
+    position: { x: 0, y: 0 },
+    data: { description: 'Trees', status: 'discovered', nodeType: 'location' },
+  },
+];
+
+describe('formatKnownPlacesForPrompt', () => {
+  it('includes IDs by default', () => {
+    const result = formatKnownPlacesForPrompt(baseNodes, false);
+    expect(result).toBe('loc1 - "Town", loc2 - "Forest".');
+  });
+
+  it('omits IDs when includeIds is false', () => {
+    const result = formatKnownPlacesForPrompt(baseNodes, false, false);
+    expect(result).toBe('"Town", "Forest".');
+  });
+});

--- a/utils/promptFormatters/map.ts
+++ b/utils/promptFormatters/map.ts
@@ -189,7 +189,8 @@ export const formatObservationsForPrompt = (observations?: string): string => {
  */
 export const formatKnownPlacesForPrompt = (
   mapNodes: Array<MapNode>,
-  detailed = false
+  detailed = false,
+  includeIds = true
 ): string => {
   const mainNodes = mapNodes.filter(
     node => node.data.nodeType !== 'feature' && node.data.nodeType !== 'room'
@@ -201,7 +202,11 @@ export const formatKnownPlacesForPrompt = (
     return (
       mainNodes
         .map(node => {
-          let detailStr = ` - ${node.id} - "${node.placeName}"`;
+          let detailStr = ' - ';
+          if (includeIds) {
+            detailStr += `${node.id} - `;
+          }
+          detailStr += `"${node.placeName}"`;
           if (node.data.aliases && node.data.aliases.length > 0) {
             detailStr += ` (aka ${node.data.aliases.map(a => `"${a}"`).join(', ')})`;
           }
@@ -215,7 +220,11 @@ export const formatKnownPlacesForPrompt = (
   return (
     mainNodes
       .map(node => {
-        let detailStr = `${node.id} - "${node.placeName}"`;
+        let detailStr = '';
+        if (includeIds) {
+          detailStr += `${node.id} - `;
+        }
+        detailStr += `"${node.placeName}"`;
         if (node.data.aliases && node.data.aliases.length > 0) {
           detailStr += ` (aka ${node.data.aliases.map(a => `"${a}"`).join(', ')})`;
         }


### PR DESCRIPTION
## Summary
- allow `formatKnownPlacesForPrompt` to optionally omit node IDs
- update dialogue prompt builder to use this option
- add unit tests for `formatKnownPlacesForPrompt`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68619ca1a4388324bed9f6a90c196b2e