### PR TITLE
Fix loading spinner reason handling

### DIFF
--- a/hooks/useMapUpdateProcessor.ts
+++ b/hooks/useMapUpdateProcessor.ts
@@ -2,7 +2,7 @@
  * @file useMapUpdateProcessor.ts
  * @description Hook that processes map updates from AI responses.
  */
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   GameStateFromAI,
   AdventureTheme,
@@ -26,6 +26,12 @@ export const useMapUpdateProcessor = ({
   setLoadingReason,
   setError,
 }: UseMapUpdateProcessorProps) => {
+  const loadingReasonRef = useRef<LoadingReason | null>(loadingReason);
+
+  useEffect(() => {
+    loadingReasonRef.current = loadingReason;
+  }, [loadingReason]);
+
   const processMapUpdates = useCallback(
     async (
       aiData: GameStateFromAI,
@@ -40,7 +46,7 @@ export const useMapUpdateProcessor = ({
           draftState,
           baseStateSnapshot,
           themeContext,
-          loadingReason,
+          loadingReasonRef.current,
           setLoadingReason,
           turnChanges,
         );
@@ -49,7 +55,7 @@ export const useMapUpdateProcessor = ({
         throw err;
       }
     },
-    [loadingReason, setLoadingReason, setError],
+    [setLoadingReason, setError],
   );
 
   return { processMapUpdates };

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   AdventureTheme,
   FullGameState,
@@ -315,6 +315,11 @@ export const useProcessAiResponse = ({
   });
 
   const objectiveAnimationClearTimerRef = useRef<number | null>(null);
+  const loadingReasonRef = useRef<LoadingReason | null>(loadingReason);
+
+  useEffect(() => {
+    loadingReasonRef.current = loadingReason;
+  }, [loadingReason]);
 
   const clearObjectiveAnimationTimer = useCallback(() => {
     if (objectiveAnimationClearTimerRef.current) {
@@ -445,7 +450,7 @@ export const useProcessAiResponse = ({
         theme: themeContextForResponse,
         baseState: baseStateSnapshot,
         playerActionText,
-        loadingReason,
+        loadingReason: loadingReasonRef.current,
         setLoadingReason,
       });
 
@@ -466,7 +471,7 @@ export const useProcessAiResponse = ({
           baseState: baseStateSnapshot,
           correctedItemChanges: correctedAndVerifiedItemChanges,
           playerActionText,
-          loadingReason,
+          loadingReason: loadingReasonRef.current,
           setLoadingReason,
         });
 
@@ -591,7 +596,7 @@ export const useProcessAiResponse = ({
         ].join('\n');
 
         const contextParts = `${baseContext}\n${idsContext}`;
-        const original = loadingReason;
+        const original = loadingReasonRef.current;
         const refineResult = await refineLore_Service({
           themeName: themeContextForResponse.name,
           turnContext: contextParts,
@@ -633,7 +638,6 @@ export const useProcessAiResponse = ({
       draftState.lastTurnChanges = turnChanges;
     },
     [
-      loadingReason,
       setLoadingReason,
       setError,
       setGameStateStack,


### PR DESCRIPTION
## Summary
- keep track of current `loadingReason` via refs so async tasks don't reset it
- pass the latest reason to map updates and inventory helpers

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861a465934883249bdb26192dc02b72