### PR TITLE
Fix loading spinner reason handling

### DIFF
--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -54,6 +54,11 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [loadingReason, setLoadingReason] = useState<LoadingReason>(null);
+  const loadingReasonRef = useRef<LoadingReason | null>(loadingReason);
+  const setLoadingReasonRef = useCallback((reason: LoadingReason | null) => {
+    loadingReasonRef.current = reason;
+    setLoadingReason(reason);
+  }, []);
   const [error, setError] = useState<string | null>(null);
   const [parseErrorCounter, setParseErrorCounter] = useState<number>(0);
   void parseErrorCounter;
@@ -131,7 +136,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setError,
-    setLoadingReason,
+    setLoadingReason: setLoadingReasonRef,
     isLoading,
   });
 
@@ -181,7 +186,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setIsLoading,
-    setLoadingReason,
+    setLoadingReason: setLoadingReasonRef,
     setError,
     setParseErrorCounter,
     triggerRealityShift,
@@ -190,7 +195,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     setFreeFormActionText,
     isLoading,
     hasGameBeenInitialized,
-    loadingReason,
+    loadingReasonRef,
     debugLore: currentSnapshot.debugLore,
     openDebugLoreModal,
   });
@@ -207,7 +212,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setIsLoading,
-    setLoadingReason,
+    setLoadingReason: setLoadingReasonRef,
     setError,
     setParseErrorCounter,
     setHasGameBeenInitialized,
@@ -227,7 +232,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason,
+    setLoadingReason: setLoadingReasonRef,
     onDialogueConcluded: (summaryPayload, preparedGameState, debugInfo) => {
       const draftState = structuredCloneGameState(preparedGameState);
       processAiResponse(summaryPayload, preparedGameState.currentThemeObject, draftState, {
@@ -255,13 +260,13 @@ export const useGameLogic = (props: UseGameLogicProps) => {
         draftState.lastDebugPacket.dialogueDebugInfo = debugInfo;
         commitGameState(draftState);
         setIsLoading(false);
-        setLoadingReason(null);
+        setLoadingReasonRef(null);
       }).catch((e: unknown) => {
         console.error('Error in post-dialogue processAiResponse:', e);
         setError('Failed to fully process dialogue conclusion. Game state might be inconsistent.');
         commitGameState(preparedGameState);
         setIsLoading(false);
-        setLoadingReason(null);
+        setLoadingReasonRef(null);
       });
     },
   });
@@ -364,7 +369,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
       ),
     );
     const mapNodeNames = currentThemeNodes.map(n => n.placeName);
-    setLoadingReason('loremaster_refine');
+    setLoadingReasonRef('loremaster_refine');
     const result = await distillFacts_Service({
       themeName: themeObj.name,
       facts: currentFullState.themeFacts,
@@ -399,8 +404,8 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     }
     commitGameState(draftState);
     setIsLoading(false);
-    setLoadingReason(null);
-  }, [commitGameState, getCurrentGameState, setError, setIsLoading, setLoadingReason]);
+    setLoadingReasonRef(null);
+  }, [commitGameState, getCurrentGameState, setError, setIsLoading, setLoadingReasonRef]);
 
   useEffect(() => {
     if (

--- a/hooks/useMapUpdateProcessor.ts
+++ b/hooks/useMapUpdateProcessor.ts
@@ -3,6 +3,7 @@
  * @description Hook that processes map updates from AI responses.
  */
 import { useCallback } from 'react';
+import * as React from 'react';
 import {
   GameStateFromAI,
   AdventureTheme,
@@ -13,7 +14,7 @@ import {
 import { handleMapUpdates } from '../utils/mapUpdateHandlers';
 
 export interface UseMapUpdateProcessorProps {
-  loadingReason: LoadingReason | null;
+  loadingReasonRef: React.RefObject<LoadingReason | null>;
   setLoadingReason: (reason: LoadingReason | null) => void;
   setError: (err: string | null) => void;
 }
@@ -22,10 +23,11 @@ export interface UseMapUpdateProcessorProps {
  * Provides a helper for applying map updates while managing error state.
  */
 export const useMapUpdateProcessor = ({
-  loadingReason,
+  loadingReasonRef,
   setLoadingReason,
   setError,
 }: UseMapUpdateProcessorProps) => {
+
   const processMapUpdates = useCallback(
     async (
       aiData: GameStateFromAI,
@@ -40,7 +42,7 @@ export const useMapUpdateProcessor = ({
           draftState,
           baseStateSnapshot,
           themeContext,
-          loadingReason,
+          loadingReasonRef.current,
           setLoadingReason,
           turnChanges,
         );
@@ -49,7 +51,7 @@ export const useMapUpdateProcessor = ({
         throw err;
       }
     },
-    [loadingReason, setLoadingReason, setError],
+    [loadingReasonRef, setLoadingReason, setError],
   );
 
   return { processMapUpdates };

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -4,6 +4,7 @@
  */
 
 import { useCallback } from 'react';
+import * as React from 'react';
 import {
   KnownUse,
   Item,
@@ -43,6 +44,7 @@ export interface UsePlayerActionsProps {
   chaosLevelProp: number;
   setIsLoading: (val: boolean) => void;
   setLoadingReason: (reason: LoadingReason | null) => void;
+  loadingReasonRef: React.RefObject<LoadingReason | null>;
   setError: (err: string | null) => void;
   setParseErrorCounter: (val: number) => void;
   triggerRealityShift: (isChaosShift?: boolean) => void;
@@ -51,7 +53,6 @@ export interface UsePlayerActionsProps {
   setFreeFormActionText: (text: string) => void;
   isLoading: boolean;
   hasGameBeenInitialized: boolean;
-  loadingReason: LoadingReason | null;
   debugLore: boolean;
   openDebugLoreModal: (
     facts: Array<string>,
@@ -80,13 +81,13 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     setFreeFormActionText,
     isLoading,
     hasGameBeenInitialized,
-    loadingReason,
+    loadingReasonRef,
     debugLore,
     openDebugLoreModal,
   } = props;
 
   const { processAiResponse, clearObjectiveAnimationTimer } = useProcessAiResponse({
-    loadingReason,
+    loadingReasonRef,
     setLoadingReason,
     setError,
     setGameStateStack,

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from 'react';
+import * as React from 'react';
 import {
   AdventureTheme,
   FullGameState,
@@ -289,7 +290,7 @@ export type ProcessAiResponseFn = (
 ) => Promise<void>;
 
 export interface UseProcessAiResponseProps {
-  loadingReason: LoadingReason | null;
+  loadingReasonRef: React.RefObject<LoadingReason | null>;
   setLoadingReason: (reason: LoadingReason | null) => void;
   setError: (err: string | null) => void;
   setGameStateStack: React.Dispatch<React.SetStateAction<GameStateStack>>;
@@ -301,7 +302,7 @@ export interface UseProcessAiResponseProps {
 }
 
 export const useProcessAiResponse = ({
-  loadingReason,
+  loadingReasonRef,
   setLoadingReason,
   setError,
   setGameStateStack,
@@ -309,7 +310,7 @@ export const useProcessAiResponse = ({
   openDebugLoreModal,
 }: UseProcessAiResponseProps) => {
   const { processMapUpdates } = useMapUpdateProcessor({
-    loadingReason,
+    loadingReasonRef,
     setLoadingReason,
     setError,
   });
@@ -445,7 +446,7 @@ export const useProcessAiResponse = ({
         theme: themeContextForResponse,
         baseState: baseStateSnapshot,
         playerActionText,
-        loadingReason,
+        loadingReason: loadingReasonRef.current,
         setLoadingReason,
       });
 
@@ -466,7 +467,7 @@ export const useProcessAiResponse = ({
           baseState: baseStateSnapshot,
           correctedItemChanges: correctedAndVerifiedItemChanges,
           playerActionText,
-          loadingReason,
+          loadingReason: loadingReasonRef.current,
           setLoadingReason,
         });
 
@@ -591,7 +592,7 @@ export const useProcessAiResponse = ({
         ].join('\n');
 
         const contextParts = `${baseContext}\n${idsContext}`;
-        const original = loadingReason;
+        const original = loadingReasonRef.current;
         const refineResult = await refineLore_Service({
           themeName: themeContextForResponse.name,
           turnContext: contextParts,
@@ -633,7 +634,7 @@ export const useProcessAiResponse = ({
       draftState.lastTurnChanges = turnChanges;
     },
     [
-      loadingReason,
+      loadingReasonRef,
       setLoadingReason,
       setError,
       setGameStateStack,


### PR DESCRIPTION
## Summary
- keep latest `loadingReason` in a ref and update it immediately when changing state
- pass the ref through player action and AI response hooks to avoid stale values during async work

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861a465934883249bdb26192dc02b72