### PR TITLE
Refactor spinner to use global loading state

### DIFF
--- a/components/DialogueDisplay.tsx
+++ b/components/DialogueDisplay.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useMemo, useCallback } from 'react';
 
 import * as React from 'react';
-import { DialogueHistoryEntry, Item, NPC, MapNode, LoadingReason } from '../types';
+import { DialogueHistoryEntry, Item, NPC, MapNode } from '../types';
 import { highlightEntitiesInText, buildHighlightableEntities } from '../utils/highlightHelper';
 import LoadingSpinner from './LoadingSpinner';
 import ModelUsageIndicators from './ModelUsageIndicators';
@@ -26,7 +26,6 @@ interface DialogueDisplayProps {
   readonly mapData: Array<MapNode>; 
   readonly allNPCs: Array<NPC>;
   readonly currentThemeName: string | null;
-  readonly loadingReason: LoadingReason | null; // Added prop
 }
 
 /**
@@ -45,7 +44,6 @@ function DialogueDisplay({
   mapData,
   allNPCs: allNPCs,
   currentThemeName,
-  loadingReason, // Destructure prop
 }: DialogueDisplayProps) {
   const dialogueFrameRef = useRef<HTMLDivElement | null>(null); 
   const lastHistoryEntryRef = useRef<HTMLDivElement | null>(null);
@@ -95,7 +93,7 @@ function DialogueDisplay({
 
   const renderOptionsArea = () => {
     if (isDialogueExiting || isLoading) {
-      return <LoadingSpinner loadingReason={loadingReason} />;
+      return <LoadingSpinner />;
     }
 
     if (options.length > 0) {

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -3,18 +3,15 @@
  * @file LoadingSpinner.tsx
  * @description Loading spinner indicating in-progress actions.
  */
-import { LoadingReason } from '../types';
 import { LOADING_REASON_UI_MAP } from '../constants';
 import { useLoadingProgress } from '../hooks/useLoadingProgress';
-
-interface LoadingSpinnerProps {
-  readonly loadingReason: LoadingReason | null;
-}
+import { useLoadingReason } from '../hooks/useLoadingReason';
 
 /**
  * Displays a spinner with a reason message while the game is busy.
  */
-function LoadingSpinner({ loadingReason = null }: LoadingSpinnerProps) {
+function LoadingSpinner() {
+  const loadingReason = useLoadingReason();
   const { progress, retryCount } = useLoadingProgress();
   const spinnerBaseClass = "rounded-full h-16 w-16 border-t-4 border-b-4";
   const spinnerClass = `${spinnerBaseClass} animate-spin border-sky-600`;

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -192,7 +192,6 @@ function App() {
     gameStateStack,
     debugPacketStack,
     handleMapLayoutConfigChange,
-    loadingReason,
     handleUndoTurn,
     destinationNodeId,
     handleSelectDestinationNode,
@@ -696,7 +695,7 @@ function App() {
   if (!appReady) {
     return (
       <div className="min-h-screen bg-slate-900 text-slate-200 flex flex-col items-center justify-center p-4">
-        <LoadingSpinner loadingReason="initial_load" />
+        <LoadingSpinner />
 
         <p className="mt-4 text-xl text-sky-400">
           Initializing application...
@@ -747,7 +746,7 @@ function App() {
               
             <ModelUsageIndicators />
 
-            {isLoading && !hasGameBeenInitialized ? !error && <LoadingSpinner loadingReason={loadingReason} /> : null}
+            {isLoading && !hasGameBeenInitialized ? !error && <LoadingSpinner /> : null}
 
             {!hasGameBeenInitialized ? (
               <div className="bg-slate-800/50 border border-slate-700 rounded-lg flex-grow min-h-48" />
@@ -768,7 +767,7 @@ function App() {
 
                     {isLoading && !dialogueState && !isDialogueExiting && Boolean(hasGameBeenInitialized) ? (
                       <div className="absolute inset-0 flex items-center justify-center bg-slate-900/75 rounded-lg">
-                        <LoadingSpinner loadingReason={loadingReason} />
+                        <LoadingSpinner />
                       </div>
                     ) : null}
                   </div>
@@ -849,7 +848,6 @@ function App() {
         isDialogueExiting={isDialogueExiting}
         isLoading={isLoading}
         isVisible={!!dialogueState}
-        loadingReason={loadingReason}
         mapData={mapData.nodes}
         onClose={handleForceExitDialogue}
         onOptionSelect={handleDialogueOptionSelectSafe}

--- a/components/modals/ImageVisualizer.tsx
+++ b/components/modals/ImageVisualizer.tsx
@@ -342,7 +342,7 @@ function ImageVisualizer({
         />
         
         {isLoading ? <div className="visualizer-spinner-container">
-          <LoadingSpinner loadingReason="visualize" />
+          <LoadingSpinner />
 
         </div> : null}
 

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -543,9 +543,9 @@ function PageView({
 
 
         {pendingWrite ? (
-          <LoadingSpinner loadingReason="journal" />
+          <LoadingSpinner />
         ) : isLoading ? (
-          <LoadingSpinner loadingReason={item?.type === 'book' ? 'book' : 'page'} />
+          <LoadingSpinner />
         ) : item?.type === 'book' && !isJournal && chapterIndex === 0 ? (
           <ul className={`p-5 mt-4 list-disc list-inside overflow-y-auto text-left ${textClassNames}`}>
             {chapters.map((ch, idx) => (

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -5,6 +5,8 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { ThemePackName, FullGameState, GameStateStack, DebugPacketStack, LoadingReason } from '../types';
+import { setLoadingReason as setGlobalLoadingReason } from '../utils/loadingState';
+import { useLoadingReason } from './useLoadingReason';
 import { getInitialGameStates } from '../utils/initialStates';
 import { useDialogueManagement } from './useDialogueManagement';
 import { useRealityShift } from './useRealityShift';
@@ -53,11 +55,11 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     () => initialDebugStackFromApp ?? [null, null],
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [loadingReason, setLoadingReason] = useState<LoadingReason>(null);
+  const loadingReason = useLoadingReason();
   const loadingReasonRef = useRef<LoadingReason | null>(loadingReason);
   const setLoadingReasonRef = useCallback((reason: LoadingReason | null) => {
     loadingReasonRef.current = reason;
-    setLoadingReason(reason);
+    setGlobalLoadingReason(reason);
   }, []);
   const [error, setError] = useState<string | null>(null);
   const [parseErrorCounter, setParseErrorCounter] = useState<number>(0);

--- a/hooks/useLoadingReason.ts
+++ b/hooks/useLoadingReason.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { LoadingReason } from '../types';
+import { onLoadingReason, offLoadingReason, getLoadingReason } from '../utils/loadingState';
+
+export const useLoadingReason = () => {
+  const [reason, setReason] = useState<LoadingReason | null>(getLoadingReason());
+
+  useEffect(() => {
+    onLoadingReason(setReason);
+    return () => {
+      offLoadingReason(setReason);
+    };
+  }, []);
+
+  return reason;
+};

--- a/utils/loadingState.ts
+++ b/utils/loadingState.ts
@@ -1,0 +1,23 @@
+import { LoadingReason } from '../types';
+
+let currentReason: LoadingReason | null = null;
+const listeners: Array<(val: LoadingReason | null) => void> = [];
+
+export const setLoadingReason = (reason: LoadingReason | null): void => {
+  currentReason = reason;
+  listeners.forEach(fn => {
+    fn(currentReason);
+  });
+};
+
+export const onLoadingReason = (fn: (val: LoadingReason | null) => void): void => {
+  listeners.push(fn);
+  fn(currentReason);
+};
+
+export const offLoadingReason = (fn: (val: LoadingReason | null) => void): void => {
+  const idx = listeners.indexOf(fn);
+  if (idx !== -1) listeners.splice(idx, 1);
+};
+
+export const getLoadingReason = (): LoadingReason | null => currentReason;


### PR DESCRIPTION
## Summary
- create `loadingState` utils with global listeners
- add `useLoadingReason` hook
- update `LoadingSpinner` to read from global state
- adjust modal and app components
- integrate global loading state into `useGameLogic`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861bf889ac48324b4d99fb82696c8e2