### PR TITLE
Refactor loading spinner handling

### DIFF
--- a/components/DialogueDisplay.tsx
+++ b/components/DialogueDisplay.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useMemo, useCallback } from 'react';
 
 import * as React from 'react';
-import { DialogueHistoryEntry, Item, NPC, MapNode, LoadingReason } from '../types';
+import { DialogueHistoryEntry, Item, NPC, MapNode } from '../types';
 import { highlightEntitiesInText, buildHighlightableEntities } from '../utils/highlightHelper';
 import LoadingSpinner from './LoadingSpinner';
 import ModelUsageIndicators from './ModelUsageIndicators';
@@ -26,7 +26,6 @@ interface DialogueDisplayProps {
   readonly mapData: Array<MapNode>; 
   readonly allNPCs: Array<NPC>;
   readonly currentThemeName: string | null;
-  readonly loadingReason: LoadingReason | null; // Added prop
 }
 
 /**
@@ -45,7 +44,6 @@ function DialogueDisplay({
   mapData,
   allNPCs: allNPCs,
   currentThemeName,
-  loadingReason, // Destructure prop
 }: DialogueDisplayProps) {
   const dialogueFrameRef = useRef<HTMLDivElement | null>(null); 
   const lastHistoryEntryRef = useRef<HTMLDivElement | null>(null);
@@ -95,7 +93,7 @@ function DialogueDisplay({
 
   const renderOptionsArea = () => {
     if (isDialogueExiting || isLoading) {
-      return <LoadingSpinner loadingReason={loadingReason} />;
+      return <LoadingSpinner />;
     }
 
     if (options.length > 0) {

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -3,18 +3,15 @@
  * @file LoadingSpinner.tsx
  * @description Loading spinner indicating in-progress actions.
  */
-import { LoadingReason } from '../types';
 import { LOADING_REASON_UI_MAP } from '../constants';
 import { useLoadingProgress } from '../hooks/useLoadingProgress';
-
-interface LoadingSpinnerProps {
-  readonly loadingReason: LoadingReason | null;
-}
+import { useLoadingReason } from '../hooks/useLoadingReason';
 
 /**
  * Displays a spinner with a reason message while the game is busy.
  */
-function LoadingSpinner({ loadingReason = null }: LoadingSpinnerProps) {
+function LoadingSpinner() {
+  const loadingReason = useLoadingReason();
   const { progress, retryCount } = useLoadingProgress();
   const spinnerBaseClass = "rounded-full h-16 w-16 border-t-4 border-b-4";
   const spinnerClass = `${spinnerBaseClass} animate-spin border-sky-600`;

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -192,7 +192,6 @@ function App() {
     gameStateStack,
     debugPacketStack,
     handleMapLayoutConfigChange,
-    loadingReason,
     handleUndoTurn,
     destinationNodeId,
     handleSelectDestinationNode,
@@ -696,7 +695,7 @@ function App() {
   if (!appReady) {
     return (
       <div className="min-h-screen bg-slate-900 text-slate-200 flex flex-col items-center justify-center p-4">
-        <LoadingSpinner loadingReason="initial_load" />
+        <LoadingSpinner />
 
         <p className="mt-4 text-xl text-sky-400">
           Initializing application...
@@ -747,7 +746,7 @@ function App() {
               
             <ModelUsageIndicators />
 
-            {isLoading && !hasGameBeenInitialized ? !error && <LoadingSpinner loadingReason={loadingReason} /> : null}
+            {isLoading && !hasGameBeenInitialized ? !error && <LoadingSpinner /> : null}
 
             {!hasGameBeenInitialized ? (
               <div className="bg-slate-800/50 border border-slate-700 rounded-lg flex-grow min-h-48" />
@@ -768,7 +767,7 @@ function App() {
 
                     {isLoading && !dialogueState && !isDialogueExiting && Boolean(hasGameBeenInitialized) ? (
                       <div className="absolute inset-0 flex items-center justify-center bg-slate-900/75 rounded-lg">
-                        <LoadingSpinner loadingReason={loadingReason} />
+                        <LoadingSpinner />
                       </div>
                     ) : null}
                   </div>
@@ -849,7 +848,6 @@ function App() {
         isDialogueExiting={isDialogueExiting}
         isLoading={isLoading}
         isVisible={!!dialogueState}
-        loadingReason={loadingReason}
         mapData={mapData.nodes}
         onClose={handleForceExitDialogue}
         onOptionSelect={handleDialogueOptionSelectSafe}

--- a/components/modals/ImageVisualizer.tsx
+++ b/components/modals/ImageVisualizer.tsx
@@ -342,7 +342,7 @@ function ImageVisualizer({
         />
         
         {isLoading ? <div className="visualizer-spinner-container">
-          <LoadingSpinner loadingReason="visualize" />
+          <LoadingSpinner />
 
         </div> : null}
 

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -543,9 +543,9 @@ function PageView({
 
 
         {pendingWrite ? (
-          <LoadingSpinner loadingReason="journal" />
+          <LoadingSpinner />
         ) : isLoading ? (
-          <LoadingSpinner loadingReason={item?.type === 'book' ? 'book' : 'page'} />
+          <LoadingSpinner />
         ) : item?.type === 'book' && !isJournal && chapterIndex === 0 ? (
           <ul className={`p-5 mt-4 list-disc list-inside overflow-y-auto text-left ${textClassNames}`}>
             {chapters.map((ch, idx) => (

--- a/hooks/useDialogueFlow.ts
+++ b/hooks/useDialogueFlow.ts
@@ -7,7 +7,6 @@ import { useRef } from 'react';
 import {
   GameStateFromAI,
   FullGameState,
-  LoadingReason,
   DialogueTurnDebugEntry,
 } from '../types';
 import { useDialogueTurn } from './useDialogueTurn';
@@ -19,7 +18,6 @@ export interface UseDialogueFlowProps {
   playerGenderProp: string;
   setError: (error: string | null) => void;
   setIsLoading: (isLoading: boolean) => void;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   onDialogueConcluded: (
     summaryPayload: GameStateFromAI | null,
     preparedGameState: FullGameState,
@@ -42,7 +40,6 @@ export const useDialogueFlow = (props: UseDialogueFlowProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason,
     onDialogueConcluded,
   } = props;
 
@@ -67,7 +64,6 @@ export const useDialogueFlow = (props: UseDialogueFlowProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason,
     onDialogueConcluded,
     getDialogueDebugLogs,
     clearDialogueDebugLogs,
@@ -79,7 +75,6 @@ export const useDialogueFlow = (props: UseDialogueFlowProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason,
     initiateDialogueExit,
     isDialogueExiting,
     addDebugEntry,

--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -4,12 +4,12 @@
  */
 
 import { useState, useCallback, useEffect } from 'react';
+import { setLoadingReason } from '../utils/loadingState';
 import {
   DialogueHistoryEntry,
   GameStateFromAI,
   FullGameState,
   DialogueSummaryContext,
-  LoadingReason,
   MapData,
   DialogueSummaryRecord,
   DialogueMemorySummaryContext,
@@ -30,7 +30,6 @@ export interface UseDialogueSummaryProps {
   playerGenderProp: string;
   setError: (error: string | null) => void;
   setIsLoading: (isLoading: boolean) => void;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   onDialogueConcluded: (
     summaryPayload: GameStateFromAI | null,
     preparedGameState: FullGameState,
@@ -55,7 +54,6 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason,
     onDialogueConcluded,
     getDialogueDebugLogs,
     clearDialogueDebugLogs,
@@ -173,7 +171,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
     onDialogueConcluded(summaryUpdatePayload, workingGameState, debugInfo);
     clearDialogueDebugLogs();
     setDialogueNextSceneAttempted(true);
-  }, [playerGenderProp, setError, setIsLoading, setLoadingReason, onDialogueConcluded, getDialogueDebugLogs, clearDialogueDebugLogs]);
+  }, [playerGenderProp, setError, setIsLoading, onDialogueConcluded, getDialogueDebugLogs, clearDialogueDebugLogs]);
 
   useEffect(() => {
     if (isDialogueExiting && dialogueNextSceneAttempted && Date.now() >= dialogueUiCloseDelayTargetMs) {

--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -8,13 +8,13 @@ import {
   DialogueHistoryEntry,
   FullGameState,
   DialogueData,
-  LoadingReason,
 } from '../types';
 import { executeDialogueTurn } from '../services/dialogue';
 import { collectRelevantFacts_Service } from '../services/loremaster';
 import { PLAYER_HOLDER_ID, RECENT_LOG_COUNT_FOR_PROMPT } from '../constants';
 import { formatDetailedContextForMentionedEntities } from '../utils/promptFormatters';
 import { DialogueTurnDebugEntry } from '../types';
+import { setLoadingReason } from '../utils/loadingState';
 
 export interface UseDialogueTurnProps {
   getCurrentGameState: () => FullGameState;
@@ -22,7 +22,6 @@ export interface UseDialogueTurnProps {
   playerGenderProp: string;
   setError: (error: string | null) => void;
   setIsLoading: (isLoading: boolean) => void;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   initiateDialogueExit: (preparedState: FullGameState) => Promise<void>;
   isDialogueExiting: boolean;
   addDebugEntry: (entry: DialogueTurnDebugEntry) => void;
@@ -38,7 +37,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason,
     initiateDialogueExit,
     isDialogueExiting,
     addDebugEntry,
@@ -185,7 +183,6 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
     isDialogueExiting,
     setError,
     setIsLoading,
-    setLoadingReason,
     initiateDialogueExit,
     addDebugEntry,
   ]);

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -7,7 +7,6 @@ import { useCallback } from 'react';
 import {
   FullGameState,
   ThemePackName,
-  LoadingReason,
   GameStateStack,
 } from '../types';
 import {
@@ -30,6 +29,7 @@ import { DEFAULT_VIEWBOX } from '../constants';
 import { ProcessAiResponseFn } from './useProcessAiResponse';
 import { repairFeatureHierarchy } from '../utils/mapHierarchyUpgradeUtils';
 import { clearAllImages } from '../services/imageDb';
+import { setLoadingReason } from '../utils/loadingState';
 
 export interface LoadInitialGameOptions {
   isRestart?: boolean;
@@ -46,7 +46,6 @@ export interface UseGameInitializationProps {
   stabilityLevelProp: number;
   chaosLevelProp: number;
   setIsLoading: (val: boolean) => void;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   setError: (err: string | null) => void;
   setParseErrorCounter: (val: number) => void;
   setHasGameBeenInitialized: (val: boolean) => void;
@@ -70,7 +69,6 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setIsLoading,
-    setLoadingReason,
     setError,
     setParseErrorCounter,
     setHasGameBeenInitialized,
@@ -321,7 +319,6 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
       stabilityLevelProp,
       chaosLevelProp,
       setIsLoading,
-      setLoadingReason,
       setError,
       setParseErrorCounter,
       setHasGameBeenInitialized,
@@ -546,7 +543,6 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
     commitGameState,
     setError,
     setIsLoading,
-    setLoadingReason,
     setParseErrorCounter,
     processAiResponse,
     playerGenderProp,

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -13,6 +13,7 @@ import { useGameInitialization, LoadInitialGameOptions } from './useGameInitiali
 import { buildSaveStateSnapshot } from './saveSnapshotHelpers';
 import { structuredCloneGameState } from '../utils/cloneUtils';
 import { PLAYER_HOLDER_ID, DISTILL_LORE_INTERVAL } from '../constants';
+import { setLoadingReason, getLoadingReason } from '../utils/loadingState';
 import { getAdjacentNodeIds } from '../utils/mapGraphUtils';
 import { distillFacts_Service } from '../services/loremaster';
 import { applyThemeFactChanges } from '../utils/gameLogicUtils';
@@ -53,8 +54,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     () => initialDebugStackFromApp ?? [null, null],
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [loadingReason, setLoadingReason] = useState<LoadingReason>(null);
-  const loadingReasonRef = useRef<LoadingReason | null>(loadingReason);
+  const loadingReasonRef = useRef<LoadingReason | null>(getLoadingReason());
   const setLoadingReasonRef = useCallback((reason: LoadingReason | null) => {
     loadingReasonRef.current = reason;
     setLoadingReason(reason);
@@ -136,7 +136,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setError,
-    setLoadingReason: setLoadingReasonRef,
     isLoading,
   });
 
@@ -186,7 +185,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setIsLoading,
-    setLoadingReason: setLoadingReasonRef,
     setError,
     setParseErrorCounter,
     triggerRealityShift,
@@ -212,7 +210,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setIsLoading,
-    setLoadingReason: setLoadingReasonRef,
     setError,
     setParseErrorCounter,
     setHasGameBeenInitialized,
@@ -232,7 +229,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     playerGenderProp,
     setError,
     setIsLoading,
-    setLoadingReason: setLoadingReasonRef,
     onDialogueConcluded: (summaryPayload, preparedGameState, debugInfo) => {
       const draftState = structuredCloneGameState(preparedGameState);
       processAiResponse(summaryPayload, preparedGameState.currentThemeObject, draftState, {
@@ -468,7 +464,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     gameLog: currentFullState.gameLog,
     lastActionLog: currentFullState.lastActionLog,
     isLoading: isLoading || (currentFullState.dialogueState !== null && isDialogueExiting),
-    loadingReason,
     error,
     themeHistory: currentFullState.themeHistory,
     allNPCs: currentFullState.allNPCs,

--- a/hooks/useLoadingReason.ts
+++ b/hooks/useLoadingReason.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { LoadingReason } from '../types';
+import { onLoadingReason, offLoadingReason, getLoadingReason } from '../utils/loadingState';
+
+export const useLoadingReason = (): LoadingReason | null => {
+  const [reason, setReason] = useState<LoadingReason | null>(getLoadingReason());
+
+  useEffect(() => {
+    onLoadingReason(setReason);
+    return () => {
+      offLoadingReason(setReason);
+    };
+  }, []);
+
+  return reason;
+};

--- a/hooks/useMapUpdateProcessor.ts
+++ b/hooks/useMapUpdateProcessor.ts
@@ -15,7 +15,6 @@ import { handleMapUpdates } from '../utils/mapUpdateHandlers';
 
 export interface UseMapUpdateProcessorProps {
   loadingReasonRef: React.RefObject<LoadingReason | null>;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   setError: (err: string | null) => void;
 }
 
@@ -24,7 +23,6 @@ export interface UseMapUpdateProcessorProps {
  */
 export const useMapUpdateProcessor = ({
   loadingReasonRef,
-  setLoadingReason,
   setError,
 }: UseMapUpdateProcessorProps) => {
 
@@ -43,7 +41,6 @@ export const useMapUpdateProcessor = ({
           baseStateSnapshot,
           themeContext,
           loadingReasonRef.current,
-          setLoadingReason,
           turnChanges,
         );
       } catch (err: unknown) {
@@ -51,7 +48,7 @@ export const useMapUpdateProcessor = ({
         throw err;
       }
     },
-    [loadingReasonRef, setLoadingReason, setError],
+    [loadingReasonRef, setError],
   );
 
   return { processMapUpdates };

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -34,6 +34,7 @@ import { useProcessAiResponse } from './useProcessAiResponse';
 import { useInventoryActions } from './useInventoryActions';
 import { distillFacts_Service } from '../services/loremaster';
 import { applyThemeFactChanges } from '../utils/gameLogicUtils';
+import { setLoadingReason } from '../utils/loadingState';
 
 export interface UsePlayerActionsProps {
   getCurrentGameState: () => FullGameState;
@@ -43,7 +44,6 @@ export interface UsePlayerActionsProps {
   stabilityLevelProp: number;
   chaosLevelProp: number;
   setIsLoading: (val: boolean) => void;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   loadingReasonRef: React.RefObject<LoadingReason | null>;
   setError: (err: string | null) => void;
   setParseErrorCounter: (val: number) => void;
@@ -72,7 +72,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setIsLoading,
-    setLoadingReason,
     setError,
     setParseErrorCounter,
     triggerRealityShift,
@@ -88,7 +87,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
 
   const { processAiResponse, clearObjectiveAnimationTimer } = useProcessAiResponse({
     loadingReasonRef,
-    setLoadingReason,
     setError,
     setGameStateStack,
     debugLore,
@@ -172,7 +170,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         }
       }
     },
-    [setLoadingReason],
+    [],
   );
 
   /**
@@ -381,7 +379,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       chaosLevelProp,
       triggerRealityShift,
       setIsLoading,
-      setLoadingReason,
       setError,
       setParseErrorCounter,
       setFreeFormActionText,

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -12,6 +12,7 @@ import {
 } from '../types';
 import { fetchCorrectedName_Service } from '../services/corrections';
 import { PLAYER_HOLDER_ID, MAX_LOG_MESSAGES } from '../constants';
+import { setLoadingReason } from '../utils/loadingState';
 import {
   addLogMessageToList,
   buildItemChangeRecords,
@@ -35,7 +36,6 @@ interface CorrectItemChangesParams {
   baseState: FullGameState;
   playerActionText?: string;
   loadingReason: LoadingReason | null;
-  setLoadingReason: (reason: LoadingReason | null) => void;
 }
 
 const correctItemChanges = async ({
@@ -45,7 +45,6 @@ const correctItemChanges = async ({
   baseState,
   playerActionText,
   loadingReason,
-  setLoadingReason,
 }: CorrectItemChangesParams): Promise<Array<ItemChange>> => {
   if (!theme) return [...aiItemChanges];
 
@@ -179,7 +178,6 @@ interface HandleInventoryHintsParams {
   correctedItemChanges: Array<ItemChange>;
   playerActionText?: string;
   loadingReason: LoadingReason | null;
-  setLoadingReason: (reason: LoadingReason | null) => void;
 }
 
 const handleInventoryHints = async ({
@@ -190,7 +188,6 @@ const handleInventoryHints = async ({
   correctedItemChanges,
   playerActionText,
   loadingReason,
-  setLoadingReason,
 }: HandleInventoryHintsParams): Promise<{
   combinedItemChanges: Array<ItemChange>;
   baseInventoryForPlayer: Array<Item>;
@@ -291,7 +288,6 @@ export type ProcessAiResponseFn = (
 
 export interface UseProcessAiResponseProps {
   loadingReasonRef: React.RefObject<LoadingReason | null>;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   setError: (err: string | null) => void;
   setGameStateStack: React.Dispatch<React.SetStateAction<GameStateStack>>;
   debugLore: boolean;
@@ -303,7 +299,6 @@ export interface UseProcessAiResponseProps {
 
 export const useProcessAiResponse = ({
   loadingReasonRef,
-  setLoadingReason,
   setError,
   setGameStateStack,
   debugLore,
@@ -311,7 +306,6 @@ export const useProcessAiResponse = ({
 }: UseProcessAiResponseProps) => {
   const { processMapUpdates } = useMapUpdateProcessor({
     loadingReasonRef,
-    setLoadingReason,
     setError,
   });
 
@@ -447,7 +441,6 @@ export const useProcessAiResponse = ({
         baseState: baseStateSnapshot,
         playerActionText,
         loadingReason: loadingReasonRef.current,
-        setLoadingReason,
       });
 
       await applyMapUpdatesFromAi({
@@ -468,7 +461,6 @@ export const useProcessAiResponse = ({
           correctedItemChanges: correctedAndVerifiedItemChanges,
           playerActionText,
           loadingReason: loadingReasonRef.current,
-          setLoadingReason,
         });
 
       turnChanges.itemChanges = buildItemChangeRecords(
@@ -635,7 +627,6 @@ export const useProcessAiResponse = ({
     },
     [
       loadingReasonRef,
-      setLoadingReason,
       setError,
       setGameStateStack,
       processMapUpdates,

--- a/hooks/useRealityShift.ts
+++ b/hooks/useRealityShift.ts
@@ -9,13 +9,13 @@ import {
   ThemePackName,
   FullGameState,
   GameStateStack,
-  LoadingReason,
   ThemeMemory
 } from '../types';
 import { getThemesFromPacks } from '../themes';
 import { summarizeThemeAdventure_Service } from '../services/storyteller';
 import { selectNextThemeName } from '../utils/gameLogicUtils';
 import { getInitialGameStates } from '../utils/initialStates';
+import { setLoadingReason } from '../utils/loadingState';
 
 export interface UseRealityShiftProps {
   getCurrentGameState: () => FullGameState;
@@ -33,7 +33,6 @@ export interface UseRealityShiftProps {
   stabilityLevelProp: number;
   chaosLevelProp: number;
   setError: (err: string | null) => void;
-  setLoadingReason: (reason: LoadingReason | null) => void;
   isLoading: boolean;
 }
 
@@ -47,7 +46,6 @@ export const useRealityShift = (props: UseRealityShiftProps) => {
     stabilityLevelProp,
     chaosLevelProp,
     setError,
-    setLoadingReason,
     isLoading
   } = props;
 
@@ -178,7 +176,6 @@ export const useRealityShift = (props: UseRealityShiftProps) => {
     summarizeAndStoreThemeHistory,
     loadInitialGame,
     setError,
-    setLoadingReason,
     setGameStateStack,
     playerGenderProp,
     stabilityLevelProp,
@@ -221,14 +218,14 @@ export const useRealityShift = (props: UseRealityShiftProps) => {
       isTransitioningFromShift: true,
       customGameFlag: true
     });
-  }, [getCurrentGameState, setGameStateStack, loadInitialGame, setLoadingReason]);
+  }, [getCurrentGameState, setGameStateStack, loadInitialGame]);
 
   /** Cancels the manual shift selection process. */
   const cancelManualShiftThemeSelection = useCallback(() => {
     setGameStateStack((prev: GameStateStack) => [{ ...prev[0], isAwaitingManualShiftThemeSelection: false, lastActionLog: 'You decide against manually shifting reality for now.' }, prev[1]]);
     setError(null);
     setLoadingReason(null);
-  }, [setGameStateStack, setError, setLoadingReason]);
+  }, [setGameStateStack, setError]);
 
   return {
     triggerRealityShift,

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -124,7 +124,7 @@ const turnChanges: TurnChanges = {
   scoreChangedBy: 0
 };
 
-await handleMapUpdates(aiData, draftState, baseState, theme, null, () => undefined, turnChanges);
+await handleMapUpdates(aiData, draftState, baseState, theme, null, turnChanges);
 
 const updatedMaybe = draftState.mapData.nodes.find(n => n.id === 'node_rim_test');
 if (!updatedMaybe) throw new Error('node_rim_test not found');
@@ -140,7 +140,7 @@ const aiData2 = {
   currentMapNodeId: 'node_utility_entrance_test'
 } as Partial<GameStateFromAI> as GameStateFromAI;
 
-await handleMapUpdates(aiData2, draftState, baseState, theme, null, () => undefined, turnChanges);
+await handleMapUpdates(aiData2, draftState, baseState, theme, null, turnChanges);
 
 const updated2Maybe = draftState.mapData.nodes.find(n => n.id === 'node_utility_entrance_test');
 const updated3Maybe = draftState.mapData.edges.find(n => n.id === 'edge_node_rim_test_to_node_utility_entrance_test_test');
@@ -173,7 +173,7 @@ const aiData3 = {
   currentMapNodeId: 'Yellow Door'
 } as Partial<GameStateFromAI> as GameStateFromAI;
 
-await handleMapUpdates(aiData3, draftState, baseState, theme, null, () => undefined, turnChanges);
+await handleMapUpdates(aiData3, draftState, baseState, theme, null, turnChanges);
 
 const updated6Maybe = draftState.mapData.nodes.find(n => n.id === 'node_main_entrance_test');
 if (!updated6Maybe) throw new Error('node_main_entrance_test not found');

--- a/utils/loadingState.ts
+++ b/utils/loadingState.ts
@@ -1,0 +1,27 @@
+import { LoadingReason } from '../types';
+
+let currentReason: LoadingReason | null = null;
+const listeners: Array<(r: LoadingReason | null) => void> = [];
+
+const emit = () => {
+  listeners.forEach(fn => {
+    fn(currentReason);
+  });
+};
+
+export const onLoadingReason = (fn: (r: LoadingReason | null) => void): void => {
+  listeners.push(fn);
+  fn(currentReason);
+};
+
+export const offLoadingReason = (fn: (r: LoadingReason | null) => void): void => {
+  const idx = listeners.indexOf(fn);
+  if (idx !== -1) listeners.splice(idx, 1);
+};
+
+export const setLoadingReason = (reason: LoadingReason | null): void => {
+  currentReason = reason;
+  emit();
+};
+
+export const getLoadingReason = (): LoadingReason | null => currentReason;

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -14,6 +14,7 @@ import {
   ValidNPCUpdatePayload
 } from '../types';
 import { updateMapFromAIData_Service, MapUpdateServiceResult } from '../services/cartographer';
+import { setLoadingReason } from './loadingState';
 import { fetchFullPlaceDetailsForNewMapNode_Service, assignSpecificNamesToDuplicateNodes_Service } from '../services/corrections';
 import { selectBestMatchingMapNode, attemptMatchAndSetNode } from './mapNodeMatcher';
 import {
@@ -38,7 +39,6 @@ export const handleMapUpdates = async (
   baseStateSnapshot: FullGameState,
   themeContextForResponse: AdventureTheme,
   loadingReason: LoadingReason | null,
-  setLoadingReason: (reason: LoadingReason | null) => void,
   turnChanges: TurnChanges
 ): Promise<string | null | undefined> => {
   let mapAISuggestedNodeIdentifier: string | null | undefined = undefined;


### PR DESCRIPTION
## Summary
- add global loading state store and hook
- simplify LoadingSpinner and usage to consume global state
- remove passing setLoadingReason through props
- update hooks and tests to use global loading state

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861bf889ac48324b4d99fb82696c8e2