### PR TITLE
Add schema to inventory service

### DIFF
--- a/prompts/helperPrompts.ts
+++ b/prompts/helperPrompts.ts
@@ -6,9 +6,6 @@
 
 import {
   VALID_ITEM_TYPES_STRING,
-  WRITING_TAGS_STRING,
-  MIN_BOOK_CHAPTERS,
-  MAX_BOOK_CHAPTERS,
   DEDICATED_BUTTON_USES_STRING
 } from '../constants';
 
@@ -37,100 +34,123 @@ export const ITEMS_GUIDE = `Generate inventory hints using these fields:
 - "newItems": array of brand new items introduced this turn, or [] if none.
 
 Examples illustrating the hint style:
-- Example for gaining a new item:
-  playerItemsHint: "Picked up Old Lantern."
-  newItems: [{
+- Example of creating a *new* item "Old Lantern" and placing it in player's inventory. Because "Old Lantern" is included in newItems, it means the item is not already present in the scene:
+playerItemsHint: "Picked up Old Lantern."
+newItems:
+[
+  {
     "name": "Old Lantern",
     "type": "equipment",
     "description": "A dusty old lantern that still flickers faintly.",
     "activeDescription": "The lantern is lit and casts a warm glow.",
     "isActive": false,
-    "tags": [],
-    "knownUses": [
+    "knownUses":
+    [
       {
         "actionName": "Light the Lantern",
         "promptEffect": "Light the lantern to illuminate the area.",
         "description": "Use this to light your way in dark places.",
-        "appliesWhenActive": true,
-        "appliesWhenInactive": false
+        "appliesWhenInactive": true
+      },
+      {
+        "actionName": "Extinguish the Lantern",
+        "promptEffect": "Extinguish the lantern.",
+        "description": "Extinguish the lantern and conserve fuel.",
+        "appliesWhenActive": true
+      }
+    ]
+  }
+]
+
+- Example for creating a *new* item "Rusty Key" inside npc_guard_4f3a inventory:
+npcItemsHint: "Guard now carries a Rusty Key."
+newItems:
+[
+  {
+    "name": "Rusty Key",
+    "type": "key",
+    "description": "A key for the armory door.",
+    "holderId": "npc_guard_4f3a"
+  }
+]
+
+- Example of creating a *new* 'page' written item and placing it in player's inventory (same structure for the 'map' and 'picture' types):
+playerItemsHint: "Found Smudged Note."
+newItems:
+[
+  {
+    "name": "Smudged Note",
+    "type": "page",
+    "description": "A hastily scribbled message with a big smudge over it.",
+    "tags": ["typed", "smudged"],
+    "holderId": "player",
+    "chapters":
+    [ /* Only one chapter, because the type is 'page' */
+      {
+        "heading": "string",
+        "description": "A hastily scribbled message about the dangers of the sunken tunnel.",
+        "contentLength": 50
+      }
+    ]
+  }
+]
+
+- Example of creating a *new* 'book' written item and placing it in player's inventory:
+playerItemsHint: "Obtained the Explorer's Adventures."
+newItems:
+[
+  {
+    "name": "Explorer's Adventures",
+    "type": "book",
+    "description": "Weathered log of travels.",
+    "holderId": "player",
+    "tags": ["handwritten", "faded"],
+    "chapters":
+    [ /* Multiple chapters because the type it 'book' */
+      {
+        "heading": "Preface",
+        "description": "Introduction. Written by the author, explaining his decisions to start his travels.",
+        "contentLength": 53
+      },
+      {
+        "heading": "Journey One",
+        "description": "First trip. The author travelled to Vibrant Isles in the search of the Endless Waterfall",
+        "contentLength": 246 
+      },
+      {
+        "heading": "Journey Two",
+        "description": "Second Trip. The author's adventure in Desolate Steppes in the search of Magnificent Oasis", 
+        "contentLength": 312 
+      },
+      {
+        "heading": "Final Thoughts",
+        "description": "The author's contemplation about whether the journeys were worth it", 
+        "contentLength": 98 
       }
     ]
   }]
 
-- Example for putting a new item into another inventory or location:
-  npcItemsHint: "Guard now carries Rusty Key."
-  newItems: [{
-    "name": "Rusty Key",
-    "type": "key",
-    "description": "Opens an old door.",
-    "tags": [],
-    "holderId": "npc_guard_4f3a"
-  }]
-
-- Example for a short page item:
-  playerItemsHint: "Found Smudged Note."
-  newItems: [{
-    "name": "Smudged Note",
-    "type": "page",
-    "description": "A hastily scribbled message with a big smudge over it.", /* REQUIRED. Moderatly detailed description of the note and its contents. Should NEVER include direct quotes of the contents. */
-    "tags": ["typed", "smudged"], /* Tags describing the page. Use one or two from: ${WRITING_TAGS_STRING}. */
-    "chapters": [ /* REQUIRED. Always a single chapter. */
-      { "heading": "string", /* REQUIRED. Can be anything*/
-        "description": "A hastily scribbled message about the dangers of the sunken tunnel.", /* REQUIRED. Moderately detailed abstract of the contents. */
-        "contentLength": 50 /* REQUIRED. Length of the content in words. */
-      }
-    "holderId": "player"
-  }]
-
-- Example for a simple book:
-  playerItemsHint: "Obtained the Explorer's Adventures."
-  newItems: [{
-    "name": "Explorer's Adventures",
-    "type": "book",
-    "description": "Weathered log of travels.", /* Should NEVER include any direct quotes from the book contents. */
-    "tags": ["handwritten", "faded"], /* Tags describing the page. Use one or two from: ${WRITING_TAGS_STRING}. */
-    "chapters": [ /* Anywhere from ${String(MIN_BOOK_CHAPTERS)} to ${String(MAX_BOOK_CHAPTERS)} chapters. */
-      { "heading": "Preface", /* REQUIRED. Short Title of the chapter*/
-        "description": "Introduction. Written by the author, explaining his decisions to start his travels.", /* REQUIRED. Short, but detailed abstract of the contents of the chapter. */
-        "contentLength": 50 /* REQUIRED. Length of the content in words. Range: 50-500 */
-      },
-      { "heading": "Journey One",
-        "description": "First trip. The author travelled to Vibrant Isles in the search of the Endless Waterfall",
-        "contentLength": 250 
-      },
-      { "heading": "Journey Two",
-        "description": "Second Trip. The author's adventure in Desolate Steppes in the search of Magnificent Oasis", 
-        "contentLength": 300 
-      },
-      { "heading": "Final Thoughts",
-        "description": "The author's contemplation about whether the journeys were worth it", 
-        "contentLength": 100 
-      }
-    ],
-    "holderId": "player"
-  }]
-
 - Example for losing, destroying, completely removing the item:
-  playerItemsHint: "Lost Old Lantern (flickering)."
+playerItemsHint: "Lost Old Lantern (flickering)."
 
-- Example for giving an existing item from one holder to another:
-  npcItemsHint: "Gave Iron Sword to Guard."
+- Example for giving an *existing* item from one holder to another:
+npcItemsHint: "Gave Iron Sword to Guard."
 
 - "take" is an alias for "give". Example:
-  playerItemsHint: "Took Coin Pouch from Bandit."
+playerItemsHint: "Took Coin Pouch from Bandit."
 
-- Example for simple update (only changing "isActive"):
-  playerItemsHint: "Plasma Torch is now active."
+- Example for simple update of *existing* item (only changing "isActive"):
+playerItemsHint: "Plasma Torch is now active."
 
 - Example for transformation or crafting:
-  playerItemsHint: "Scrap Metal transformed into Makeshift Shiv."
+playerItemsHint: "Scrap Metal transformed into Makeshift Shiv."
 
-- Example for adding a known use (type/description etc. inherited):
-  playerItemsHint: "Mystic Orb can now 'Peer into the Orb'."
+- Example for adding a known use to an item without changing anything else:
+playerItemsHint: "Mystic Orb can now 'Peer into the Orb'."
 
-  - ALWAYS appropriately handle spending single-use items and state toggles ("isActive": true/false).
-  - Using some "single-use" items (food, water, medicine, etc) MUST add or remove appropriate "status effects".
-  - Mention remaining uses for multi-use items when they change.
+- ALWAYS appropriately handle spending single-use items and state toggles ("isActive": true/false).
+- Using some "single-use" items (food, water, medicine, etc) MUST add or remove appropriate "status effects".
+- Mention remaining uses for multi-use items when they change.
 IMPORTANT: For items that CLEARLY can be enabled or disabled (e.g., light sources, powered equipment, wielded or worn items) provide at least the two knownUses to enable and disable them with appropriate names:
   - The knownUse to turn on, light, or otherwise enable the item should ALWAYS have "appliesWhenInactive": true (and typically "appliesWhenActive": false or undefined).
   - The knownUse to turn off, extinguish, or disable the item should ALWAYS have "appliesWhenActive": true (and typically "appliesWhenInactive": false or undefined).

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -86,7 +86,6 @@ export const INVENTORY_ITEM_SCHEMA = {
       items: INVENTORY_CHAPTER_SCHEMA,
       description: `For 'page' use one chapter. For 'book' between ${String(MIN_BOOK_CHAPTERS)} chapters.`,
     },
-    chapter: INVENTORY_CHAPTER_SCHEMA,
     knownUses: { type: 'array', items: INVENTORY_KNOWN_USE_SCHEMA },
     addKnownUse: INVENTORY_KNOWN_USE_SCHEMA,
   },

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -4,185 +4,205 @@
  */
 
 import {
-  VALID_ITEM_TYPES_STRING,
-  VALID_TAGS_STRING,
-  WRITING_TAGS_STRING,
   VALID_ACTIONS_STRING,
+  DEDICATED_BUTTON_USES_STRING,
 } from '../../constants';
 import { ITEM_TYPES_GUIDE } from '../../prompts/helperPrompts';
 
 export const SYSTEM_INSTRUCTION = `** SYSTEM INSTRUCTIONS: **
 You are an AI assistant that converts item hints into explicit inventory actions for a text adventure game.
 Analyze the hints and optional new items JSON provided in the prompt.
-You MUST 'gain' or 'put' *all* items in the New Items JSON and *only* the items in the New Items JSON. NEVER gain or put items that are part of the Player's Inventory.
+
 Define any operations on existing items in the Player's Inventory, based on Player's Action and the Player Items Hint.
 Define any operations on existing items at Locations, or in NPCs' inventories, according to Location Items Hint and NPCs Items Hint.
-Items described in the "World Items Hint" must be placed at their appropriate map node holderId from this context using the 'put' action.
+Define any transfers of existing items between NPCs' and Player's Inventories using 'give' or 'take' actions.
+Items described in the "World Items Hint" must be placed at their appropriate map node holderId using the 'put' action.
 
-Provide your response as a JSON object matching the Inventory JSON schema. The
-object must contain \`observations\`, \`rationale\`, and an array of
-\`itemChanges\`. Valid actions are ${VALID_ACTIONS_STRING}.
-CRITICALLY IMPORTANT: Use 'put' or 'gain' only when revealing or creating a **NEW** item at a specific location, specific NPC inventory, or in Player's inventory.
+Available actions are: ${VALID_ACTIONS_STRING}.
+CRITICALLY IMPORTANT: Use 'put' or 'gain' only when revealing or creating a **NEW** item at a specific location, specific NPC inventory, or in Player's inventory. You MUST 'gain' or 'put' *all* items in the New Items JSON and *only* the items in the New Items JSON. NEVER gain or put items that are part of the Player's Inventory.
 CRITICALLY IMPORTANT: Use 'give' or 'take' when transferring an **EXISTING** item from one holder to another, or dropping/picking up the item at the current location.
-CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consumed, destroyed, or otherwise removed from play.
+CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consumed, destroyed, or otherwise removed from the world.
 
-Structure for individual ItemChange objects within the array:
+## Examples:
+
 - Example for gaining a *new* item from the provided New Items JSON:
-  { "action": "gain", /* "put" action follows the same structure, but is used for placing new items in the world and can accept 'node_*' and 'npc_*' IDs as holderId. */
-    item: {
-      "name": "Old Lantern", /* REQUIRED: Full name of the item. */
-      "type": "equipment", /* REQUIRED. MUST be one of ${VALID_ITEM_TYPES_STRING} */
-      "description": "A dusty old lantern that still flickers faintly.", /* REQUIRED: Short description of the item. */
-      "holderId": "player", /* REQUIRED: MUST BE 'player', or an ID of the NPC or map node that will hold the item if the action is 'put'. Use "player" for Player's inventory, or a specific NPC ID for their inventory. */
-      "activeDescription"?: "The lantern is lit and casts a warm glow.", /* Optional: Description when the item is active. REQUIRED for toggle-able items.*/
-      "isActive"?: false, /* Optional: true if the item is currently active (e.g., a lit lantern, powered equipment). Defaults to false if not provided. */
-      "tags"?: ["junk"], /* Optional: array of short tags describing the item. Valid tags: ${VALID_TAGS_STRING}. Include "junk" if the item is unimportant or has served its ONLY purpose. IMPORTANT: "status effects" can never have the "junk" tag. */
-      /* IMPORTANT: For written items, ALWAYS add one of the style tags from: 'printed', 'handwritten', 'typed', or 'digital'. Add condition tags like 'faded', 'torn', etc., when appropriate. Writing tags: ${WRITING_TAGS_STRING}. */
-      "chapters"?: [ /* Optional for most items, and REQUIRED for 'page' and 'book' items: Array of chapter objects for books. Each chapter MUST have "heading", "description", and "contentLength". For pages, use a single chapter with "heading", "description", and "contentLength". */
-        { "heading": "Preface", /* REQUIRED. Short Title of the chapter*/
-          "description": "Introduction. Written by the author, explaining his decisions to start his travels.", /* REQUIRED. Short, but detailed abstract of the contents of the chapter. */
-          "contentLength": 50 /* REQUIRED. Length of the content in words. Range: 50-500 */
-        }
-      ],
-      "knownUses"?: /* Optional: Array of KnownUse objects describing how the item can be used. If not provided, the item has no known uses yet.
-        [
-          { 
-            "actionName": "Light the Lantern", /* REQUIRED: User-facing text for the action button. */
-            "promptEffect": "Light the lantern to illuminate the area.", /* REQUIRED: Non-empty text sent to the game AI when this action is chosen, e.g., "Player lights the lantern, illuminating the area." */
-            "description": "Use this to light your way in dark places.", /* REQUIRED: A small hint or detail for the player, shown as a tooltip, e.g., "Use this to light your way in dark places." */
-            "appliesWhenActive"?: true, /* Optional: If true, this use is shown when item.isActive is true. Defaults to false if not provided. */
-            "appliesWhenInactive"?: false /* Optional: If true, this use is shown when item.isActive is false or undefined. Defaults to false if not provided. */
-          }
-        ]
-    }
+{ 
+  "action": "gain",
+  item: {
+    "name": "Old Lantern",
+    "type": "equipment",
+    "description": "A dusty old lantern that still flickers faintly.",
+    "holderId": "player",
+    "activeDescription": "The lantern is lit and casts a warm glow.",
+    "isActive": false,
+    "knownUses": [
+      { 
+        "actionName": "Light the Lantern",
+        "promptEffect": "Light the lantern to illuminate the area.",
+        "description": "Use this to light your way in dark places.",
+        "appliesWhenInactive": true
+      },
+      { 
+        "actionName": "Extinguish the Lantern",
+        "promptEffect": "Extinguish the lantern.",
+        "description": "Extinguish and conserve the fuel",
+        "appliesWhenActive": true
+      }
+    ]
   }
+}
 
 - Example of gaining a new book item with chapters:
-  { "action": "gain", /* "put" action follows the same structure, but is used for placing new items in the world. */
-    item: { 
-      "name": "Adventurer's Path", /* REQUIRED: Full name of the item. */
-      "type": "book",
-      "description": "A personal recollection filled with the adventures of a seasoned explorer.", /* REQUIRED: Short description of the item. */
-      "tags": ["printed"], /* Optional: array of short tags describing the item. Valid tags: ${VALID_TAGS_STRING}.*/
-      "chapters": [ /* REQUIRED: Array of chapter objects for books. Each chapter MUST have "heading", "description", and "contentLength". */
-        { "heading": "Chapter 1: The Beginning", /* REQUIRED. Short Title of the chapter*/
-          "description": "The first steps of an adventurer's journey.", /* REQUIRED. Short, but detailed abstract of the contents of the chapter. */
-          "contentLength": 100 /* REQUIRED. Length of the content in words. Range: 50-500 */
-        },
-        { "heading": "Chapter 2: The Trials",
-          "description": "Facing challenges and overcoming obstacles.",
-          "contentLength": 150
-        },
-        { "heading": "Chapter 3: The Triumph",
-          "description": "The final victory and lessons learned.",
-          "contentLength": 200
-        }
-      ],
-      "holderId": "player", /* REQUIRED: ID of the NPC or map node that will hold the item. Use "player" for adding to Player's inventory, or a specific NPC ID for their inventory. */
-    }
+{
+  "action": "gain",
+  item: { 
+    "name": "Adventurer's Path",
+    "type": "book",
+    "description": "A personal recollection filled with the adventures of a seasoned explorer.",
+    "holderId": "player",
+    "tags": ["handwritten"],
+    "chapters": [
+      {
+        "heading": "Chapter 1: The Beginning",
+        "description": "The first steps of an adventurer's journey.",
+        "contentLength": 100
+      },
+      {
+        "heading": "Chapter 2: The Trials",
+        "description": "Facing challenges and overcoming obstacles.",
+        "contentLength": 150
+      },
+      {
+        "heading": "Chapter 3: The Triumph",
+        "description": "The final victory and lessons learned.",
+        "contentLength": 200
+      }
+    ]
   }
+}
 
 - Example for losing, destroying, completely removing an *existing* item from the world:
-  { "action": "destroy",
-    item:{
-      "id": "item_old_lantern_flickering_7fr4", /* REQUIRED: Unique identifier for the item being lost. Choose from the provided Player Inventory or Location Inventory. */
-      "name": "Old Lantern (flickering)" /* REQUIRED: Full name of the item being lost, including any notes in brackets. Choose from the provided Player inventory. */
-    }
+{
+  "action": "destroy",
+  item:
+  {
+    "id": "item_old_lantern_7fr4",
+    "name": "Old Lantern (flickering)"
   }
+}
 
-- Example for giving an *existing* item from one holder to another, or for placing it in the current location:
-  { "action": "give",
-    item: {
-      "id": "item_iron_sword_ab12",
-      "name": "Iron Sword",
-      "fromId": "player",
-      "toId": "npc_guard_4f3a"
-    }
+- Example for giving an *existing* item item_iron_sword_ab12 from player to npc_guard_4f3a, or for placing it in the current location:
+{
+  "action": "give",
+  item: {
+    "id": "item_iron_sword_ab12",
+    "name": "Iron Sword",
+    "fromId": "player",
+    "toId": "npc_guard_4f3a"
   }
+}
 
-- "take" is an alias for "give". It has the same structure and is used when the player takes an *existing* item from somewhere or someone. Example:
-  { "action": "take",
-    item: {
-      "id": "item_coin_pouch_8f2c",
-      "name": "Coin Pouch",
-      "fromId": "npc_bandit_8f2c",
-      "toId": "player"
-    }
+- Example of taking an *existing* item item_coin_pouch_8f2c from npc_bandit_1wrc and putting it in player's inventory:
+{
+  "action": "take",
+  item: {
+    "id": "item_coin_pouch_8f2c",
+    "name": "Coin Pouch",
+    "fromId": "npc_bandit_1wrc",
+    "toId": "player"
   }
+}
 
-- Example for simple update (only changing "isActive", other properties like type/description are inherited from the *existing* "Old Torch"): 
-  { "action": "update",
-      item: {
-        "id": "item_plasma_torch_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
-        "name": "Plasma Torch", /* REQUIRED: Full name of the item to update.  Choose from the provided context. */  
-        "isActive": true /* REQUIRED: true if the item is now active (e.g., a lit torch), false if it is inactive (e.g., an unlit torch). Defaults to false if not provided. */
+- Example of picking up an *existing* item item_crowbar_55nf from node_rubble_pile_f4s3 and putting it in player's inventory:
+{
+  "action": "take",
+  item: {
+    "id": "item_crowbar_55nf",
+    "name": "Crowbar",
+    "fromId": "node_rubble_pile_f4s3",
+    "toId": "player"
+  }
+}
+
+- Example for simple update that only changes "isActive" state (Lighting the Plasma Torch), all other properties are inherited from the *existing* item item_plasma_torch_7fr4:
+{
+  "action": "update",
+  item:
+  {
+    "id": "item_plasma_torch_7fr4",
+    "name": "Plasma Torch",
+    "isActive": true
+  }
+}
+
+- Example for transformation or crafting (new item details can be partial and will inherit old properties):
+{
+  "action": "update",
+  "item":
+  {
+    "id": "item_scrap_metal_7fr4",
+    "name": "Scrap Metal",
+    "newName": "Makeshift Shiv",
+    "type": "weapon",
+    "description": "A sharp piece of metal.",
+    "tags": [], /* empty array to remove the 'junk' tag from scrap metal */
+    "knownUses": [
+      { 
+        "actionName": "Cut",
+        "promptEffect": "Cut something with the shiv.",
+        "description": "Use this to cut things."
       }
+    ]
   }
+}
 
-- Example for transformation or crafting (new item details can be partial and will inherit missing fields):
-  { "action": "update",
-    "item": {
-      "id": "item_scrap_metal_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
-      "name": "Scrap Metal", /* REQUIRED: Full name of the item to update. Choose from the provided context. */
-      "newName": "Makeshift Shiv", /* REQUIRED: New name for the transformed item, e.g., "Makeshift Shiv" */
-      "type": "weapon", /* Optional: New type for the transformed item if it changes. MUST be one of ${VALID_ITEM_TYPES_STRING} */
-      "description": "A sharp piece of metal.", /* Optional: New description for the transformed item if it changes. */
-      "tags"?: ["junk"] /* Optional: Update the tags array. Include "junk" to mark the item as junk, remove it if the item becomes important again. IMPORTANT: "status effects" can never have the "junk" tag. */
-      "knownUses"?: [
-        { 
-          "actionName": "Cut", /* REQUIRED: User-facing text for the action button. */
-          "promptEffect": "Cut something.", /* REQUIRED: Non-empty text sent to the game AI when this action is chosen, e.g., "Player lights the lantern, illuminating the area." */
-          "description": "Use this to cut things.", /* REQUIRED: A small hint or detail for the player, shown as a tooltip, e.g., "Use this to light your way in dark places." */
-          "appliesWhenActive"?: false, /* Optional: If true, this use is shown when item.isActive is true. Defaults to false if not provided. */
-          "appliesWhenInactive"?: false /* Optional: If true, this use is shown when item.isActive is false or undefined. Defaults to false if not provided. */
-        }
-      ]
+- Example for adding a known use to *existing* item (existing properties and known uses are inherited): 
+{
+  "action": "update",
+  "item":
+  {
+    "id": "item_mystic_orb_7fr4",
+    "name": "Mystic Orb",
+    "addKnownUse":
+    {
+      "actionName": "Peer into the Orb",
+      "promptEffect": "Peer into the Mystic Orb, trying to glimpse the future.",
+      "description": "Try to see the beyond",
+      "AppliesWhenActive": true
     }
   }
-
-- Example for adding a known use to *existing* item (type/description etc. inherited): 
-  { "action": "update",
-    "item": {
-      "id": "item_mystic_orb_7fr4", /* REQUIRED: Unique identifier for the item. Choose from the provided context. */
-      "name": "Mystic Orb", /* REQUIRED: Full name of the item to update. Choose from the provided context. */
-      "addKnownUse": { /* REQUIRED: New known use to add to the item. */
-        "actionName": "Peer into the Orb", /* REQUIRED: User-facing text for the action button. */
-        "promptEffect": "Peer into the Mystic Orb, trying to glimpse the future.", /* REQUIRED: Non-empty text sent to the game AI when this action is chosen. */
-        "description": "Try to see the beyond", /* REQUIRED: A small hint or detail for the player, shown as a tooltip. */
-        "AppliesWhenActive": true /* Optional: If true, this use is shown when item.isActive is true. Defaults to false if not provided. */
-      }
-    }
-  }
+}
 
 - Example for adding a new chapter to an existing written item:
-  { "action": "addChapter",
-    "item": {
-      "id": "item_codex_8g3c", /* REQUIRED: Unique identifier for the item. */
-      "name": "The Codex of Whispering Echoes", /* REQUIRED: Name of the book. */
-      "chapter": {
-        "heading": "The Sacrifice of Silence",
-        "description": "A grim tale about the price of forbidden knowledge.",
-        "contentLength": 120
-      }
+{
+  "action": "addChapter",
+  "item":
+  {
+    "id": "item_codex_8g3c",
+    "name": "The Codex of Whispering Echoes",
+    "chapter":
+    {
+      "heading": "The Sacrifice of Silence",
+      "description": "A grim tale about the price of forbidden knowledge.",
+      "contentLength": 120
     }
   }
+}
 
-  - CRITICALLY IMPORTANT: holderId, toId, and fromId can only be 'node_*', 'npc_*' or 'player'. NEVER put an item inside another item!
-  - If the Player successfully restores, decodes or translates a 'book' or a 'page', you MUST add 'recovered' tag to the item, in addition to existing tags.
-  - If a torn page or book is completed by reuniting its missing half, you MUST add 'recovered' tag to the item and keep existing tags.
-  - ALWAYS appropriately handle spending single-use items and state toggles ("isActive": true/false).
-  - Using some "single-use" items (food, water, medicine, etc) MUST add or remove appropriate "status effect" items.
-  - Use "update" to change the remaining number of uses for multi-use items in their name (in brackets) or in description.
-  - IMPORTANT: For written 'page' and 'book' items (including journals), determine whether the text appears 'printed', 'handwritten', 'typed' or 'digital' and ALWAYS add the matching tag. If the text condition implies it, add other tags like 'faded', 'smudged', 'torn', or 'encrypted'. Available writing tags: ${WRITING_TAGS_STRING}.
-  - Journals contain no text until the player writes in them. They are treated as 'book' items and start with no chapters.
-  - When using "addChapter", simply append the chapter and reset "lastInspect" so the player discovers it later.
-  IMPORTANT: For items that CLEARLY can be enabled or disabled (e.g., light sources, powered equipment, wielded or worn items) provide at least the two knownUses to enable and disable them with appropriate names:
+- CRITICALLY IMPORTANT: holderId, toId, and fromId can only be 'node_*', 'npc_*' or 'player'. NEVER put an item inside another item!
+- If the Player successfully restores, decodes or translates a 'book' or a 'page', you MUST add 'recovered' tag to the item, in addition to existing tags.
+- If a torn page or book is completed by reuniting its missing half, you MUST add 'recovered' tag to the item and keep existing tags.
+- ALWAYS appropriately handle spending single-use items and state toggles ("isActive": true/false).
+- Using some "single-use" items (food, water, medicine, etc) MUST add or remove appropriate "status effect" items.
+- Use "update" to change the remaining number of uses for multi-use items in their name (in brackets) or in description.
+- Use "addChapter" to reveal new chapters, or when missing pages of a book are found and incorporated into the rest of the book.
+IMPORTANT: For items that CLEARLY can be enabled or disabled (e.g., light sources, powered equipment, wielded or worn items) provide at least the two knownUses to enable and disable them with appropriate names:
   - The knownUse to turn on, light, or otherwise enable the item should ALWAYS have "appliesWhenInactive": true (and typically "appliesWhenActive": false or undefined).
   - The knownUse to turn off, extinguish, or disable the item should ALWAYS have "appliesWhenActive": true (and typically "appliesWhenInactive": false or undefined).
-IMPORTANT: NEVER add "Inspect", "Use", "Drop", "Discard", "Enter", "Park", "Read", "Write" known uses - there are dedicated buttons for those in the game.
+  - ALWAYS provide these actions in pairs, e.g. turn on/turn off, wield/put away, wear/take off, light/extinguish, activate/deactivate, start/stop, etc.
+IMPORTANT: NEVER add ${DEDICATED_BUTTON_USES_STRING} known uses - there are dedicated buttons for those in the game.
 
 ${ITEM_TYPES_GUIDE}
 
-IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName" and optionally the new "type" and "description" if they change. Your "logMessage" must creatively explain this transformation. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand". The log message could be: "The strange metal device from another world shimmers and reshapes into a humming metal wand in your grasp!"
-
-Do not include any explanations or formatting outside of the JSON object.`;
+IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName" and optionally the new "type" and "description" if they change. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand"."
+`;


### PR DESCRIPTION
## Summary
- introduce `INVENTORY_JSON_SCHEMA` and related helper schemas
- link inventory API calls to the new schema
- trim system prompt and reference valid actions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68624cf33d2c8324a22f91d09907602b