### PR TITLE
Revise item change actions

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -84,7 +84,7 @@ export const VALID_ITEM_TYPES = [
 
 export const VALID_ITEM_TYPES_STRING = VALID_ITEM_TYPES.map(type => `"${type}"`).join(' | ');
 
-export const VALID_ACTIONS = ['gain', 'destroy', 'update', 'addChapter', 'put', 'give', 'take'] as const;
+export const VALID_ACTIONS = ['create', 'change', 'move', 'destroy', 'addDetails'] as const;
 export const VALID_ACTIONS_STRING = VALID_ACTIONS.map(action => `"${action}"`).join(' | ');
 
 export const COMMON_TAGS = [

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -54,18 +54,12 @@ const correctItemChanges = async ({
     let currentChange: ItemChange = { ...change };
 
     if ('item' in currentChange && (currentChange.item as { type?: string }).type === 'immovable') {
-      if (currentChange.action === 'gain') {
+      if (currentChange.action === 'create') {
         const itm = currentChange.item;
-        currentChange = {
-          action: 'put',
-          item: { ...itm, holderId: baseState.currentMapNodeId ?? 'unknown' },
-        };
-      } else if (currentChange.action === 'put') {
-        const item = currentChange.item;
-        if (!item.holderId.startsWith('node_')) {
-          item.holderId = baseState.currentMapNodeId ?? 'unknown';
+        if (!itm.holderId.startsWith('node_')) {
+          itm.holderId = baseState.currentMapNodeId ?? 'unknown';
         }
-      } else if (currentChange.action === 'give' || currentChange.action === 'take') {
+      } else if (currentChange.action === 'move') {
         const payload = currentChange.item;
         if (!payload.fromId.startsWith('node_')) {
           payload.fromId = baseState.currentMapNodeId ?? 'unknown';
@@ -129,7 +123,7 @@ const correctItemChanges = async ({
         );
         if (invItem) {
           currentChange = {
-            action: 'put',
+            action: 'create',
             item: {
               ...invItem,
               holderId: baseState.currentMapNodeId ?? 'unknown',
@@ -489,7 +483,7 @@ export const useProcessAiResponse = ({
 
       if (themeContextForResponse) {
         for (const change of combinedItemChanges) {
-          if (change.action === 'addChapter') {
+          if (change.action === 'addDetails') {
             const target = findItemByIdentifier([
               change.item.id,
               change.item.name,

--- a/services/inventory/api.ts
+++ b/services/inventory/api.ts
@@ -209,9 +209,9 @@ const mergeBookChaptersFromSuggestions = (
     const suggChapters = suggestion.chapters;
     if (!suggChapters || suggChapters.length === 0) continue;
     const match = itemChanges.find(
-      ch => (ch.action === 'gain' || ch.action === 'put') && ch.item.name === suggestion.name,
+      ch => ch.action === 'create' && ch.item.name === suggestion.name,
     );
-    if (match && (match.action === 'gain' || match.action === 'put')) {
+    if (match && match.action === 'create') {
       const item = match.item;
       if (!item.chapters || item.chapters.length !== suggChapters.length) {
         item.chapters = suggChapters;
@@ -309,7 +309,7 @@ export const applyInventoryHints_Service = async (
   if (parsed) {
     mergeBookChaptersFromSuggestions(parsed.itemChanges, newItems);
     for (const change of parsed.itemChanges) {
-      if ((change.action === 'gain' || change.action === 'put') && change.item.type === 'book') {
+      if (change.action === 'create' && change.item.type === 'book') {
         const chapters = change.item.chapters ?? [];
         if (chapters.length < MIN_BOOK_CHAPTERS) {
           const additional = await fetchAdditionalBookChapters_Service(

--- a/services/inventory/systemPrompt.ts
+++ b/services/inventory/systemPrompt.ts
@@ -15,19 +15,19 @@ Analyze the hints and optional new items JSON provided in the prompt.
 
 Define any operations on existing items in the Player's Inventory, based on Player's Action and the Player Items Hint.
 Define any operations on existing items at Locations, or in NPCs' inventories, according to Location Items Hint and NPCs Items Hint.
-Define any transfers of existing items between NPCs' and Player's Inventories using 'give' or 'take' actions.
-Items described in the "World Items Hint" must be placed at their appropriate map node holderId using the 'put' action.
+Define any transfers of existing items between NPCs' and Player's Inventories using the 'move' action.
+Items described in the "World Items Hint" must be placed at their appropriate map node holderId using the 'create' action.
 
 Available actions are: ${VALID_ACTIONS_STRING}.
-CRITICALLY IMPORTANT: Use 'put' or 'gain' only when revealing or creating a **NEW** item at a specific location, specific NPC inventory, or in Player's inventory. You MUST 'gain' or 'put' *all* items in the New Items JSON and *only* the items in the New Items JSON. NEVER gain or put items that are part of the Player's Inventory.
-CRITICALLY IMPORTANT: Use 'give' or 'take' when transferring an **EXISTING** item from one holder to another, or dropping/picking up the item at the current location.
+CRITICALLY IMPORTANT: Use 'create' only when revealing or creating a **NEW** item at a specific location, specific NPC inventory, or in Player's inventory. You MUST 'create' *all* items in the New Items JSON and *only* the items in the New Items JSON. NEVER create items that are part of the Player's Inventory.
+CRITICALLY IMPORTANT: Use 'move' when transferring an **EXISTING** item from one holder to another, or dropping/picking up the item at the current location.
 CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consumed, destroyed, or otherwise removed from the world.
 
 ## Examples:
 
 - Example for gaining a *new* item from the provided New Items JSON:
 { 
-  "action": "gain",
+  "action": "create",
   item: {
     "name": "Old Lantern",
     "type": "equipment",
@@ -54,7 +54,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example of gaining a new book item with chapters:
 {
-  "action": "gain",
+  "action": "create",
   item: { 
     "name": "Adventurer's Path",
     "type": "book",
@@ -93,7 +93,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example for giving an *existing* item item_iron_sword_ab12 from player to npc_guard_4f3a, or for placing it in the current location:
 {
-  "action": "give",
+  "action": "move",
   item: {
     "id": "item_iron_sword_ab12",
     "name": "Iron Sword",
@@ -104,7 +104,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example of taking an *existing* item item_coin_pouch_8f2c from npc_bandit_1wrc and putting it in player's inventory:
 {
-  "action": "take",
+  "action": "move",
   item: {
     "id": "item_coin_pouch_8f2c",
     "name": "Coin Pouch",
@@ -115,7 +115,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example of picking up an *existing* item item_crowbar_55nf from node_rubble_pile_f4s3 and putting it in player's inventory:
 {
-  "action": "take",
+  "action": "move",
   item: {
     "id": "item_crowbar_55nf",
     "name": "Crowbar",
@@ -126,7 +126,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example for simple update that only changes "isActive" state (Lighting the Plasma Torch), all other properties are inherited from the *existing* item item_plasma_torch_7fr4:
 {
-  "action": "update",
+  "action": "change",
   item:
   {
     "id": "item_plasma_torch_7fr4",
@@ -137,7 +137,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example for transformation or crafting (new item details can be partial and will inherit old properties):
 {
-  "action": "update",
+  "action": "change",
   "item":
   {
     "id": "item_scrap_metal_7fr4",
@@ -158,7 +158,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example for adding a known use to *existing* item (existing properties and known uses are inherited): 
 {
-  "action": "update",
+  "action": "change",
   "item":
   {
     "id": "item_mystic_orb_7fr4",
@@ -175,7 +175,7 @@ CRITICALLY IMPORTANT: Use 'destroy' ONLY when the item is **IRREVERSIBLY** consu
 
 - Example for adding a new chapter to an existing written item:
 {
-  "action": "addChapter",
+  "action": "addDetails",
   "item":
   {
     "id": "item_codex_8g3c",
@@ -204,5 +204,5 @@ IMPORTANT: NEVER add ${DEDICATED_BUTTON_USES_STRING} known uses - there are dedi
 
 ${ITEM_TYPES_GUIDE}
 
-IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "update", providing "newName" and optionally the new "type" and "description" if they change. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand"."
+IMPORTANT GAME FEATURE - Anachronistic Items: If some items are CLEARLY anachronistic for the current theme (e.g., a high-tech device in a medieval fantasy setting), you MAY transform them. Use "itemChange" with "action": "change", providing "newName" and optionally the new "type" and "description" if they change. For example, a "Laser Pistol" (Sci-Fi item) in a "Classic Dungeon Delve" (Fantasy theme) might transform into a "Humming Metal Wand"."
 `;

--- a/tests/inventoryUtils.test.ts
+++ b/tests/inventoryUtils.test.ts
@@ -6,7 +6,7 @@ import type { ItemChange, Item } from '../types';
 describe('inventoryUtils', () => {
   it('applyItemChangeAction adds gained item', () => {
     const change: ItemChange = {
-      action: 'gain',
+      action: 'create',
       item: { id: 'it1', name: 'Torch', type: 'equipment', description: 'Bright', holderId: PLAYER_HOLDER_ID },
     };
     const result = applyItemChangeAction([], change);
@@ -16,7 +16,7 @@ describe('inventoryUtils', () => {
 
   it('gain page item preserves contentLength', () => {
     const change: ItemChange = {
-      action: 'gain',
+      action: 'create',
       item: {
         id: 'pg1',
         name: 'Torn Note',
@@ -38,7 +38,7 @@ describe('inventoryUtils', () => {
 
   it('buildItemChangeRecords returns gain record', () => {
     const change: ItemChange = {
-      action: 'gain',
+      action: 'create',
       item: { id: 'it1', name: 'Torch', type: 'equipment', description: 'Bright', holderId: PLAYER_HOLDER_ID },
     };
     const records = buildItemChangeRecords([change], []);
@@ -63,11 +63,11 @@ describe('inventoryUtils', () => {
   it('applyAllItemChanges applies multiple changes', () => {
     const changes: Array<ItemChange> = [
       {
-        action: 'gain',
+        action: 'create',
         item: { id: 'it1', name: 'Torch', type: 'equipment', description: 'Bright', holderId: PLAYER_HOLDER_ID },
       },
       {
-        action: 'update',
+        action: 'change',
         item: { id: 'it1', name: 'Torch', isActive: true, holderId: PLAYER_HOLDER_ID },
       },
     ];
@@ -75,7 +75,7 @@ describe('inventoryUtils', () => {
     expect(result[0].isActive).toBe(true);
   });
 
-  it('addChapter action appends chapter and resets inspect turn', () => {
+  it('addDetails action appends chapter and resets inspect turn', () => {
     const initial: Array<Item> = [
       {
         id: 'book1',
@@ -90,7 +90,7 @@ describe('inventoryUtils', () => {
       },
     ];
     const change: ItemChange = {
-      action: 'addChapter',
+      action: 'addDetails',
       item: {
         id: 'book1',
         name: 'Mysteries',

--- a/tests/itemChangeParsing.test.ts
+++ b/tests/itemChangeParsing.test.ts
@@ -7,17 +7,17 @@ describe('parseInventoryResponse', () => {
   it('filters invalid ItemChange entries', () => {
     const rawPayload = {
       itemChanges: [
-        { action: 'gain', item: { name: 'Lantern', type: 'equipment', description: 'Bright', holderId: PLAYER } },
-        { action: 'gain', item: { name: 'BadItem', type: 'invalid', description: 'oops', holderId: PLAYER } },
-        { action: 'update', item: { name: 'Lantern', newName: 'Bright Lantern', holderId: PLAYER } },
-        { action: 'update', item: { newName: 'No Name' } },
+        { action: 'create', item: { name: 'Lantern', type: 'equipment', description: 'Bright', holderId: PLAYER } },
+        { action: 'create', item: { name: 'BadItem', type: 'invalid', description: 'oops', holderId: PLAYER } },
+        { action: 'change', item: { name: 'Lantern', newName: 'Bright Lantern', holderId: PLAYER } },
+        { action: 'change', item: { newName: 'No Name' } },
         { action: 'destroy', item: { id: 'old1', name: 'Old Lantern' } },
         { action: 'destroy', item: null },
-        { action: 'give', item: { id: 'gift1', fromId: PLAYER, toId: 'npc1' } },
-        { action: 'take', item: { id: 'gift2', fromId: 'npc2', toId: PLAYER } },
-        { action: 'give', item: { id: 5, fromId: PLAYER } },
+        { action: 'move', item: { id: 'gift1', fromId: PLAYER, toId: 'npc1' } },
+        { action: 'move', item: { id: 'gift2', fromId: 'npc2', toId: PLAYER } },
+        { action: 'move', item: { id: 5, fromId: PLAYER } },
         { action: 123, item: { name: 'Bad', type: 'equipment', description: 'x', holderId: PLAYER } },
-        { action: 'gain', item: 'not object' },
+        { action: 'create', item: 'not object' },
       ],
       observations: 'obs',
       rationale: 'why',
@@ -43,11 +43,11 @@ describe('parseInventoryResponse', () => {
   it('handles update rename and destroy heuristics with put action', () => {
     const payload = {
       itemChanges: [
-        { action: 'update', item: { id: 'i1', name: 'Old Sword', newName: 'Shiny Sword' } },
-        { action: 'update', item: { id: 'i2', name: 'Old Shield' } },
-        { action: 'update', item: { id: 'i3', name: 'Broken Torch', type: 'destroyed' } },
-        { action: 'update', item: { id: 'i4', name: 'Lost Ring', status: 'gone' } },
-        { action: 'put', item: { name: 'Lantern', type: 'Equipment', description: 'Bright', holderId: 'node1' } },
+        { action: 'change', item: { id: 'i1', name: 'Old Sword', newName: 'Shiny Sword' } },
+        { action: 'change', item: { id: 'i2', name: 'Old Shield' } },
+        { action: 'change', item: { id: 'i3', name: 'Broken Torch', type: 'destroyed' } },
+        { action: 'change', item: { id: 'i4', name: 'Lost Ring', status: 'gone' } },
+        { action: 'create', item: { name: 'Lantern', type: 'Equipment', description: 'Bright', holderId: 'node1' } },
       ],
     };
 
@@ -61,15 +61,15 @@ describe('parseInventoryResponse', () => {
       payload.itemChanges[1],
       { action: 'destroy', item: { id: 'i3', name: 'Broken Torch' } },
       { action: 'destroy', item: { id: 'i4', name: 'Lost Ring' } },
-      { action: 'put', item: { name: 'Lantern', type: 'equipment', description: 'Bright', holderId: 'node1' } },
+      { action: 'create', item: { name: 'Lantern', type: 'equipment', description: 'Bright', holderId: 'node1' } },
     ]);
   });
 
   it('adds printed tag when page item lacks style tags', () => {
     const payload = {
       itemChanges: [
-        {
-          action: 'gain',
+          {
+            action: 'create',
           item: {
             name: 'Mysterious Note',
             type: 'page',

--- a/types.ts
+++ b/types.ts
@@ -65,7 +65,7 @@ export interface Item {
   chapters?: Array<ItemChapter>;
   lastWriteTurn?: number;
   lastInspectTurn?: number;
-  // --- Fields for "update" action payloads ---
+  // --- Fields for "change" action payloads ---
   newName?: string;
   addKnownUse?: KnownUse;
 }
@@ -76,7 +76,7 @@ export interface ItemReference {
   name?: string;
 }
 
-export interface GiveItemPayload {
+export interface MoveItemPayload {
   id?: string;
   name?: string;
   fromId: string;
@@ -85,7 +85,7 @@ export interface GiveItemPayload {
   toName?: string;
 }
 
-export type ItemUpdatePayload =
+export type ItemChangePayload =
   Partial<Omit<Item, 'activeDescription'>> & { activeDescription?: string | null };
 
 export interface NewItemSuggestion {
@@ -100,7 +100,7 @@ export interface NewItemSuggestion {
   knownUses?: Array<KnownUse>;
 }
 
-export interface AddChapterPayload {
+export interface AddDetailsPayload {
   id?: string;
   name?: string;
   chapter: ItemChapter;
@@ -108,12 +108,7 @@ export interface AddChapterPayload {
 
 export type ItemChange =
   | {
-      action: 'gain';
-      item: Item;
-      invalidPayload?: unknown;
-    }
-  | {
-      action: 'put';
+      action: 'create';
       item: Item;
       invalidPayload?: unknown;
     }
@@ -123,23 +118,18 @@ export type ItemChange =
       invalidPayload?: unknown;
     }
   | {
-      action: 'update';
-      item: ItemUpdatePayload;
+      action: 'change';
+      item: ItemChangePayload;
       invalidPayload?: unknown;
     }
   | {
-      action: 'addChapter';
-      item: AddChapterPayload;
+      action: 'addDetails';
+      item: AddDetailsPayload;
       invalidPayload?: unknown;
     }
   | {
-      action: 'give';
-      item: GiveItemPayload;
-      invalidPayload?: unknown;
-    }
-  | {
-      action: 'take';
-      item: GiveItemPayload;
+      action: 'move';
+      item: MoveItemPayload;
       invalidPayload?: unknown;
     };
 


### PR DESCRIPTION
## Summary
- introduce new inventory actions and payload types
- update constants and validation helpers
- adjust inventory utilities and response parsing
- align prompts and correction services with new actions
- update tests for renamed actions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686290cbb0f48324a12f17cf0abc0da5