### PR TITLE
Fix dynamic import issue in storage.ts

### DIFF
--- a/services/storage.ts
+++ b/services/storage.ts
@@ -14,6 +14,7 @@ import {
   expandSavedStackToFullStates,
   normalizeLoadedSaveDataStack,
 } from './saveLoad';
+import { attachImageRefsFromDb } from './imageDb';
 import { safeParseJson } from '../utils/jsonUtils';
 
 /** Saves the current game state to localStorage. */
@@ -76,7 +77,6 @@ export const loadGameStateFromLocalStorageWithImages = async (): Promise<GameSta
   const loaded = loadGameStateFromLocalStorage();
   if (!loaded) return null;
   const [current, previous] = loaded;
-  const { attachImageRefsFromDb } = await import('./imageDb');
   const withImagesCurrent = await attachImageRefsFromDb(current);
   const withImagesPrevious = previous ? await attachImageRefsFromDb(previous) : undefined;
   return [withImagesCurrent, withImagesPrevious];


### PR DESCRIPTION
## Summary
- use static import for `attachImageRefsFromDb` to avoid runtime resolution issues

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686517f4beb08324bac2968921fdbd7c