### PR TITLE
Enable stash for pictures and maps

### DIFF
--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -180,7 +180,13 @@ function InventoryItem({
     );
   }
 
-  if ((item.type === 'page' || item.type === 'book') && !isConfirmingDiscard) {
+  if (
+    (item.type === 'page' ||
+      item.type === 'book' ||
+      item.type === 'picture' ||
+      item.type === 'map') &&
+    !isConfirmingDiscard
+  ) {
     actionButtons.push(
       <Button
         ariaLabel={filterMode === 'stashed' ? `Retrieve ${item.name}` : `Stash ${item.name}`}

--- a/hooks/useInventoryActions.ts
+++ b/hooks/useInventoryActions.ts
@@ -47,7 +47,10 @@ export const useInventoryActions = ({
         }
 
         const shouldResetStashed =
-          item.type === 'page' || item.type === 'book';
+          item.type === 'page' ||
+          item.type === 'book' ||
+          item.type === 'picture' ||
+          item.type === 'map';
 
         return {
           ...item,


### PR DESCRIPTION
## Summary
- allow stash/retrieve for picture and map items
- reset stashed flag on drop for picture and map items

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865423db99c8324a3d1081cccfa725f