### PR TITLE
Enable stash for pictures and maps

### DIFF
--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -48,7 +48,11 @@ function InventoryItem({
   registerRef,
 }: InventoryItemProps) {
   const displayDescription = item.isActive && item.activeDescription ? item.activeDescription : item.description;
-  const isWrittenItem = item.type === 'page' || item.type === 'book';
+  const isWrittenItem =
+    item.type === 'page' ||
+    item.type === 'book' ||
+    item.type === 'picture' ||
+    item.type === 'map';
   const isImageItem = item.type === 'picture' || item.type === 'map';
   const canShowGenericUse =
     item.type !== 'status effect' && item.type !== 'vehicle';
@@ -180,7 +184,13 @@ function InventoryItem({
     );
   }
 
-  if ((item.type === 'page' || item.type === 'book') && !isConfirmingDiscard) {
+  if (
+    (item.type === 'page' ||
+      item.type === 'book' ||
+      item.type === 'picture' ||
+      item.type === 'map') &&
+    !isConfirmingDiscard
+  ) {
     actionButtons.push(
       <Button
         ariaLabel={filterMode === 'stashed' ? `Retrieve ${item.name}` : `Stash ${item.name}`}

--- a/hooks/useInventoryActions.ts
+++ b/hooks/useInventoryActions.ts
@@ -47,7 +47,10 @@ export const useInventoryActions = ({
         }
 
         const shouldResetStashed =
-          item.type === 'page' || item.type === 'book';
+          item.type === 'page' ||
+          item.type === 'book' ||
+          item.type === 'picture' ||
+          item.type === 'map';
 
         return {
           ...item,

--- a/hooks/useInventoryDisplay.ts
+++ b/hooks/useInventoryDisplay.ts
@@ -227,7 +227,7 @@ export const useInventoryDisplay = ({
   const displayedItems = useMemo(() => {
     const itemsToDisplay = items.filter(item => {
       if (stashingItemNames.has(item.name)) return true;
-      const isWritten = ['page', 'book'].includes(item.type);
+      const isWritten = ['page', 'book', 'picture', 'map'].includes(item.type);
       if (filterMode === 'stashed') return item.stashed && isWritten;
       const isStashedWritten = item.stashed && isWritten;
       return !isStashedWritten;


### PR DESCRIPTION
## Summary
- allow stash/retrieve for picture and map items
- reset stashed flag on drop for picture and map items
- treat maps and pictures as written items to hide drop button unless stashed
- fix stash filtering so maps and pictures move to Stash view

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865423db99c8324a3d1081cccfa725f