### PR TITLE
Add tooltip to sidebar journal button

### DIFF
--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -81,6 +81,7 @@ function GameSidebar({
           onClick={onReadPlayerJournal}
           preset="blue"
           size="lg"
+          title="Write a journal entry"
           variant="toolbarLarge"
         />
       </div>

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -545,6 +545,7 @@ function PageView({
                 onClick={handleWriteClick}
                 preset="blue"
                 size="sm"
+                title="Write a new journal entry"
                 variant="compact"
               />
             ) : null}


### PR DESCRIPTION
## Summary
- add tooltip to open journal button in sidebar
- retain tooltip for small journal write button

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68656062d4188324acfb87eb78287c69