### PR TITLE
Add Google login to fetch API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ An AI-powered text adventure built with React and TypeScript. The game uses Goog
 
 1. **Install Node.js 18 or newer**.
 2. **Set the environment variable `GEMINI_API_KEY`** with your API key so the app can talk to the Gemini service.
-3. Install dependencies and launch the dev server:
+3. *(Optional)* **Set `GOOGLE_CLIENT_ID`** if you want players to fetch their API key automatically using Google Login.
+4. Install dependencies and launch the dev server:
    ```bash
    npm install
    npm run dev
    ```
    The game will be available at `http://localhost:5173`.
-4. To verify TypeScript compilation and bundling run:
+5. To verify TypeScript compilation and bundling run:
    ```bash
    npm run build
    ```
-5. To lint the project run the test script:
+6. To lint the project run the test script:
    ```bash
    npm test
    ```

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -23,6 +23,8 @@ import CustomGameSetupScreen from '../modals/CustomGameSetupScreen';
 import SettingsDisplay from '../modals/SettingsDisplay';
 import InfoDisplay from '../modals/InfoDisplay';
 import DebugLoreModal from '../modals/DebugLoreModal';
+import { loginWithGoogle } from '../../services/auth/googleAuth';
+import { isApiConfigured } from '../../services/apiClient';
 import Footer from './Footer';
 import AppModals from './AppModals';
 import AppHeader from './AppHeader';
@@ -320,9 +322,7 @@ function App() {
       debugLore, debugGoodFacts, debugBadFacts,
     ],
   });
-
-
-
+  const [apiConfigured, setApiConfigured] = useState(isApiConfigured());
 
   const canPerformFreeAction = score >= FREE_FORM_ACTION_COST && !isLoading && hasGameBeenInitialized && !dialogueState;
 
@@ -606,6 +606,13 @@ function App() {
     }
     setShouldReturnToTitleMenu(false);
   }, [closeInfoModal, shouldReturnToTitleMenu, hasGameBeenInitialized, openTitleMenu, setShouldReturnToTitleMenu]);
+  const handleLoginWithGoogle = useCallback(() => {
+    void (async () => {
+      await loginWithGoogle();
+      setApiConfigured(isApiConfigured());
+    })();
+  }, []);
+
 
 
   const handleOpenCustomGameSetup = useCallback(() => {
@@ -877,6 +884,8 @@ function App() {
         isVisible={effectiveIsTitleMenuOpen}
         onClose={closeTitleMenu}
         onCustomGame={handleOpenCustomGameSetup}
+        onLoginWithGoogle={handleLoginWithGoogle}
+        isApiConfigured={apiConfigured}
         onLoadGame={handleLoadGameFromMenu}
         onNewGame={handleNewGameFromMenu}
         onOpenInfo={openInfoFromMenu}

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -5,6 +5,7 @@
  */
 import { useCallback } from 'react';
 import { CURRENT_GAME_VERSION } from '../../constants';
+import { isGoogleAuthAvailable } from '../../services/auth/googleAuth';
 import AppHeader from '../app/AppHeader';
 import Button from '../elements/Button';
 import { Icon } from '../elements/icons';
@@ -113,7 +114,7 @@ function TitleMenu({
               size="lg"
             />
 
-            {!isApiConfigured && onLoginWithGoogle ? (
+            {!isApiConfigured && onLoginWithGoogle && isGoogleAuthAvailable() ? (
               <Button
                 ariaLabel="Login with Google to fetch your API key"
                 label="Login with Google"

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -19,6 +19,8 @@ interface TitleMenuProps {
   readonly onLoadGame: () => void;
   readonly onOpenSettings: () => void;
   readonly onOpenInfo: () => void;
+  readonly onLoginWithGoogle?: () => void;
+  readonly isApiConfigured?: boolean;
   readonly isGameActive: boolean;
 }
 
@@ -34,6 +36,8 @@ function TitleMenu({
   onLoadGame,
   onOpenSettings,
   onOpenInfo,
+  onLoginWithGoogle,
+  isApiConfigured,
   isGameActive,
 }: TitleMenuProps) {
 
@@ -109,6 +113,16 @@ function TitleMenu({
               size="lg"
             />
 
+            {!isApiConfigured && onLoginWithGoogle ? (
+              <Button
+                ariaLabel="Login with Google to fetch your API key"
+                label="Login with Google"
+                onClick={onLoginWithGoogle}
+                preset="yellow"
+                size="lg"
+              />
+            ) : null}
+
             <Button
               ariaLabel="Open Settings"
               label="Settings"
@@ -146,6 +160,10 @@ function TitleMenu({
   );
 }
 
-TitleMenu.defaultProps = { onSaveGame: undefined };
+TitleMenu.defaultProps = {
+  onSaveGame: undefined,
+  isApiConfigured: false,
+  onLoginWithGoogle: undefined,
+};
 
 export default TitleMenu;

--- a/constants.ts
+++ b/constants.ts
@@ -41,6 +41,8 @@ export const CURRENT_SAVE_GAME_VERSION = "7";
 export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
 export const LOCAL_STORAGE_DEBUG_KEY = "whispersInTheDark_debugPacket";
 export const LOCAL_STORAGE_DEBUG_LORE_KEY = "whispersInTheDark_debugLore";
+export const LOCAL_STORAGE_API_KEY = "whispersInTheDark_geminiApiKey";
+export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? '';
 
 export const DEFAULT_STABILITY_LEVEL = 30; // Number of turns before chaos can occur
 export const DEFAULT_CHAOS_LEVEL = 5;   // Percentage chance of chaos shift

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.4",
       "dependencies": {
         "@google/genai": "^1.7.0",
+        "google-auth-library": "^10.1.0",
         "idb": "^8.0.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -948,6 +949,95 @@
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google/genai/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
           "optional": true
         }
       }
@@ -2762,6 +2852,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3601,6 +3700,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -3688,6 +3810,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3745,33 +3879,31 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -3885,26 +4017,27 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.1.0.tgz",
+      "integrity": "sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -3931,16 +4064,16 @@
       "license": "MIT"
     },
     "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
       "license": "MIT",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^7.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/has-bigints": {
@@ -4897,24 +5030,42 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -6544,6 +6695,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.7.0",
+    "google-auth-library": "^10.1.0",
     "idb": "^8.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -3,21 +3,43 @@
  * @description Centralized Gemini API key handling and client exposure.
  */
 import { GoogleGenAI } from '@google/genai';
+import { LOCAL_STORAGE_API_KEY } from '../constants';
 
-/** Cached API key read from environment variables. */
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? process.env.API_KEY;
+let geminiApiKey: string | null = null;
 
-if (!GEMINI_API_KEY) {
-  console.error('GEMINI_API_KEY environment variable is not set. Gemini services will be unavailable.');
+try {
+  geminiApiKey = localStorage.getItem(LOCAL_STORAGE_API_KEY);
+} catch {
+  geminiApiKey = null;
+}
+
+geminiApiKey ??=
+  process.env.GEMINI_API_KEY ?? process.env.API_KEY ?? null;
+
+if (!geminiApiKey) {
+  console.error(
+    'GEMINI_API_KEY environment variable is not set. Gemini services will be unavailable.',
+  );
 }
 
 /** Shared GoogleGenAI client instance, or null if API key is missing. */
-export const geminiClient: GoogleGenAI | null = GEMINI_API_KEY
-  ? new GoogleGenAI({ apiKey: GEMINI_API_KEY })
+export let geminiClient: GoogleGenAI | null = geminiApiKey
+  ? new GoogleGenAI({ apiKey: geminiApiKey })
   : null;
 
 /** Returns whether the Gemini API key is configured. */
-export const isApiConfigured = (): boolean => !!GEMINI_API_KEY;
+export const isApiConfigured = (): boolean => geminiApiKey !== null;
 
 /** Returns the configured API key, or null when absent. */
-export const getApiKey = (): string | null => GEMINI_API_KEY ?? null;
+export const getApiKey = (): string | null => geminiApiKey;
+
+/** Sets the API key and updates the shared client instance. */
+export const setApiKey = (key: string): void => {
+  geminiApiKey = key;
+  try {
+    localStorage.setItem(LOCAL_STORAGE_API_KEY, key);
+  } catch {
+    // ignore storage errors
+  }
+  geminiClient = new GoogleGenAI({ apiKey: key });
+};

--- a/services/auth/googleAuth.ts
+++ b/services/auth/googleAuth.ts
@@ -20,6 +20,9 @@ declare global {
 
 let scriptPromise: Promise<void> | null = null;
 
+/** Returns true when a Google OAuth client ID is provided. */
+export const isGoogleAuthAvailable = (): boolean => GOOGLE_CLIENT_ID.trim().length > 0;
+
 const loadGoogleScript = (): Promise<void> => {
   if (scriptPromise) return scriptPromise;
   scriptPromise = new Promise((resolve, reject) => {
@@ -47,6 +50,10 @@ const loadGoogleScript = (): Promise<void> => {
  * Prompts the user to sign in with Google and fetches their Gemini API key.
  */
 export const loginWithGoogle = async (): Promise<void> => {
+  if (!isGoogleAuthAvailable()) {
+    console.error('GOOGLE_CLIENT_ID is not configured; cannot use Google login.');
+    return;
+  }
   await loadGoogleScript();
   if (!window.google?.accounts?.id) {
     console.error('Google Identity Services failed to initialize.');

--- a/services/auth/googleAuth.ts
+++ b/services/auth/googleAuth.ts
@@ -1,0 +1,87 @@
+/**
+ * @file services/auth/googleAuth.ts
+ * @description Google authentication helpers to fetch the user's Gemini API key.
+ */
+import { setApiKey } from '../apiClient';
+import { GOOGLE_CLIENT_ID } from '../../constants';
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        id: {
+          initialize: (options: { client_id: string; callback: (resp: { credential: string }) => void }) => void;
+          prompt: () => void;
+        };
+      };
+    };
+  }
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+const loadGoogleScript = (): Promise<void> => {
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve, reject) => {
+    if (document.querySelector('script[data-google-identity]')) {
+      resolve();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.dataset.googleIdentity = 'true';
+    script.onload = () => {
+      resolve();
+    };
+    script.onerror = () => {
+      reject(new Error('Failed to load Google Identity script'));
+    };
+    document.head.append(script);
+  });
+  return scriptPromise;
+};
+
+/**
+ * Prompts the user to sign in with Google and fetches their Gemini API key.
+ */
+export const loginWithGoogle = async (): Promise<void> => {
+  await loadGoogleScript();
+  if (!window.google?.accounts?.id) {
+    console.error('Google Identity Services failed to initialize.');
+    return;
+  }
+  return new Promise(resolve => {
+    window.google?.accounts?.id.initialize({
+      client_id: GOOGLE_CLIENT_ID,
+      callback: ({ credential }) => {
+        void (async () => {
+          try {
+            const resp = await fetch(
+              'https://aistudio.googleapis.com/v1alpha/userAPIKey',
+              { headers: { Authorization: `Bearer ${credential}` } },
+            );
+            if (!resp.ok) {
+              console.error('Failed to fetch API key from Google AI Studio.');
+              resolve();
+              return;
+            }
+            const data: unknown = await resp.json();
+            const key = (data as { apiKey?: unknown }).apiKey;
+            if (typeof key === 'string') {
+              setApiKey(key);
+            } else {
+              console.error('Google AI Studio response missing apiKey field.');
+            }
+          } catch (err) {
+            console.error('Error retrieving Gemini API key:', err);
+          } finally {
+            resolve();
+          }
+        })();
+      },
+    });
+    window.google?.accounts?.id.prompt();
+  });
+};

--- a/services/geminiClient.ts
+++ b/services/geminiClient.ts
@@ -3,7 +3,7 @@
  * @description Provides a shared GoogleGenAI client instance.
  */
 import { GoogleGenAI } from "@google/genai";
-import { geminiClient, isApiConfigured } from "./apiClient";
+import { geminiClient, isApiConfigured } from './apiClient';
 
 if (!isApiConfigured()) {
   console.error("GEMINI_API_KEY environment variable is not set. The application will not be able to connect to the Gemini API.");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }: { mode: string }) => {
     define: {
       'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+      'process.env.GOOGLE_CLIENT_ID': JSON.stringify(env.GOOGLE_CLIENT_ID),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- allow storing API key in localStorage and update Gemini client
- expose `GOOGLE_CLIENT_ID` and `LOCAL_STORAGE_API_KEY` constants
- provide Google authentication helper service
- show Google login button in title menu
- wire login button into app

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68657d0df7b8832498a85e6a7619a736