### PR TITLE
Add Google login using google-auth-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,22 @@ An AI-powered text adventure built with React and TypeScript. The game uses Goog
 
 1. **Install Node.js 18 or newer**.
 2. **Set the environment variable `GEMINI_API_KEY`** with your API key so the app can talk to the Gemini service.
-3. Install dependencies and launch the dev server:
+3. *(Optional)* Provide a Google OAuth client ID to enable "Login with Google".
+   You can set the `GOOGLE_CLIENT_ID` environment variable or assign
+   `window.GOOGLE_CLIENT_ID` in `index.html` before loading the application.
+   The app uses **google-auth-library** to sign you in and automatically fetch
+   your personal API key from Google AI Studio.
+4. Install dependencies and launch the dev server:
    ```bash
    npm install
    npm run dev
    ```
    The game will be available at `http://localhost:5173`.
-4. To verify TypeScript compilation and bundling run:
+5. To verify TypeScript compilation and bundling run:
    ```bash
    npm run build
    ```
-5. To lint the project run the test script:
+6. To lint the project run the test script:
    ```bash
    npm test
    ```

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -23,6 +23,8 @@ import CustomGameSetupScreen from '../modals/CustomGameSetupScreen';
 import SettingsDisplay from '../modals/SettingsDisplay';
 import InfoDisplay from '../modals/InfoDisplay';
 import DebugLoreModal from '../modals/DebugLoreModal';
+import { loginWithGoogle, maybeCompleteOAuth } from '../../services/auth/googleAuth';
+import { isApiConfigured } from '../../services/apiClient';
 import Footer from './Footer';
 import AppModals from './AppModals';
 import AppHeader from './AppHeader';
@@ -320,9 +322,14 @@ function App() {
       debugLore, debugGoodFacts, debugBadFacts,
     ],
   });
+  const [apiConfigured, setApiConfigured] = useState(isApiConfigured());
 
-
-
+  useEffect(() => {
+    void (async () => {
+      await maybeCompleteOAuth();
+      setApiConfigured(isApiConfigured());
+    })();
+  }, []);
 
   const canPerformFreeAction = score >= FREE_FORM_ACTION_COST && !isLoading && hasGameBeenInitialized && !dialogueState;
 
@@ -606,6 +613,13 @@ function App() {
     }
     setShouldReturnToTitleMenu(false);
   }, [closeInfoModal, shouldReturnToTitleMenu, hasGameBeenInitialized, openTitleMenu, setShouldReturnToTitleMenu]);
+  const handleLoginWithGoogle = useCallback(() => {
+    void (async () => {
+      await loginWithGoogle();
+      setApiConfigured(isApiConfigured());
+    })();
+  }, []);
+
 
 
   const handleOpenCustomGameSetup = useCallback(() => {
@@ -877,6 +891,8 @@ function App() {
         isVisible={effectiveIsTitleMenuOpen}
         onClose={closeTitleMenu}
         onCustomGame={handleOpenCustomGameSetup}
+        onLoginWithGoogle={handleLoginWithGoogle}
+        isApiConfigured={apiConfigured}
         onLoadGame={handleLoadGameFromMenu}
         onNewGame={handleNewGameFromMenu}
         onOpenInfo={openInfoFromMenu}

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -19,6 +19,8 @@ interface TitleMenuProps {
   readonly onLoadGame: () => void;
   readonly onOpenSettings: () => void;
   readonly onOpenInfo: () => void;
+  readonly onLoginWithGoogle?: () => void;
+  readonly isApiConfigured?: boolean;
   readonly isGameActive: boolean;
 }
 
@@ -34,6 +36,8 @@ function TitleMenu({
   onLoadGame,
   onOpenSettings,
   onOpenInfo,
+  onLoginWithGoogle,
+  isApiConfigured,
   isGameActive,
 }: TitleMenuProps) {
 
@@ -109,6 +113,16 @@ function TitleMenu({
               size="lg"
             />
 
+            {!isApiConfigured && onLoginWithGoogle ? (
+              <Button
+                ariaLabel="Login with Google to fetch your API key"
+                label="Login with Google"
+                onClick={onLoginWithGoogle}
+                preset="yellow"
+                size="lg"
+              />
+            ) : null}
+
             <Button
               ariaLabel="Open Settings"
               label="Settings"
@@ -146,6 +160,10 @@ function TitleMenu({
   );
 }
 
-TitleMenu.defaultProps = { onSaveGame: undefined };
+TitleMenu.defaultProps = {
+  onSaveGame: undefined,
+  isApiConfigured: false,
+  onLoginWithGoogle: undefined,
+};
 
 export default TitleMenu;

--- a/constants.ts
+++ b/constants.ts
@@ -41,6 +41,11 @@ export const CURRENT_SAVE_GAME_VERSION = "7";
 export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
 export const LOCAL_STORAGE_DEBUG_KEY = "whispersInTheDark_debugPacket";
 export const LOCAL_STORAGE_DEBUG_LORE_KEY = "whispersInTheDark_debugLore";
+export const LOCAL_STORAGE_API_KEY = "whispersInTheDark_geminiApiKey";
+export const GOOGLE_CLIENT_ID =
+  (typeof window !== 'undefined'
+    ? (window as { GOOGLE_CLIENT_ID?: string }).GOOGLE_CLIENT_ID
+    : undefined) ?? process.env.GOOGLE_CLIENT_ID ?? '';
 
 export const DEFAULT_STABILITY_LEVEL = 30; // Number of turns before chaos can occur
 export const DEFAULT_CHAOS_LEVEL = 5;   // Percentage chance of chaos shift

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.4",
       "dependencies": {
         "@google/genai": "^1.7.0",
+        "google-auth-library": "^9.15.1",
         "idb": "^8.0.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.7.0",
+    "google-auth-library": "^9.15.1",
     "idb": "^8.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -3,21 +3,43 @@
  * @description Centralized Gemini API key handling and client exposure.
  */
 import { GoogleGenAI } from '@google/genai';
+import { LOCAL_STORAGE_API_KEY } from '../constants';
 
-/** Cached API key read from environment variables. */
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? process.env.API_KEY;
+let geminiApiKey: string | null = null;
 
-if (!GEMINI_API_KEY) {
-  console.error('GEMINI_API_KEY environment variable is not set. Gemini services will be unavailable.');
+try {
+  geminiApiKey = localStorage.getItem(LOCAL_STORAGE_API_KEY);
+} catch {
+  geminiApiKey = null;
+}
+
+geminiApiKey ??=
+  process.env.GEMINI_API_KEY ?? process.env.API_KEY ?? null;
+
+if (!geminiApiKey) {
+  console.error(
+    'GEMINI_API_KEY environment variable is not set. Gemini services will be unavailable.',
+  );
 }
 
 /** Shared GoogleGenAI client instance, or null if API key is missing. */
-export const geminiClient: GoogleGenAI | null = GEMINI_API_KEY
-  ? new GoogleGenAI({ apiKey: GEMINI_API_KEY })
+export let geminiClient: GoogleGenAI | null = geminiApiKey
+  ? new GoogleGenAI({ apiKey: geminiApiKey })
   : null;
 
 /** Returns whether the Gemini API key is configured. */
-export const isApiConfigured = (): boolean => !!GEMINI_API_KEY;
+export const isApiConfigured = (): boolean => geminiApiKey !== null;
 
 /** Returns the configured API key, or null when absent. */
-export const getApiKey = (): string | null => GEMINI_API_KEY ?? null;
+export const getApiKey = (): string | null => geminiApiKey;
+
+/** Sets the API key and updates the shared client instance. */
+export const setApiKey = (key: string): void => {
+  geminiApiKey = key;
+  try {
+    localStorage.setItem(LOCAL_STORAGE_API_KEY, key);
+  } catch {
+    // ignore storage errors
+  }
+  geminiClient = new GoogleGenAI({ apiKey: key });
+};

--- a/services/auth/googleAuth.ts
+++ b/services/auth/googleAuth.ts
@@ -1,0 +1,79 @@
+/**
+ * @file services/auth/googleAuth.ts
+ * @description Google OAuth helpers to fetch the user\'s Gemini API key.
+ */
+import { OAuth2Client, CodeChallengeMethod } from 'google-auth-library';
+import { GOOGLE_CLIENT_ID } from '../../constants';
+import { setApiKey } from '../apiClient';
+
+const CODE_VERIFIER_KEY = 'whispersInTheDark_codeVerifier';
+
+/** Returns true when a Google OAuth client ID is provided. */
+export const isGoogleAuthAvailable = (): boolean => GOOGLE_CLIENT_ID.trim().length > 0;
+
+const createOAuthClient = (): OAuth2Client =>
+  new OAuth2Client({ clientId: GOOGLE_CLIENT_ID, redirectUri: window.location.origin + window.location.pathname });
+
+/**
+ * Starts the OAuth flow by redirecting the browser to the consent page.
+ */
+export const loginWithGoogle = async (): Promise<void> => {
+  if (!isGoogleAuthAvailable()) {
+    console.error('GOOGLE_CLIENT_ID is not configured; cannot use Google login.');
+    return;
+  }
+  const client = createOAuthClient();
+  const { codeVerifier, codeChallenge } = await client.generateCodeVerifierAsync();
+  try {
+    sessionStorage.setItem(CODE_VERIFIER_KEY, codeVerifier);
+  } catch {
+    // ignore storage errors
+  }
+  const url = client.generateAuthUrl({
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    prompt: 'consent',
+    access_type: 'online',
+    code_challenge: codeChallenge,
+    code_challenge_method: CodeChallengeMethod.S256,
+  });
+  window.location.href = url;
+};
+
+/**
+ * Handles a redirect from Google OAuth and fetches the user\'s API key.
+ */
+export const maybeCompleteOAuth = async (): Promise<void> => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  const codeVerifier = sessionStorage.getItem(CODE_VERIFIER_KEY);
+  if (!code || !codeVerifier) return;
+
+  const client = createOAuthClient();
+  try {
+    const { tokens } = await client.getToken({ code, codeVerifier });
+    const token = tokens.access_token;
+    if (!token) return;
+    const resp = await fetch('https://aistudio.googleapis.com/v1alpha/userAPIKey', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (resp.ok) {
+      const data: unknown = await resp.json();
+      const key = (data as { apiKey?: unknown }).apiKey;
+      if (typeof key === 'string') {
+        setApiKey(key);
+      } else {
+        console.error('Google AI Studio response missing apiKey field.');
+      }
+    } else {
+      console.error('Failed to fetch API key from Google AI Studio.');
+    }
+  } catch (err) {
+    console.error('Error completing Google OAuth:', err);
+  } finally {
+    sessionStorage.removeItem(CODE_VERIFIER_KEY);
+    params.delete('code');
+    params.delete('scope');
+    const query = params.toString();
+    window.history.replaceState(null, '', `${window.location.pathname}${query ? `?${query}` : ''}`);
+  }
+};

--- a/services/geminiClient.ts
+++ b/services/geminiClient.ts
@@ -3,7 +3,7 @@
  * @description Provides a shared GoogleGenAI client instance.
  */
 import { GoogleGenAI } from "@google/genai";
-import { geminiClient, isApiConfigured } from "./apiClient";
+import { geminiClient, isApiConfigured } from './apiClient';
 
 if (!isApiConfigured()) {
   console.error("GEMINI_API_KEY environment variable is not set. The application will not be able to connect to the Gemini API.");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }: { mode: string }) => {
     define: {
       'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+      'process.env.GOOGLE_CLIENT_ID': JSON.stringify(env.GOOGLE_CLIENT_ID),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- add `google-auth-library` to dependencies
- implement OAuth helper using google-auth-library
- handle OAuth completion on app start
- describe Google login in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68657d0df7b8832498a85e6a7619a736