### PR TITLE
Fix OAuth startup crash by replacing google-auth-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ An AI-powered text adventure built with React and TypeScript. The game uses Goog
 3. *(Optional)* Provide a Google OAuth client ID to enable "Login with Google".
    You can set the `GOOGLE_CLIENT_ID` environment variable or assign
    `window.GOOGLE_CLIENT_ID` in `index.html` before loading the application.
-   The app uses **google-auth-library** to sign you in and automatically fetch
-   your personal API key from Google AI Studio.
+   The app can sign you in via Google's OAuth endpoints and will automatically
+   fetch your personal API key from Google AI Studio.
 4. Install dependencies and launch the dev server:
    ```bash
    npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.4",
       "dependencies": {
         "@google/genai": "^1.7.0",
-        "google-auth-library": "^9.15.1",
         "idb": "^8.0.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@google/genai": "^1.7.0",
-    "google-auth-library": "^9.15.1",
     "idb": "^8.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/services/auth/googleAuth.ts
+++ b/services/auth/googleAuth.ts
@@ -1,58 +1,85 @@
 /**
  * @file services/auth/googleAuth.ts
- * @description Google OAuth helpers to fetch the user\'s Gemini API key.
+ * @description Minimal Google OAuth helpers implemented without external libraries.
  */
-import { OAuth2Client, CodeChallengeMethod } from 'google-auth-library';
 import { GOOGLE_CLIENT_ID } from '../../constants';
 import { setApiKey } from '../apiClient';
 
 const CODE_VERIFIER_KEY = 'whispersInTheDark_codeVerifier';
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
 
 /** Returns true when a Google OAuth client ID is provided. */
 export const isGoogleAuthAvailable = (): boolean => GOOGLE_CLIENT_ID.trim().length > 0;
 
-const createOAuthClient = (): OAuth2Client =>
-  new OAuth2Client({ clientId: GOOGLE_CLIENT_ID, redirectUri: window.location.origin + window.location.pathname });
+const generateRandomString = (length: number): string => {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => ALPHABET[b % ALPHABET.length]).join('');
+};
 
-/**
- * Starts the OAuth flow by redirecting the browser to the consent page.
- */
+const base64UrlEncode = (data: ArrayBuffer): string =>
+  btoa(String.fromCharCode(...new Uint8Array(data)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+const sha256 = async (text: string): Promise<string> => {
+  const encoded = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest('SHA-256', encoded);
+  return base64UrlEncode(hash);
+};
+
+const getRedirectUri = (): string => `${window.location.origin}${window.location.pathname}`;
+
+/** Starts the OAuth flow by redirecting the browser to the consent page. */
 export const loginWithGoogle = async (): Promise<void> => {
   if (!isGoogleAuthAvailable()) {
     console.error('GOOGLE_CLIENT_ID is not configured; cannot use Google login.');
     return;
   }
-  const client = createOAuthClient();
-  const { codeVerifier, codeChallenge } = await client.generateCodeVerifierAsync();
+  const codeVerifier = generateRandomString(64);
+  const codeChallenge = await sha256(codeVerifier);
   try {
     sessionStorage.setItem(CODE_VERIFIER_KEY, codeVerifier);
   } catch {
     // ignore storage errors
   }
-  const url = client.generateAuthUrl({
+  const params = new URLSearchParams({
+    client_id: GOOGLE_CLIENT_ID,
+    redirect_uri: getRedirectUri(),
+    response_type: 'code',
     scope: 'https://www.googleapis.com/auth/cloud-platform',
     prompt: 'consent',
     access_type: 'online',
     code_challenge: codeChallenge,
-    code_challenge_method: CodeChallengeMethod.S256,
+    code_challenge_method: 'S256',
   });
-  window.location.href = url;
+  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
 };
 
-/**
- * Handles a redirect from Google OAuth and fetches the user\'s API key.
- */
+/** Handles a redirect from Google OAuth and fetches the user's API key. */
 export const maybeCompleteOAuth = async (): Promise<void> => {
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
   const codeVerifier = sessionStorage.getItem(CODE_VERIFIER_KEY);
   if (!code || !codeVerifier) return;
 
-  const client = createOAuthClient();
   try {
-    const { tokens } = await client.getToken({ code, codeVerifier });
-    const token = tokens.access_token;
-    if (!token) return;
+    const tokenResp = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: GOOGLE_CLIENT_ID,
+        code,
+        code_verifier: codeVerifier,
+        redirect_uri: getRedirectUri(),
+        grant_type: 'authorization_code',
+      }),
+    });
+    const tokenData: unknown = await tokenResp.json();
+    const token = (tokenData as { access_token?: unknown }).access_token;
+    if (typeof token !== 'string') return;
+
     const resp = await fetch('https://aistudio.googleapis.com/v1alpha/userAPIKey', {
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -67,7 +94,7 @@ export const maybeCompleteOAuth = async (): Promise<void> => {
     } else {
       console.error('Failed to fetch API key from Google AI Studio.');
     }
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('Error completing Google OAuth:', err);
   } finally {
     sessionStorage.removeItem(CODE_VERIFIER_KEY);


### PR DESCRIPTION
## Summary
- remove google-auth-library dependency
- implement OAuth helper without external libraries
- document the new OAuth logic in the README

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686589bea0ac8324890fda52cf1b7a0f