### PR TITLE
Implement runtime Google login setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ An AI-powered text adventure built with React and TypeScript. The game uses Goog
 1. **Install Node.js 18 or newer**.
 2. **Set the environment variable `GEMINI_API_KEY`** with your API key so the app can talk to the Gemini service.
 3. *(Optional)* Provide a Google OAuth client ID to enable "Login with Google".
-   You can set the `GOOGLE_CLIENT_ID` environment variable or assign
-   `window.GOOGLE_CLIENT_ID` in `index.html` before loading the application.
-   The app can sign you in via Google's OAuth endpoints and will automatically
-   fetch your personal API key from Google AI Studio.
+   You can set the `GOOGLE_CLIENT_ID` environment variable, assign
+   `window.GOOGLE_CLIENT_ID` in `index.html`, or simply enter it when prompted.
+   The app uses the [Google Identity Services](https://developers.google.com/identity/oauth2/web/guides/overview)
+   library to request a short-lived access token and automatically fetch your
+   personal API key from Google AI Studio.
 4. Install dependencies and launch the dev server:
    ```bash
    npm install

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -23,7 +23,7 @@ import CustomGameSetupScreen from '../modals/CustomGameSetupScreen';
 import SettingsDisplay from '../modals/SettingsDisplay';
 import InfoDisplay from '../modals/InfoDisplay';
 import DebugLoreModal from '../modals/DebugLoreModal';
-import { loginWithGoogle, maybeCompleteOAuth } from '../../services/auth/googleAuth';
+import { loginWithGoogle } from '../../services/auth/googleAuth';
 import { isApiConfigured } from '../../services/apiClient';
 import Footer from './Footer';
 import AppModals from './AppModals';
@@ -325,10 +325,7 @@ function App() {
   const [apiConfigured, setApiConfigured] = useState(isApiConfigured());
 
   useEffect(() => {
-    void (async () => {
-      await maybeCompleteOAuth();
-      setApiConfigured(isApiConfigured());
-    })();
+    setApiConfigured(isApiConfigured());
   }, []);
 
   const canPerformFreeAction = score >= FREE_FORM_ACTION_COST && !isLoading && hasGameBeenInitialized && !dialogueState;

--- a/constants.ts
+++ b/constants.ts
@@ -42,10 +42,36 @@ export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
 export const LOCAL_STORAGE_DEBUG_KEY = "whispersInTheDark_debugPacket";
 export const LOCAL_STORAGE_DEBUG_LORE_KEY = "whispersInTheDark_debugLore";
 export const LOCAL_STORAGE_API_KEY = "whispersInTheDark_geminiApiKey";
-export const GOOGLE_CLIENT_ID =
-  (typeof window !== 'undefined'
-    ? (window as { GOOGLE_CLIENT_ID?: string }).GOOGLE_CLIENT_ID
-    : undefined) ?? process.env.GOOGLE_CLIENT_ID ?? '';
+export const LOCAL_STORAGE_GOOGLE_CLIENT_ID = "whispersInTheDark_googleClientId";
+
+/**
+ * Returns the Google OAuth client ID from localStorage, window or env vars.
+ */
+export const getGoogleClientId = (): string => {
+  const winId =
+    typeof window !== 'undefined'
+      ? (window as { GOOGLE_CLIENT_ID?: string }).GOOGLE_CLIENT_ID
+      : undefined;
+  try {
+    return (
+      winId ?? localStorage.getItem(LOCAL_STORAGE_GOOGLE_CLIENT_ID) ?? process.env.GOOGLE_CLIENT_ID ?? ''
+    );
+  } catch {
+    return winId ?? process.env.GOOGLE_CLIENT_ID ?? '';
+  }
+};
+
+/** Persists the given Google OAuth client ID to localStorage. */
+export const setGoogleClientId = (id: string): void => {
+  try {
+    localStorage.setItem(LOCAL_STORAGE_GOOGLE_CLIENT_ID, id);
+  } catch {
+    // ignore storage errors
+  }
+  if (typeof window !== 'undefined') {
+    (window as { GOOGLE_CLIENT_ID?: string }).GOOGLE_CLIENT_ID = id;
+  }
+};
 
 export const DEFAULT_STABILITY_LEVEL = 30; // Number of turns before chaos can occur
 export const DEFAULT_CHAOS_LEVEL = 5;   // Percentage chance of chaos shift

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,28 @@
+declare global {
+  interface GoogleTokenClient {
+    requestAccessToken: () => void;
+  }
+
+  interface GoogleOauth2 {
+    initTokenClient: (config: {
+      client_id: string;
+      scope: string;
+      callback: (resp: { access_token?: string; error?: string }) => void;
+    }) => GoogleTokenClient;
+  }
+
+  interface GoogleAccounts {
+    oauth2?: GoogleOauth2;
+  }
+
+  interface GoogleNamespace {
+    accounts?: GoogleAccounts;
+  }
+
+  interface Window {
+    google?: GoogleNamespace;
+    GOOGLE_CLIENT_ID?: string;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- load Google client ID from localStorage, window or environment
- prompt the user for Google OAuth client ID when needed
- persist the client ID in localStorage for future sessions
- update README instructions for providing the client ID

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68658c3d72c88324a7c10902731b4d9b