### PR TITLE
Add Gemini API key setup modal

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -23,6 +23,7 @@ import CustomGameSetupScreen from '../modals/CustomGameSetupScreen';
 import SettingsDisplay from '../modals/SettingsDisplay';
 import InfoDisplay from '../modals/InfoDisplay';
 import DebugLoreModal from '../modals/DebugLoreModal';
+import GeminiKeyModal from '../modals/GeminiKeyModal';
 import Footer from './Footer';
 import AppModals from './AppModals';
 import AppHeader from './AppHeader';
@@ -36,6 +37,7 @@ import { useAutosave } from '../../hooks/useAutosave';
 import { findTravelPath, buildTravelAdjacency, TravelStep, TravelAdjacency } from '../../utils/mapPathfinding';
 import { isDescendantIdOf } from '../../utils/mapGraphUtils';
 import { applyNestedCircleLayout } from '../../utils/mapLayoutUtils';
+import { isApiConfigured } from '../../services/apiClient';
 
 
 import {
@@ -145,8 +147,19 @@ function App() {
     debugLoreFacts,
     openDebugLoreModal,
     submitDebugLoreModal,
-    closeDebugLoreModal,
-  } = useAppModals();
+  closeDebugLoreModal,
+} = useAppModals();
+
+  const [geminiKeyVisible, setGeminiKeyVisible] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!isApiConfigured()) {
+      setGeminiKeyVisible(true);
+    }
+  }, []);
+
+  const openGeminiKeyModal = useCallback(() => { setGeminiKeyVisible(true); }, []);
+  const closeGeminiKeyModal = useCallback(() => { setGeminiKeyVisible(false); }, []);
 
 
   const gameLogic = useGameLogic({
@@ -881,6 +894,7 @@ function App() {
         onNewGame={handleNewGameFromMenu}
         onOpenInfo={openInfoFromMenu}
         onOpenSettings={openSettingsFromMenu}
+        onOpenGeminiKeyModal={openGeminiKeyModal}
         onSaveGame={hasGameBeenInitialized ? handleSaveGameFromMenu : undefined}
       />
 
@@ -923,6 +937,11 @@ function App() {
         isVisible={isDebugLoreVisible}
         onClose={closeDebugLoreModal}
         onSubmit={submitDebugLoreModal}
+      />
+
+      <GeminiKeyModal
+        isVisible={geminiKeyVisible}
+        onClose={closeGeminiKeyModal}
       />
 
       {hasGameBeenInitialized && currentTheme ? <AppModals

--- a/components/modals/GeminiKeyModal.tsx
+++ b/components/modals/GeminiKeyModal.tsx
@@ -1,0 +1,81 @@
+import { useState, useCallback, useEffect } from 'react';
+import Button from '../elements/Button';
+import { Icon } from '../elements/icons';
+import TextBox from '../elements/TextBox';
+import { getApiKey, setApiKey } from '../../services/apiClient';
+
+interface GeminiKeyModalProps {
+  readonly isVisible: boolean;
+  readonly onClose: () => void;
+}
+
+function GeminiKeyModal({ isVisible, onClose }: GeminiKeyModalProps) {
+  const [key, setKey] = useState('');
+
+  useEffect(() => {
+    if (isVisible) {
+      setKey(getApiKey() ?? '');
+    }
+  }, [isVisible]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setKey(e.target.value);
+  }, []);
+
+  const handleSave = useCallback(() => {
+    setApiKey(key.trim());
+    onClose();
+  }, [key, onClose]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      aria-labelledby="gemini-key-title"
+      aria-modal="true"
+      className="animated-frame open"
+      role="dialog"
+    >
+      <div className="animated-frame-content flex flex-col items-center">
+        <Button
+          ariaLabel="Close Gemini key setup"
+          icon={<Icon name="x" size={20} />}
+          onClick={onClose}
+          size="sm"
+          variant="close"
+        />
+
+        <h1 className="text-2xl font-bold text-sky-300 mb-4" id="gemini-key-title">
+          Configure Gemini API Key
+        </h1>
+
+        <TextBox
+          containerClassName="mb-4"
+          text="Visit https://aistudio.google.com to generate a free API key. Paste it below."
+        />
+
+        <div className="flex w-full max-w-md space-x-2">
+          <input
+            aria-label="Gemini API key"
+            className="flex-grow p-2 bg-slate-700 text-slate-200 border border-slate-600 rounded-md shadow-sm focus:ring-sky-500 focus:border-sky-500"
+            onChange={handleChange}
+            placeholder="Enter API key"
+            type="text"
+            value={key}
+          />
+
+          <Button
+            ariaLabel="Save API key"
+            disabled={key.trim() === ''}
+            label="Save"
+            onClick={handleSave}
+            preset="green"
+            variant="compact"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default GeminiKeyModal;

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -5,6 +5,7 @@
  */
 import { useCallback } from 'react';
 import { CURRENT_GAME_VERSION } from '../../constants';
+import { isApiConfigured } from '../../services/apiClient';
 import AppHeader from '../app/AppHeader';
 import Button from '../elements/Button';
 import { Icon } from '../elements/icons';
@@ -19,6 +20,7 @@ interface TitleMenuProps {
   readonly onLoadGame: () => void;
   readonly onOpenSettings: () => void;
   readonly onOpenInfo: () => void;
+  readonly onOpenGeminiKeyModal?: () => void;
   readonly isGameActive: boolean;
 }
 
@@ -34,6 +36,7 @@ function TitleMenu({
   onLoadGame,
   onOpenSettings,
   onOpenInfo,
+  onOpenGeminiKeyModal,
   isGameActive,
 }: TitleMenuProps) {
 
@@ -77,6 +80,7 @@ function TitleMenu({
           <div className="space-y-3 sm:space-y-3 w-full max-w-xs sm:max-w-sm">
             <Button
               ariaLabel={isGameActive ? 'Start a New Game (Random Shifts, Progress will be lost)' : 'Start a New Game (Random Shifts)'}
+              disabled={!isApiConfigured()}
               label="New Game"
               onClick={onNewGame}
               preset="red"
@@ -85,11 +89,22 @@ function TitleMenu({
 
             <Button
               ariaLabel={isGameActive ? 'Start a Custom Game (Choose Theme, No Random Shifts, Progress will be lost)' : 'Start a Custom Game (Choose Theme, No Random Shifts)'}
+              disabled={!isApiConfigured()}
               label="Custom Game"
               onClick={onCustomGame}
               preset="orange"
               size="lg"
             />
+
+            {!isApiConfigured() ? (
+              <Button
+                ariaLabel="Set Gemini API key"
+                label="Set Gemini Key"
+                onClick={onOpenGeminiKeyModal}
+                preset="indigo"
+                size="lg"
+              />
+            ) : null}
 
             {isGameActive && onSaveGame ? (
               <Button
@@ -146,6 +161,6 @@ function TitleMenu({
   );
 }
 
-TitleMenu.defaultProps = { onSaveGame: undefined };
+TitleMenu.defaultProps = { onSaveGame: undefined, onOpenGeminiKeyModal: undefined };
 
 export default TitleMenu;

--- a/constants.ts
+++ b/constants.ts
@@ -41,6 +41,7 @@ export const CURRENT_SAVE_GAME_VERSION = "7";
 export const LOCAL_STORAGE_SAVE_KEY = "whispersInTheDark_gameState";
 export const LOCAL_STORAGE_DEBUG_KEY = "whispersInTheDark_debugPacket";
 export const LOCAL_STORAGE_DEBUG_LORE_KEY = "whispersInTheDark_debugLore";
+export const LOCAL_STORAGE_GEMINI_KEY = "whispersInTheDark_geminiApiKey";
 
 export const DEFAULT_STABILITY_LEVEL = 30; // Number of turns before chaos can occur
 export const DEFAULT_CHAOS_LEVEL = 5;   // Percentage chance of chaos shift


### PR DESCRIPTION
## Summary
- store API key in browser storage with `LOCAL_STORAGE_GEMINI_KEY`
- initialize Gemini client from localStorage and allow setting a new key
- add `GeminiKeyModal` component for entering the API key
- disable new/custom game buttons without API key and provide "Set Gemini Key" option
- show the API key modal on app start when no key is configured

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866b5dc009083249d761d8e0f2739ae