### PR TITLE
Indicate Gemini Key source

### DIFF
--- a/components/elements/VersionBadge.tsx
+++ b/components/elements/VersionBadge.tsx
@@ -1,16 +1,19 @@
 interface VersionBadgeProps {
   readonly version: string;
+  readonly sourceInfo?: string;
 }
 
-function VersionBadge({ version}: VersionBadgeProps) {
+function VersionBadge({ version, sourceInfo }: VersionBadgeProps) {
   return (
     <span className='text-sm text-slate-300 absolute bottom-4 right-4'>
       {'Version: ' + version}
+      {sourceInfo ? ` – ${sourceInfo}` : null}
     </span>
   );
 }
 
 VersionBadge.defaultProps = {
+  sourceInfo: undefined,
 };
 
 export default VersionBadge;

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -5,7 +5,7 @@
  */
 import { useCallback } from 'react';
 import { CURRENT_GAME_VERSION } from '../../constants';
-import { isApiConfigured } from '../../services/apiClient';
+import { isApiConfigured, isApiKeyFromEnv } from '../../services/apiClient';
 import AppHeader from '../app/AppHeader';
 import Button from '../elements/Button';
 import { Icon } from '../elements/icons';
@@ -96,7 +96,7 @@ function TitleMenu({
               size="lg"
             />
 
-            {!isApiConfigured() ? (
+            {!isApiConfigured() && onOpenGeminiKeyModal ? (
               <Button
                 ariaLabel="Set Gemini API key"
                 label="Set Gemini Key"
@@ -154,6 +154,7 @@ function TitleMenu({
 
         {/* Version Number Display */}
         <VersionBadge
+          sourceInfo={isApiKeyFromEnv() ? 'System Gemini Key' : undefined}
           version={CURRENT_GAME_VERSION}
         />
       </div>

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -6,12 +6,18 @@ import { GoogleGenAI } from '@google/genai';
 import { LOCAL_STORAGE_GEMINI_KEY } from '../constants';
 
 let geminiApiKey: string | null = null;
+let geminiKeyFromEnv = false;
 
 if (typeof localStorage !== 'undefined') {
   geminiApiKey = localStorage.getItem(LOCAL_STORAGE_GEMINI_KEY);
 }
 
-geminiApiKey ??= process.env.GEMINI_API_KEY ?? process.env.API_KEY ?? null;
+if (!geminiApiKey) {
+  geminiApiKey = process.env.GEMINI_API_KEY ?? process.env.API_KEY ?? null;
+  if (geminiApiKey) {
+    geminiKeyFromEnv = true;
+  }
+}
 
 if (!geminiApiKey) {
   console.error('GEMINI_API_KEY environment variable is not set. Gemini services will be unavailable.');
@@ -23,10 +29,13 @@ export let geminiClient: GoogleGenAI | null = geminiApiKey
 
 export const isApiConfigured = (): boolean => !!geminiApiKey;
 
+export const isApiKeyFromEnv = (): boolean => geminiKeyFromEnv;
+
 export const getApiKey = (): string | null => geminiApiKey;
 
 export const setApiKey = (key: string): void => {
   geminiApiKey = key;
+  geminiKeyFromEnv = false;
   if (typeof localStorage !== 'undefined') {
     localStorage.setItem(LOCAL_STORAGE_GEMINI_KEY, key);
   }


### PR DESCRIPTION
## Summary
- expose a flag from `apiClient` to detect if the API key came from environment variables
- show 'System Gemini Key' in the title menu when a system key is used
- allow `VersionBadge` to display additional info such as the API key source
- only render the Gemini key setup button when the handler is provided

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866bbcb4638832491900c7709b10707