### PR TITLE
Fix environment variable handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An AI-powered text adventure built with React and TypeScript. The game uses Goog
 ## Getting Started
 
 1. **Install Node.js 18 or newer**.
-2. **Set the environment variable `GEMINI_API_KEY`** with your API key so the app can talk to the Gemini service.
+2. **Provide your API key**. The game will look for `GEMINI_API_KEY` in the runtime environment (for example a global `GEMINI_API_KEY` variable) or you can enter the key in the in-game prompt which stores it in local storage.
 3. Install dependencies and launch the dev server:
    ```bash
    npm install

--- a/components/elements/VersionBadge.tsx
+++ b/components/elements/VersionBadge.tsx
@@ -10,7 +10,7 @@ function VersionBadge({ version, sourceInfo }: VersionBadgeProps) {
 
       <br />
 
-      <span>{sourceInfo ? `${sourceInfo}` : null}</span>
+      <span>{sourceInfo ?? null}</span>
     </p>
   );
 }

--- a/components/modals/GeminiKeyModal.tsx
+++ b/components/modals/GeminiKeyModal.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import Button from '../elements/Button';
 import { Icon } from '../elements/icons';
-import TextBox from '../elements/TextBox';
 import { getApiKey, setApiKey } from '../../services/apiClient';
 
 interface GeminiKeyModalProps {

--- a/components/modals/TitleMenu.tsx
+++ b/components/modals/TitleMenu.tsx
@@ -78,7 +78,7 @@ function TitleMenu({
           />
 
           <div className="space-y-3 sm:space-y-3 w-full max-w-xs sm:max-w-sm">
-            {!isApiConfigured() ? (
+            {!isApiConfigured() && onOpenGeminiKeyModal ? (
               <Button
                 ariaLabel="Set Gemini API key"
                 label="Set Gemini Key"

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -13,7 +13,17 @@ if (typeof localStorage !== 'undefined') {
 }
 
 if (!geminiApiKey) {
-  geminiApiKey = process.env.GEMINI_API_KEY ?? process.env.API_KEY ?? null;
+  const globalKey =
+    typeof globalThis !== 'undefined'
+      ? (globalThis as Record<string, unknown>).GEMINI_API_KEY as string | undefined
+      : undefined;
+
+  const envKey =
+    typeof process !== 'undefined'
+      ? process.env.GEMINI_API_KEY ?? process.env.API_KEY
+      : undefined;
+
+  geminiApiKey = globalKey ?? envKey ?? null;
   if (geminiApiKey) {
     geminiKeyFromEnv = true;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,20 +4,15 @@
  */
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig(({ mode }: { mode: string }) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
   return {
     plugins: [svgr()],
     base: "/Whispers-in-the-Dark/",
-    define: {
-      'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- remove `define` section from Vite config to avoid embedding secrets
- look for GEMINI_API_KEY at runtime in a global variable or Node env
- clean up Gemini key modal import
- guard `Set Gemini Key` button so onClick is never undefined
- simplify VersionBadge JSX
- update README instructions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866c524062883249335a829d16386f2