### PR TITLE
Update loremaster distill prompt

### DIFF
--- a/services/loremaster/promptBuilder.ts
+++ b/services/loremaster/promptBuilder.ts
@@ -85,7 +85,10 @@ export const buildDistillFactsPrompt = (
   mapNodeNames: Array<string>,
 ): string => {
   const factLines = facts
-    .map(f => `- ID ${String(f.id)}: "${f.text}" (Tier ${String(f.tier)})`)
+    .map(
+      f =>
+        `- ID ${String(f.id)}: "${f.text}" [${f.entities.join(', ')}] (Tier ${String(f.tier)})`,
+    )
     .join('\n');
   const inventoryLines = inventoryItemNames
     .map(name => `- ${name}`)

--- a/services/loremaster/systemPrompt.ts
+++ b/services/loremaster/systemPrompt.ts
@@ -80,6 +80,7 @@ Select the ten most important facts for the upcoming story turn.
 export const DISTILL_SYSTEM_INSTRUCTION = `You are the Loremaster refining and pruning accumulated facts.
 1. Look for statements that describe the same idea and merge them into a single, more specific fact. Keep the length of the merged fact under 200 words. Split any fact longer than 200 words into two non-overlapping facts.
 Increase the tier of the merged fact by one.
+When merging, combine the entity IDs from all merged facts into a single set with no duplicates.
 
 2. Prune facts that reference obsolete or irrelevant details, such as:
 - places that no longer exist;

--- a/tests/loremasterPromptDistill.test.ts
+++ b/tests/loremasterPromptDistill.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { buildDistillFactsPrompt } from '../services/loremaster/promptBuilder';
+import type { ThemeFact } from '../types';
+
+describe('buildDistillFactsPrompt', () => {
+  it('includes entity IDs for each fact', () => {
+    const facts: Array<ThemeFact> = [
+      { id: 1, text: 'First fact', entities: ['a', 'b'], themeName: 'theme', createdTurn: 1, tier: 1 },
+      { id: 2, text: 'Second fact', entities: ['c'], themeName: 'theme', createdTurn: 1, tier: 1 },
+    ];
+
+    const prompt = buildDistillFactsPrompt('theme', facts, null, null, [], []);
+
+    expect(prompt).toContain('ID 1: "First fact" [a, b]');
+    expect(prompt).toContain('ID 2: "Second fact" [c]');
+  });
+});
+


### PR DESCRIPTION
## Summary
- include entity IDs alongside each fact in Loremaster Distill prompts
- mention in the system instruction how to combine entity IDs when merging facts
- add unit test for `buildDistillFactsPrompt`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6882a34a32bc8324b40da9ba1d882562