### PR TITLE
Add hero description to hero generation

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -24,6 +24,7 @@ import SettingsDisplay from '../modals/SettingsDisplay';
 import InfoDisplay from '../modals/InfoDisplay';
 import DebugLoreModal from '../modals/DebugLoreModal';
 import GeminiKeyModal from '../modals/GeminiKeyModal';
+import CharacterSelectModal from '../modals/CharacterSelectModal';
 import Footer from './Footer';
 import AppModals from './AppModals';
 import AppHeader from './AppHeader';
@@ -48,7 +49,17 @@ import {
   JOURNAL_WRITE_COOLDOWN,
   INSPECT_COOLDOWN,
 } from '../../constants';
-import { ThemePackName, Item, ItemChapter, FullGameState } from '../../types';
+import {
+  ThemePackName,
+  Item,
+  ItemChapter,
+  FullGameState,
+  AdventureTheme,
+  WorldFacts,
+  CharacterOption,
+  HeroSheet,
+  HeroBackstory,
+} from '../../types';
 import { saveDebugLoreToLocalStorage } from '../../services/storage';
 
 
@@ -146,6 +157,10 @@ function App() {
     isDebugLoreVisible,
     debugLoreFacts,
     openDebugLoreModal,
+    openCharacterSelectModal,
+    isCharacterSelectVisible,
+    characterSelectData,
+    submitCharacterSelectModal,
     submitDebugLoreModal,
   closeDebugLoreModal,
 } = useAppModals();
@@ -161,6 +176,18 @@ function App() {
   const openGeminiKeyModal = useCallback(() => { setGeminiKeyVisible(true); }, []);
   const closeGeminiKeyModal = useCallback(() => { setGeminiKeyVisible(false); }, []);
 
+  const openCharacterSelect = useCallback(
+    (data: {
+      theme: AdventureTheme;
+      playerGender: string;
+      worldFacts: WorldFacts;
+      options: Array<CharacterOption>;
+    }) => new Promise<{ name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null }>(resolve => {
+      openCharacterSelectModal(data, resolve);
+    }),
+    [openCharacterSelectModal],
+  );
+
 
   const gameLogic = useGameLogic({
     playerGenderProp: playerGender,
@@ -172,6 +199,7 @@ function App() {
     initialDebugStackFromApp: initialDebugStack,
     isAppReady: appReady,
     openDebugLoreModal,
+    openCharacterSelectModal: openCharacterSelect,
   });
   gameLogicRef.current = gameLogic;
 
@@ -943,6 +971,17 @@ function App() {
         isVisible={geminiKeyVisible}
         onClose={closeGeminiKeyModal}
       />
+
+      {characterSelectData ? (
+        <CharacterSelectModal
+          isVisible={isCharacterSelectVisible}
+          onComplete={submitCharacterSelectModal}
+          options={characterSelectData.options}
+          playerGender={characterSelectData.playerGender}
+          theme={characterSelectData.theme}
+          worldFacts={characterSelectData.worldFacts}
+        />
+      ) : null}
 
       {hasGameBeenInitialized && currentTheme ? <AppModals
         allNPCs={allNPCs}

--- a/components/elements/CharacterCard.tsx
+++ b/components/elements/CharacterCard.tsx
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+import type { CharacterOption } from '../../types';
+import Button from './Button';
+
+interface CharacterCardProps {
+  readonly option: CharacterOption;
+  readonly onSelect: (option: CharacterOption) => void;
+  readonly disabled?: boolean;
+}
+
+function CharacterCard({ option, onSelect, disabled = false }: CharacterCardProps) {
+  const handleClick = useCallback(() => { onSelect(option); }, [onSelect, option]);
+
+  return (
+    <Button
+      ariaLabel={`Select character ${option.name}${disabled ? ' (selected)' : ''}`}
+      disabled={disabled}
+      label={(
+        <div className="flex flex-col items-start text-left w-full" style={{ minHeight: '160px' }}>
+          <h3 className="text-xl font-semibold text-amber-400 mb-2">
+            {option.name}
+          </h3>
+
+          <p className="text-sm text-slate-300 leading-snug line-clamp-8">
+            {option.description}
+          </p>
+
+          {disabled ? (
+            <p className="text-xs text-orange-300 mt-1 italic">
+              (Selected)
+            </p>
+          ) : null}
+        </div>
+      )}
+      onClick={handleClick}
+      preset="slate"
+      variant="standard"
+    />
+  );
+}
+
+CharacterCard.defaultProps = { disabled: false };
+
+export default CharacterCard;

--- a/components/modals/CharacterSelectModal.tsx
+++ b/components/modals/CharacterSelectModal.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+import type { AdventureTheme, WorldFacts, CharacterOption, HeroSheet, HeroBackstory } from '../../types';
+import Button from '../elements/Button';
+import CharacterCard from '../elements/CharacterCard';
+import LoadingSpinner from '../LoadingSpinner';
+import { Icon } from '../elements/icons';
+import { generateHeroData } from '../../services/worldData';
+
+interface CharacterSelectModalProps {
+  readonly isVisible: boolean;
+  readonly theme: AdventureTheme;
+  readonly playerGender: string;
+  readonly worldFacts: WorldFacts;
+  readonly options: Array<CharacterOption>;
+  readonly onComplete: (result: { name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null }) => void;
+}
+
+function CharacterSelectModal({ isVisible, theme, playerGender, worldFacts, options, onComplete }: CharacterSelectModalProps) {
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [heroSheet, setHeroSheet] = useState<HeroSheet | null>(null);
+  const [heroBackstory, setHeroBackstory] = useState<HeroBackstory | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const handleSelect = useCallback(
+    (option: CharacterOption) => {
+      setSelectedName(option.name);
+      setIsGenerating(true);
+      void (async () => {
+        const result = await generateHeroData(
+          theme,
+          playerGender,
+          worldFacts,
+          option.name,
+          option.description,
+        );
+        setHeroSheet(result?.heroSheet ?? null);
+        setHeroBackstory(result?.heroBackstory ?? null);
+        setIsGenerating(false);
+      })();
+    },
+    [theme, playerGender, worldFacts]
+  );
+
+  const handleBegin = useCallback(() => {
+    if (!selectedName) return;
+    onComplete({ name: selectedName, heroSheet, heroBackstory });
+  }, [selectedName, heroSheet, heroBackstory, onComplete]);
+
+  const renderOption = useCallback(
+    (opt: CharacterOption) => (
+      <CharacterCard
+        key={opt.name}
+        disabled={selectedName === opt.name}
+        onSelect={handleSelect}
+        option={opt}
+      />
+    ),
+    [selectedName, handleSelect]
+  );
+
+  if (!isVisible) return null;
+
+  return (
+    <div aria-labelledby="character-select-title" aria-modal="true" className="animated-frame open" role="dialog">
+      <div className="animated-frame-content">
+        <h1 className="text-3xl font-bold text-sky-300 mb-4 text-center" id="character-select-title">
+          Choose Your Hero
+        </h1>
+
+        <p className="text-slate-300 mb-6 text-center text-sm max-w-2xl mx-auto">
+          Explore the world of {theme.name}. Select a hero to begin your adventure.
+        </p>
+
+        {isGenerating ? (
+          <LoadingSpinner />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-96 overflow-y-auto px-4">
+            {options.map(renderOption)}
+          </div>
+        )}
+
+        {heroSheet && heroBackstory ? (
+          <div className="mt-4 space-y-3 text-slate-300">
+            <p className="text-lg font-semibold text-amber-400 text-center">{heroSheet.name}</p>
+            <p className="text-center">Occupation: {heroSheet.occupation}</p>
+            <p className="text-center">Traits: {heroSheet.traits.join(', ')}</p>
+            <p className="text-center">Starting Items: {heroSheet.startingItems.join(', ')}</p>
+            <p className="mt-2 whitespace-pre-line text-sm">Backstory:\n- 5 years ago: {heroBackstory.fiveYearsAgo}\n- 1 year ago: {heroBackstory.oneYearAgo}\n- 6 months ago: {heroBackstory.sixMonthsAgo}\n- 1 month ago: {heroBackstory.oneMonthAgo}\n- 1 week ago: {heroBackstory.oneWeekAgo}\n- Yesterday: {heroBackstory.yesterday}</p>
+          </div>
+        ) : null}
+
+        <div className="mt-6 flex justify-center space-x-4">
+          {heroSheet && heroBackstory ? (
+            <Button ariaLabel="Begin the adventure" icon={<Icon name="bookOpen" size={20} />} onClick={handleBegin} preset="green" size="lg" label="Begin the Journey" />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CharacterSelectModal;

--- a/hooks/useAppModals.ts
+++ b/hooks/useAppModals.ts
@@ -4,6 +4,7 @@
  */
 import { useCallback, useState, useRef } from 'react';
 import { clearProgress } from '../utils/loadingProgress';
+import type { AdventureTheme, WorldFacts, CharacterOption, HeroSheet, HeroBackstory } from '../types';
 
 export const useAppModals = () => {
   const [isVisualizerVisible, setIsVisualizerVisible] = useState(false);
@@ -29,6 +30,14 @@ export const useAppModals = () => {
   const [isDebugLoreVisible, setIsDebugLoreVisible] = useState(false);
   const [debugLoreFacts, setDebugLoreFacts] = useState<Array<string>>([]);
   const debugLoreResolveRef = useRef<((good: Array<string>, bad: Array<string>, proceed: boolean) => void) | null>(null);
+  const [isCharacterSelectVisible, setIsCharacterSelectVisible] = useState(false);
+  const [characterSelectData, setCharacterSelectData] = useState<{
+    theme: AdventureTheme;
+    playerGender: string;
+    worldFacts: WorldFacts;
+    options: Array<CharacterOption>;
+  } | null>(null);
+  const characterSelectResolveRef = useRef<((result: { name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null }) => void) | null>(null);
 
   const openVisualizer = useCallback(() => { setIsVisualizerVisible(true); }, []);
   const closeVisualizer = useCallback(() => { setIsVisualizerVisible(false); }, []);
@@ -85,6 +94,32 @@ export const useAppModals = () => {
     setIsDebugLoreVisible(false);
   }, []);
 
+  const openCharacterSelectModal = useCallback(
+    (
+      data: {
+        theme: AdventureTheme;
+        playerGender: string;
+        worldFacts: WorldFacts;
+        options: Array<CharacterOption>;
+      },
+      resolve: (result: { name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null }) => void,
+    ) => {
+      setCharacterSelectData(data);
+      characterSelectResolveRef.current = resolve;
+      setIsCharacterSelectVisible(true);
+    },
+    []
+  );
+
+  const submitCharacterSelectModal = useCallback(
+    (result: { name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null }) => {
+      characterSelectResolveRef.current?.(result);
+      setIsCharacterSelectVisible(false);
+      setCharacterSelectData(null);
+    },
+    []
+  );
+
   return {
     // state
     isVisualizerVisible,
@@ -107,6 +142,8 @@ export const useAppModals = () => {
    pageItemId,
    pageStartChapterIndex,
    isPageVisible,
+    isCharacterSelectVisible,
+    characterSelectData,
    // setters used outside
     setVisualizerImageUrl,
     setVisualizerImageScene,
@@ -144,9 +181,11 @@ export const useAppModals = () => {
    closePageView,
    isDebugLoreVisible,
    debugLoreFacts,
-   openDebugLoreModal,
-   submitDebugLoreModal,
-   closeDebugLoreModal,
+    openDebugLoreModal,
+    submitDebugLoreModal,
+    closeDebugLoreModal,
+    openCharacterSelectModal,
+    submitCharacterSelectModal,
   } as const;
 };
 

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -4,7 +4,18 @@
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ThemePackName, FullGameState, GameStateStack, DebugPacketStack, LoadingReason } from '../types';
+import {
+  ThemePackName,
+  FullGameState,
+  GameStateStack,
+  DebugPacketStack,
+  LoadingReason,
+  AdventureTheme,
+  WorldFacts,
+  CharacterOption,
+  HeroSheet,
+  HeroBackstory,
+} from '../types';
 import { setLoadingReason as setGlobalLoadingReason } from '../utils/loadingState';
 import { useLoadingReason } from './useLoadingReason';
 import { getInitialGameStates } from '../utils/initialStates';
@@ -34,6 +45,14 @@ export interface UseGameLogicProps {
     facts: Array<string>,
     resolve: (good: Array<string>, bad: Array<string>, proceed: boolean) => void,
   ) => void;
+  openCharacterSelectModal: (
+    data: {
+      theme: AdventureTheme;
+      playerGender: string;
+      worldFacts: WorldFacts;
+      options: Array<CharacterOption>;
+    },
+  ) => Promise<{ name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null }>;
 }
 
 /** Manages overall game state and delegates to sub hooks. */
@@ -48,6 +67,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     initialDebugStackFromApp,
     isAppReady,
     openDebugLoreModal,
+    openCharacterSelectModal,
   } = props;
 
   const [gameStateStack, setGameStateStack] = useState<GameStateStack>(() => [getInitialGameStates(), getInitialGameStates()]);
@@ -224,6 +244,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     resetGameStateStack,
     setGameStateStack,
     processAiResponse,
+    openCharacterSelectModal,
   });
   loadInitialGameRef.current = loadInitialGame;
 

--- a/services/worldData/index.ts
+++ b/services/worldData/index.ts
@@ -1,1 +1,7 @@
-export { generateWorldData } from './api';
+export {
+  generateWorldData,
+  generateWorldFacts,
+  generateCharacterNames,
+  generateCharacterDescriptions,
+  generateHeroData,
+} from './api';

--- a/types.ts
+++ b/types.ts
@@ -356,6 +356,12 @@ export interface HeroBackstory {
   yesterday: string;
 }
 
+export interface CharacterOption {
+  name: string;
+  description: string;
+}
+
+
 export interface LoremasterModeDebugInfo {
   prompt: string;
   rawResponse?: string;


### PR DESCRIPTION
## Summary
- pass entire character option from selection card
- include description in hero generation requests
- expose hero description in backstory prompt

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68834b6619f883249f2abdf91f73f191