### PR TITLE
Use world generation data in initial game prompt

### DIFF
--- a/hooks/initPromptHelpers.ts
+++ b/hooks/initPromptHelpers.ts
@@ -2,7 +2,16 @@
  * @file initPromptHelpers.ts
  * @description Helper for constructing initial game prompts.
  */
-import { AdventureTheme, NPC, MapData, ThemeMemory, Item } from '../types';
+import {
+  AdventureTheme,
+  NPC,
+  MapData,
+  ThemeMemory,
+  Item,
+  WorldFacts,
+  HeroSheet,
+  HeroBackstory,
+} from '../types';
 import { PLAYER_HOLDER_ID } from '../constants';
 import {
   buildNewGameFirstTurnPrompt,
@@ -18,6 +27,9 @@ export interface BuildInitialGamePromptOptions {
   themeMemory?: ThemeMemory;
   mapDataForTheme?: MapData;
   npcsForTheme?: Array<NPC>;
+  worldFacts?: WorldFacts;
+  heroSheet?: HeroSheet;
+  heroBackstory?: HeroBackstory;
 }
 
 /**
@@ -34,6 +46,9 @@ export const buildInitialGamePrompt = (
     themeMemory,
     mapDataForTheme,
     npcsForTheme,
+    worldFacts,
+    heroSheet,
+    heroBackstory,
   } = options;
 
   const inventoryForPrompt = inventory.filter(i => i.holderId === PLAYER_HOLDER_ID);
@@ -55,7 +70,29 @@ export const buildInitialGamePrompt = (
       playerGender,
     );
   } else {
-    prompt = buildNewGameFirstTurnPrompt(theme, playerGender);
+    prompt = buildNewGameFirstTurnPrompt(
+      theme,
+      playerGender,
+      worldFacts ?? {
+        geography: '',
+        climate: '',
+        technologyLevel: '',
+        supernaturalElements: '',
+        majorFactions: [],
+        keyResources: [],
+        culturalNotes: [],
+        notableLocations: [],
+      },
+      heroSheet ?? { name: 'Hero', occupation: '', traits: [], startingItems: [] },
+      heroBackstory ?? {
+        fiveYearsAgo: '',
+        oneYearAgo: '',
+        sixMonthsAgo: '',
+        oneMonthAgo: '',
+        oneWeekAgo: '',
+        yesterday: '',
+      },
+    );
   }
   return prompt;
 };

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -11,6 +11,9 @@ import {
   MapNode,
   ThemeMemory,
   ThemeHistoryState,
+  WorldFacts,
+  HeroSheet,
+  HeroBackstory,
 } from '../../types';
 import {
   itemsToString,
@@ -20,27 +23,36 @@ import {
   formatRecentEventsForPrompt,
   formatDetailedContextForMentionedEntities,
   formatTravelPlanLine,
+  formatWorldFactsForPrompt,
+  formatHeroSheetForPrompt,
+  formatHeroBackstoryForPrompt,
 } from '../../utils/promptFormatters';
 
 /**
  * Build the initial prompt for starting a new game.
  */
 export const buildNewGameFirstTurnPrompt = (
-
   theme: AdventureTheme,
-  playerGender: string
+  playerGender: string,
+  worldFacts: WorldFacts,
+  heroSheet: HeroSheet,
+  heroBackstory: HeroBackstory,
 ): string => {
+  const worldInfo = formatWorldFactsForPrompt(worldFacts);
+  const heroDescription = formatHeroSheetForPrompt(heroSheet);
+  const heroPast = formatHeroBackstoryForPrompt(heroBackstory);
   const prompt = `Start a new adventure in the theme "${theme.name}". ${theme.systemInstructionModifier}
 Player's Character Gender: "${playerGender}"
-Suggested Initial Scene: "${theme.initialSceneDescriptionSeed}" (adjust for variety)
-Suggested Initial Main Quest: "${theme.initialMainQuest}" (adjust for variety)
-Suggested Initial Current Objective: "${theme.initialCurrentObjective}" (adjust for variety)
-Suggested Initial New Items for the player: "${theme.initialItems}" (adjust names and descriptions for variety)
+
+World Details:\n${worldInfo}
+
+Hero Description:\n${heroDescription}
+
+Hero Backstory:\n${heroPast}
 
 The player's last action was unremarkable—something common anyone would do in this situation.
 
-Creatively generate variations of the main quest and current objective based on the suggestions, but make them noticeably different.
-Creatively generate the initial scene description, action options, and items (variations based on 'New Items for the player'), along with a logMessage.
+Creatively generate the main quest, current objective, scene description, action options, and starting items using the world details and hero history for inspiration.
 Creatively add any important quest item(s), if any, based on your generated quest and objective.
 
 ALWAYS SET "mapUpdated": true.

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -10,6 +10,7 @@ import { MAIN_TURN_OPTIONS_COUNT, LOCAL_STORAGE_SAVE_KEY } from '../constants';
 import { saveGameStateToLocalStorage } from '../services/storage';
 import { getInitialGameStates } from '../utils/initialStates';
 import type { GenerateContentResponse } from '@google/genai';
+import type { WorldFacts, HeroSheet, HeroBackstory } from '../types';
 
 vi.mock('../services/storyteller/api', () => ({
   executeAIMainTurn: vi.fn(),
@@ -38,6 +39,33 @@ const fakeAiJson = JSON.stringify({
   currentMapNodeId: 'cell_1',
 });
 
+const dummyWorldFacts: WorldFacts = {
+  geography: 'Mountains',
+  climate: 'Mild',
+  technologyLevel: 'Medieval',
+  supernaturalElements: 'Low magic',
+  majorFactions: ['Guild'],
+  keyResources: ['Iron'],
+  culturalNotes: ['Honor bound'],
+  notableLocations: ['Great Forge'],
+};
+
+const dummyHeroSheet: HeroSheet = {
+  name: 'Aron',
+  occupation: 'Warrior',
+  traits: ['Brave'],
+  startingItems: ['Sword', 'Shield'],
+};
+
+const dummyHeroBackstory: HeroBackstory = {
+  fiveYearsAgo: 'Trained as a squire.',
+  oneYearAgo: 'Swore an oath.',
+  sixMonthsAgo: 'Defeated a bandit leader.',
+  oneMonthAgo: 'Was betrayed by a friend.',
+  oneWeekAgo: 'Left home seeking adventure.',
+  yesterday: 'Arrived at the new town.',
+};
+
 describe('game start sequence', () => {
   it('generates a valid initial scene', async () => {
     mockedExecute.mockResolvedValue({
@@ -49,7 +77,13 @@ describe('game start sequence', () => {
     });
 
     const theme = FANTASY_AND_MYTH_THEMES[0];
-    const prompt = buildNewGameFirstTurnPrompt(theme, 'Male');
+    const prompt = buildNewGameFirstTurnPrompt(
+      theme,
+      'Male',
+      dummyWorldFacts,
+      dummyHeroSheet,
+      dummyHeroBackstory,
+    );
 
     const { response } = await executeAIMainTurn(prompt);
     const parsed = await parseAIResponse(
@@ -107,7 +141,13 @@ describe('game start sequence', () => {
     });
 
     const theme = FANTASY_AND_MYTH_THEMES[0];
-    const prompt = buildNewGameFirstTurnPrompt(theme, 'Male');
+    const prompt = buildNewGameFirstTurnPrompt(
+      theme,
+      'Male',
+      dummyWorldFacts,
+      dummyHeroSheet,
+      dummyHeroBackstory,
+    );
     const { response } = await executeAIMainTurn(prompt);
     const parsed = await parseAIResponse(
       response.text ?? '',

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -8,6 +8,9 @@ import {
   NPC,
   MapData,
   MapNode,
+  WorldFacts,
+  HeroSheet,
+  HeroBackstory,
 } from '../../types';
 import { formatKnownPlacesForPrompt } from './map';
 import { findTravelPath, buildTravelAdjacency } from '../mapPathfinding';
@@ -172,3 +175,42 @@ export const formatTravelPlanLine = (
   return line;
 };
 
+
+
+/**
+ * Formats world facts into a multiline string for prompts.
+ */
+export const formatWorldFactsForPrompt = (worldFacts: WorldFacts): string => {
+  const lines = [
+    `Geography: ${worldFacts.geography}`,
+    `Climate: ${worldFacts.climate}`,
+    `Technology Level: ${worldFacts.technologyLevel}`,
+    `Supernatural Elements: ${worldFacts.supernaturalElements}`,
+    `Major Factions: ${worldFacts.majorFactions.join(', ')}`,
+    `Key Resources: ${worldFacts.keyResources.join(', ')}`,
+    `Cultural Notes: ${worldFacts.culturalNotes.join(', ')}`,
+    `Notable Locations: ${worldFacts.notableLocations.join(', ')}`,
+  ];
+  return lines.join('\n');
+};
+
+/**
+ * Formats a hero sheet into a short single paragraph.
+ */
+export const formatHeroSheetForPrompt = (hero: HeroSheet): string =>
+  `${hero.name} - Occupation: ${hero.occupation}. Traits: ${hero.traits.join(', ')}. Starting items: ${hero.startingItems.join(', ')}.`;
+
+/**
+ * Formats a hero backstory as a multiline string.
+ */
+export const formatHeroBackstoryForPrompt = (
+  backstory: HeroBackstory,
+): string =>
+  [
+    `5 years ago: ${backstory.fiveYearsAgo}`,
+    `1 year ago: ${backstory.oneYearAgo}`,
+    `6 months ago: ${backstory.sixMonthsAgo}`,
+    `1 month ago: ${backstory.oneMonthAgo}`,
+    `1 week ago: ${backstory.oneWeekAgo}`,
+    `Yesterday: ${backstory.yesterday}`,
+  ].join('\n');


### PR DESCRIPTION
## Summary
- use generated world facts and hero info for starting prompts
- provide formatter helpers for world facts and hero data
- wire in new params for initialization helpers
- update tests for new prompt builder API

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6883664fb7cc8324accff3df4cfa76f4