### PR TITLE
Fix missing world and hero data in first prompt

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -304,6 +304,9 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
         themeMemory: hasExistingHistory ? draftState.themeHistory[themeObjToLoad.name] : undefined,
         mapDataForTheme: draftState.mapData,
         npcsForTheme: draftState.allNPCs.filter(npc => npc.themeName === themeObjToLoad.name),
+        worldFacts: draftState.worldFacts ?? undefined,
+        heroSheet: draftState.heroSheet ?? undefined,
+        heroBackstory: draftState.heroBackstory ?? undefined,
       });
       draftState.lastDebugPacket = {
         prompt,


### PR DESCRIPTION
## Summary
- pass generated world facts and hero details to `buildInitialGamePrompt`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688370b51a88832497a3d7c7634e65dd