### PR TITLE
Expand main prompt with hero sheet and facts

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -262,6 +262,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         currentFullState.localEnvironment,
         currentFullState.localPlace,
         playerGenderProp,
+        currentFullState.worldFacts,
+        currentFullState.heroSheet,
         currentFullState.themeHistory,
         currentMapNodeDetails,
         currentFullState.mapData,

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -180,6 +180,8 @@ export const buildMainGameTurnPrompt = (
   localEnvironment: string | null,
   localPlace: string | null,
   playerGender: string,
+  worldFacts: WorldFacts | null,
+  heroSheet: HeroSheet | null,
   themeHistory: ThemeHistoryState,
   currentMapNodeDetails: MapNode | null,
   fullMapData: MapData,
@@ -263,10 +265,20 @@ export const buildMainGameTurnPrompt = (
     '### Details on relevant NPCs mentioned in current scene or action:'
   );
 
+  const worldInfo =
+    worldFacts !== null ? formatWorldFactsForPrompt(worldFacts) : 'Unknown';
+  const heroDescription =
+    heroSheet !== null
+      ? formatHeroSheetForPrompt(heroSheet)
+      : 'The hero remains undescribed.';
+
   const prompt = `Based on the Previous Scene and Player Action, and taking into account the provided context (including map context), generate the next scene description, options, item changes, log message, etc.
 
 ## Context:
 Player's Character Gender: "${playerGender}"
+World Details:\n${worldInfo}
+
+Hero Description:\n${heroDescription}
 Previous Local Time: "${localTime ?? 'Unknown'}"
 Previous Local Environment: "${localEnvironment ?? 'Undetermined'}"
 Previous Local Place: "${localPlace ?? 'Undetermined Location'}"


### PR DESCRIPTION
## Summary
- include worldFacts and heroSheet info in `buildMainGameTurnPrompt`
- pass new data from `usePlayerActions`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68837571614c8324add5bc53c020fcba