### PR TITLE
Fix hero sheet prompt option

### DIFF
--- a/components/modals/CharacterSelectModal.tsx
+++ b/components/modals/CharacterSelectModal.tsx
@@ -73,13 +73,8 @@ function CharacterSelectModal({ isVisible, theme, playerGender, worldFacts, opti
 
         {isGenerating ? (
           <LoadingSpinner />
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 px-4">
-            {options.map(renderOption)}
-          </div>
-        )}
-
-          {heroSheet && heroBackstory ? (
+        ) : heroSheet && heroBackstory ? (
+          <>
             <div className="mt-4 space-y-3 text-slate-300">
               <p className="text-lg font-semibold text-amber-400 text-center">{heroSheet.name}</p>
               <p className="text-center">Occupation: {heroSheet.occupation}</p>
@@ -99,11 +94,35 @@ function CharacterSelectModal({ isVisible, theme, playerGender, worldFacts, opti
                 </ul>
               </div>
             </div>
-          ) : null}
+
+            <div className="mt-4 space-y-1 text-slate-300">
+              <p className="text-lg font-semibold text-sky-300 text-center">World Information</p>
+              <p className="text-center">Geography: {worldFacts.geography}</p>
+              <p className="text-center">Climate: {worldFacts.climate}</p>
+              <p className="text-center">Technology Level: {worldFacts.technologyLevel}</p>
+              <p className="text-center">Supernatural Elements: {worldFacts.supernaturalElements}</p>
+              <p className="text-center">Major Factions: {worldFacts.majorFactions.join(', ')}</p>
+              <p className="text-center">Key Resources: {worldFacts.keyResources.join(', ')}</p>
+              <p className="text-center">Cultural Notes: {worldFacts.culturalNotes.join(', ')}</p>
+              <p className="text-center">Notable Locations: {worldFacts.notableLocations.join(', ')}</p>
+            </div>
+          </>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 px-4">
+            {options.map(renderOption)}
+          </div>
+        )}
 
         <div className="mt-6 flex justify-center space-x-4">
           {heroSheet && heroBackstory ? (
-            <Button ariaLabel="Begin the adventure" icon={<Icon name="bookOpen" size={20} />} onClick={handleBegin} preset="green" size="lg" label="Begin the Journey" />
+            <Button
+              ariaLabel="Begin the adventure"
+              icon={<Icon name="bookOpen" size={20} />}
+              label="Begin the Journey"
+              onClick={handleBegin}
+              preset="green"
+              size="lg"
+            />
           ) : null}
         </div>
       </div>

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -39,7 +39,7 @@ export const buildNewGameFirstTurnPrompt = (
   heroBackstory: HeroBackstory,
 ): string => {
   const worldInfo = formatWorldFactsForPrompt(worldFacts);
-  const heroDescription = formatHeroSheetForPrompt(heroSheet);
+  const heroDescription = formatHeroSheetForPrompt(heroSheet, true);
   const heroPast = formatHeroBackstoryForPrompt(heroBackstory);
   const prompt = `Start a new adventure in the theme "${theme.name}". ${theme.systemInstructionModifier}
 Player's Character Gender: "${playerGender}"
@@ -269,7 +269,7 @@ export const buildMainGameTurnPrompt = (
     worldFacts !== null ? formatWorldFactsForPrompt(worldFacts) : 'Unknown';
   const heroDescription =
     heroSheet !== null
-      ? formatHeroSheetForPrompt(heroSheet)
+      ? formatHeroSheetForPrompt(heroSheet, false)
       : 'The hero remains undescribed.';
 
   const prompt = `Based on the Previous Scene and Player Action, and taking into account the provided context (including map context), generate the next scene description, options, item changes, log message, etc.

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -197,11 +197,20 @@ export const formatWorldFactsForPrompt = (worldFacts: WorldFacts): string => {
 /**
  * Formats a hero sheet into a short single paragraph.
  */
-export const formatHeroSheetForPrompt = (hero: HeroSheet): string =>
-  `Name: ${hero.name}
-Occupation: ${hero.occupation}.
-Traits: ${hero.traits.join(', ')}.
-Starting items: ${hero.startingItems.join(', ')}.`;
+export const formatHeroSheetForPrompt = (
+  hero: HeroSheet,
+  includeStartingItems = false,
+): string => {
+  const lines = [
+    `Name: ${hero.name}`,
+    `Occupation: ${hero.occupation}.`,
+    `Traits: ${hero.traits.join(', ')}.`,
+  ];
+  if (includeStartingItems && hero.startingItems.length > 0) {
+    lines.push(`Starting items: ${hero.startingItems.join(', ')}.`);
+  }
+  return lines.join('\n');
+};
 
 /**
  * Formats a hero backstory as a multiline string.


### PR DESCRIPTION
## Summary
- add optional boolean to `formatHeroSheetForPrompt` for including starting items
- include starting items for the first turn only

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68837a6197748324bccd4c6b09ef11b1