### PR TITLE
Extract world lore once at start

### DIFF
--- a/services/loremaster/index.ts
+++ b/services/loremaster/index.ts
@@ -1,9 +1,12 @@
 export {
+  extractInitialFacts_Service,
   refineLore_Service,
   collectRelevantFacts_Service,
   distillFacts_Service,
 } from './api';
 export type {
+  ExtractInitialFactsParams,
+  ExtractInitialFactsServiceResult,
   RefineLoreParams,
   CollectFactsParams,
   DistillFactsParams,

--- a/services/loremaster/promptBuilder.ts
+++ b/services/loremaster/promptBuilder.ts
@@ -2,16 +2,36 @@
  * @file promptBuilder.ts
  * @description Constructs prompts for the Loremaster service.
  */
-import { ThemeFact, FactWithEntities } from '../../types';
+import {
+  ThemeFact,
+  FactWithEntities,
+  WorldFacts,
+  HeroSheet,
+  HeroBackstory,
+} from '../../types';
+import {
+  formatWorldFactsForPrompt,
+  formatHeroSheetForPrompt,
+  formatHeroBackstoryForPrompt,
+} from '../../utils/promptFormatters';
 
 export const buildExtractFactsPrompt = (
   themeName: string,
   turnContext: string,
+  worldFacts?: WorldFacts,
+  heroSheet?: HeroSheet,
+  heroBackstory?: HeroBackstory,
 ): string => {
+  const worldInfo = worldFacts ? `\n${formatWorldFactsForPrompt(worldFacts)}` : '';
+  const heroInfo = heroSheet ? `\n${formatHeroSheetForPrompt(heroSheet, false)}` : '';
+  const heroPast = heroBackstory
+    ? `\n${formatHeroBackstoryForPrompt(heroBackstory)}`
+    : '';
+  const extras = `${worldInfo}${heroInfo}${heroPast}`;
   return `Theme: ${themeName}
 
   ## Context:
-${turnContext}
+${turnContext}${extras}
 
 List immutable facts according to your instructions. Return JSON as:
 [{"entities": ["id1", "id2"], "text": "fact"}]


### PR DESCRIPTION
## Summary
- run Loremaster once during initialization to extract facts from world data
- capture extracted facts and integrate them directly
- remove world data from regular loremaster calls

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68838460dc1c8324bd37c45bfb31b0f3