### PR TITLE
Add 'Now' to hero backstory and tweak intro prompt

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -23,7 +23,7 @@ v1.4. Ink and Quill update
 
 v1.5 Backstory update
   - Character Generation.
-  - Backstory generation: 5 years, 3 years, 1 year, 6 months, 1 month, 1 week, yesterday.
+  - Backstory generation: 5 years, 3 years, 1 year, 6 months, 1 month, 1 week, yesterday, now.
   - Extraction of extra lore from backstory that should not change.
   - Interactive backstory generation for the custom mode, random generation, based on old choices durin shifts.
   - Character sheet (per Theme)

--- a/components/modals/CharacterSelectModal.tsx
+++ b/components/modals/CharacterSelectModal.tsx
@@ -86,11 +86,18 @@ function CharacterSelectModal({ isVisible, theme, playerGender, worldFacts, opti
 
                 <ul className="list-disc list-inside text-lg whitespace-pre-line">
                   <li>5 years ago: {heroBackstory.fiveYearsAgo}</li>
+
                   <li>1 year ago: {heroBackstory.oneYearAgo}</li>
+
                   <li>6 months ago: {heroBackstory.sixMonthsAgo}</li>
+
                   <li>1 month ago: {heroBackstory.oneMonthAgo}</li>
+
                   <li>1 week ago: {heroBackstory.oneWeekAgo}</li>
+
                   <li>Yesterday: {heroBackstory.yesterday}</li>
+
+                  <li>Now: {heroBackstory.now}</li>
                 </ul>
               </div>
             </div>

--- a/docs/worldGenPrompts.md
+++ b/docs/worldGenPrompts.md
@@ -66,7 +66,7 @@ const heroSheet: HeroSheet;
 
 ## 5. Protagonist Backstory
 
-*Prompt*: "Write a short backstory for `heroName` using these time markers: 5 years ago, 1 year ago, 6 months ago, 1 month ago, 1 week ago, and yesterday. Keep each segment to two sentences."
+*Prompt*: "Write a short backstory for `heroName` using these time markers: 5 years ago, 1 year ago, 6 months ago, 1 month ago, 1 week ago, yesterday, and now. Keep each segment to two sentences."
 
 *Data Stored*:
 ```ts
@@ -77,6 +77,7 @@ interface HeroBackstory {
   oneMonthAgo: string;
   oneWeekAgo: string;
   yesterday: string;
+  now: string;
 }
 const heroBackstory: HeroBackstory;
 ```

--- a/hooks/initPromptHelpers.ts
+++ b/hooks/initPromptHelpers.ts
@@ -91,6 +91,7 @@ export const buildInitialGamePrompt = (
         oneMonthAgo: '',
         oneWeekAgo: '',
         yesterday: '',
+        now: '',
       },
     );
   }

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -173,7 +173,8 @@ export function isValidHeroBackstory(data: unknown): data is HeroBackstory {
     typeof maybe.sixMonthsAgo === 'string' &&
     typeof maybe.oneMonthAgo === 'string' &&
     typeof maybe.oneWeekAgo === 'string' &&
-    typeof maybe.yesterday === 'string'
+    typeof maybe.yesterday === 'string' &&
+    typeof maybe.now === 'string'
   );
 }
 

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -53,8 +53,6 @@ ${heroDescription}
 ## Player Character Backstory:
 ${heroPast}
 
-The player's last action was unremarkable—something common anyone would do in this situation.
-
 Creatively generate the main quest, current objective, scene description, action options, and starting items using the world details and hero history for inspiration.
 Creatively add any important quest item(s), if any, based on your generated quest and objective.
 

--- a/services/worldData/api.ts
+++ b/services/worldData/api.ts
@@ -62,6 +62,7 @@ const heroBackstorySchema = {
     oneMonthAgo: { type: 'string', minLength: 2000 },
     oneWeekAgo: { type: 'string', minLength: 2000 },
     yesterday: { type: 'string', minLength: 2000 },
+    now: { type: 'string', minLength: 2000 },
   },
   required: [
     'fiveYearsAgo',
@@ -70,6 +71,7 @@ const heroBackstorySchema = {
     'oneMonthAgo',
     'oneWeekAgo',
     'yesterday',
+    'now',
   ],
   additionalProperties: false,
 } as const;
@@ -228,7 +230,7 @@ export const generateHeroData = async (
         and this hero sheet:
         ${sheetText ?? ''}
         The hero's description is: ${heroDescription}.
-        Write a short backstory for ${heroName} using these time markers: 5 years ago, 1 year ago, 6 months ago, 1 month ago, 1 week ago, and yesterday.`;
+        Write a short backstory for ${heroName} using these time markers: 5 years ago, 1 year ago, 6 months ago, 1 month ago, 1 week ago, yesterday, and now.`;
       const backstoryText = await request(backstoryPrompt, heroBackstorySchema, 'HeroBackstory');
       const parsedBackstory = backstoryText ? safeParseJson<HeroBackstory>(extractJsonFromFence(backstoryText)) : null;
       return { result: { heroSheet: parsedSheet ?? null, heroBackstory: parsedBackstory ?? null } };
@@ -282,7 +284,7 @@ export const generateWorldData = async (
     const heroBackstoryPrompt =
       `Using these world details:\n${factsText ?? ''}\nand this hero sheet:\n${heroSheetText ?? ''}\n` +
       `Write a short backstory for ${heroName} using these time markers: ` +
-      '5 years ago, 1 year ago, 6 months ago, 1 month ago, 1 week ago, and yesterday.';
+      '5 years ago, 1 year ago, 6 months ago, 1 month ago, 1 week ago, yesterday, and now.';
     const backstoryText = await request(heroBackstoryPrompt, heroBackstorySchema, 'HeroBackstory');
     const parsedBackstory = backstoryText ? safeParseJson<HeroBackstory>(extractJsonFromFence(backstoryText)) : null;
     return {

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -64,6 +64,7 @@ const dummyHeroBackstory: HeroBackstory = {
   oneMonthAgo: 'Was betrayed by a friend.',
   oneWeekAgo: 'Left home seeking adventure.',
   yesterday: 'Arrived at the new town.',
+  now: 'Standing in the town square.',
 };
 
 describe('game start sequence', () => {

--- a/types.ts
+++ b/types.ts
@@ -354,6 +354,7 @@ export interface HeroBackstory {
   oneMonthAgo: string;
   oneWeekAgo: string;
   yesterday: string;
+  now: string;
 }
 
 export interface CharacterOption {

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -225,4 +225,5 @@ export const formatHeroBackstoryForPrompt = (
     `1 month ago: ${backstory.oneMonthAgo}`,
     `1 week ago: ${backstory.oneWeekAgo}`,
     `Yesterday: ${backstory.yesterday}`,
+    `Now: ${backstory.now}`,
   ].join('\n');


### PR DESCRIPTION
## Summary
- extend HeroBackstory with a new `now` entry
- display the new time marker in CharacterSelectModal
- update prompt builders and world generation to include "now"
- remove an unnecessary line from the first turn prompt
- adjust validators, formatters, docs and tests

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883b35a80a48324bc099868985a12c6