### PR TITLE
Provide heroSheet data in dialogue prompts

### DIFF
--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -113,6 +113,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
           stateAfterPlayerChoice.allNPCs.filter((npc) => npc.themeName === currentThemeObj.name),
           stateAfterPlayerChoice.inventory.filter(item => item.holderId === PLAYER_HOLDER_ID),
           playerGenderProp,
+          stateAfterPlayerChoice.heroSheet,
           historyWithPlayerChoice,
           option,
           (() => {

--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -12,6 +12,7 @@ import {
   MapNode,
   DialogueMemorySummaryContext,
   AdventureTheme,
+  HeroSheet,
 } from '../../types';
 import {
   GEMINI_MODEL_NAME,
@@ -97,6 +98,7 @@ export const executeDialogueTurn = async (
   knownNPCsInTheme: Array<NPC>,
   inventory: Array<Item>,
   playerGender: string,
+  heroSheet: HeroSheet | null,
   dialogueHistory: Array<DialogueHistoryEntry>,
   playerLastUtterance: string,
   dialogueParticipants: Array<string>,
@@ -119,6 +121,7 @@ export const executeDialogueTurn = async (
     knownNPCsInTheme: knownNPCsInTheme,
     inventory,
     playerGender,
+    heroSheet,
     dialogueHistory,
     playerLastUtterance,
     dialogueParticipants,

--- a/services/dialogue/promptBuilder.ts
+++ b/services/dialogue/promptBuilder.ts
@@ -12,6 +12,7 @@ import {
   MAIN_TURN_OPTIONS_COUNT,
 } from '../../constants';
 import { formatKnownPlacesForPrompt } from '../../utils/promptFormatters/map';
+import { formatHeroSheetForPrompt } from '../../utils/promptFormatters';
 
 /**
  * Builds the prompt used to fetch the next dialogue turn.
@@ -31,11 +32,16 @@ export const buildDialogueTurnPrompt = (
     knownNPCsInTheme: knownNPCsInTheme,
     inventory,
     playerGender,
+    heroSheet,
     dialogueHistory,
     playerLastUtterance,
     dialogueParticipants,
     relevantFacts,
   } = context;
+  const heroDescription =
+    heroSheet !== null
+      ? formatHeroSheetForPrompt(heroSheet, false)
+      : 'The player character remains undescribed.';
   let historyToUseInPrompt = [...dialogueHistory];
   if (
     historyToUseInPrompt.length > 0 &&
@@ -117,7 +123,10 @@ Current Main Quest: "${currentQuest ?? 'Not set'}";
 Current Objective: "${currentObjective ?? 'Not set'}";
 Scene Description (for environmental context): "${currentScene}";
 Local Time: "${localTime ?? 'Unknown'}", Environment: "${localEnvironment ?? 'Undetermined'}", Place: "${localPlace ?? 'Undetermined'}";
-Player's Character Gender: ${playerGender};
+### Player Character Description:
+Gender: ${playerGender}.
+${heroDescription}
+Character Traits should especially influence dialogue choices.
 
 ## Relevant Facts about the world:
 ${relevantFactsSection}

--- a/types.ts
+++ b/types.ts
@@ -195,6 +195,7 @@ export interface DialogueTurnContext {
   knownNPCsInTheme: Array<NPC>;
   inventory: Array<Item>;
   playerGender: string;
+  heroSheet: HeroSheet | null;
   dialogueHistory: Array<DialogueHistoryEntry>;
   playerLastUtterance: string;
   dialogueParticipants: Array<string>;


### PR DESCRIPTION
## Summary
- extend `DialogueTurnContext` with `heroSheet`
- include hero sheet details in dialogue prompt builder
- pass hero sheet to `executeDialogueTurn`
- forward hero sheet from `useDialogueTurn` when requesting dialogue turns

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883c75877648324a9e809c8765601ab