### PR TITLE
Add recent game log to loremaster distill

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -282,6 +282,7 @@ export const MAX_DIALOGUE_SUMMARIES_IN_PROMPT = 3;   // Max summaries to include
 export const MIN_DIALOGUE_TURN_OPTIONS = 4; // Minimum dialogue options per turn
 export const MAX_DIALOGUE_TURN_OPTIONS = 8; // Maximum dialogue options per turn
 export const RECENT_LOG_COUNT_FOR_PROMPT = 10; // Number of log messages to include in AI prompts
+export const RECENT_LOG_COUNT_FOR_DISTILL = 20; // Log entries for loremaster distill
 
 // Standard instructions for AI-generated text fields
 export const NODE_DESCRIPTION_INSTRUCTION =

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -25,7 +25,11 @@ import { useGameTurn } from './useGameTurn';
 import { useGameInitialization, LoadInitialGameOptions } from './useGameInitialization';
 import { buildSaveStateSnapshot } from './saveSnapshotHelpers';
 import { structuredCloneGameState } from '../utils/cloneUtils';
-import { PLAYER_HOLDER_ID, DISTILL_LORE_INTERVAL } from '../constants';
+import {
+  PLAYER_HOLDER_ID,
+  DISTILL_LORE_INTERVAL,
+  RECENT_LOG_COUNT_FOR_DISTILL,
+} from '../constants';
 import { getAdjacentNodeIds } from '../utils/mapGraphUtils';
 import { distillFacts_Service } from '../services/loremaster';
 import { applyThemeFactChanges } from '../utils/gameLogicUtils';
@@ -394,6 +398,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
       ),
     );
     const mapNodeNames = currentThemeNodes.map(n => n.placeName);
+    const recentLogs = currentFullState.gameLog.slice(-RECENT_LOG_COUNT_FOR_DISTILL);
     setLoadingReasonRef('loremaster_refine');
     const result = await distillFacts_Service({
       themeName: themeObj.name,
@@ -402,6 +407,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
       currentObjective: currentFullState.currentObjective,
       inventoryItemNames,
       mapNodeNames,
+      recentLogEntries: recentLogs,
     });
     const draftState = structuredCloneGameState(currentFullState);
     draftState.lastLoreDistillTurn = currentFullState.globalTurnNumber;

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -27,6 +27,7 @@ import {
   RECENT_LOG_COUNT_FOR_PROMPT,
   PLAYER_HOLDER_ID,
   DISTILL_LORE_INTERVAL,
+  RECENT_LOG_COUNT_FOR_DISTILL,
 } from '../constants';
 
 import { structuredCloneGameState } from '../utils/cloneUtils';
@@ -138,6 +139,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           ),
         );
         const mapNodeNames = currentThemeNodes.map(n => n.placeName);
+        const recentLogs = state.gameLog.slice(-RECENT_LOG_COUNT_FOR_DISTILL);
         setLoadingReason('loremaster_refine');
         const result = await distillFacts_Service({
           themeName: themeObj.name,
@@ -146,6 +148,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           currentObjective: state.currentObjective,
           inventoryItemNames,
           mapNodeNames,
+          recentLogEntries: recentLogs,
         });
         state.lastLoreDistillTurn = state.globalTurnNumber;
         state.lastDebugPacket ??= {

--- a/services/loremaster/api.ts
+++ b/services/loremaster/api.ts
@@ -516,6 +516,7 @@ export interface DistillFactsParams {
   currentObjective: string | null;
   inventoryItemNames: Array<string>;
   mapNodeNames: Array<string>;
+  recentLogEntries: Array<string>;
 }
 
 export interface DistillFactsServiceResult {
@@ -546,6 +547,7 @@ export const distillFacts_Service = async (
     currentObjective,
     inventoryItemNames,
     mapNodeNames,
+    recentLogEntries,
   } = params;
 
   const prompt = buildDistillFactsPrompt(
@@ -555,6 +557,7 @@ export const distillFacts_Service = async (
     currentObjective,
     inventoryItemNames,
     mapNodeNames,
+    recentLogEntries,
   );
 
   const result = await retryAiCall<{

--- a/services/loremaster/promptBuilder.ts
+++ b/services/loremaster/promptBuilder.ts
@@ -103,6 +103,7 @@ export const buildDistillFactsPrompt = (
   currentObjective: string | null,
   inventoryItemNames: Array<string>,
   mapNodeNames: Array<string>,
+  recentLogEntries: Array<string>,
 ): string => {
   const factLines = facts
     .map(
@@ -114,9 +115,13 @@ export const buildDistillFactsPrompt = (
     .map(name => `- ${name}`)
     .join('\n');
   const mapLines = mapNodeNames.map(name => `- ${name}`).join('\n');
+  const logLines = recentLogEntries.map(l => `- ${l}`).join('\n');
   return `Theme: ${themeName}
 Current Quest: ${currentQuest ?? 'None'}
 Current Objective: ${currentObjective ?? 'None'}
+
+## Recent Log:
+${logLines || 'None'}
 
 ## Inventory Items:
 ${inventoryLines || 'None'}

--- a/services/loremaster/systemPrompt.ts
+++ b/services/loremaster/systemPrompt.ts
@@ -78,6 +78,7 @@ Select the ten most important facts for the upcoming story turn.
 `;
 
 export const DISTILL_SYSTEM_INSTRUCTION = `You are the Loremaster refining and pruning accumulated facts.
+Consider the last 20 log entries supplied in the prompt. Remove or edit any facts that have been addressed and are no longer in effect.
 1. Look for statements that describe the same idea and merge them into a single, more specific fact. Keep the length of the merged fact under 200 words. Split any fact longer than 200 words into two non-overlapping facts.
 Increase the tier of the merged fact by one.
 When merging, combine the entity IDs from all merged facts into a single set with no duplicates.

--- a/tests/loremasterPromptDistill.test.ts
+++ b/tests/loremasterPromptDistill.test.ts
@@ -9,10 +9,17 @@ describe('buildDistillFactsPrompt', () => {
       { id: 2, text: 'Second fact', entities: ['c'], themeName: 'theme', createdTurn: 1, tier: 1 },
     ];
 
-    const prompt = buildDistillFactsPrompt('theme', facts, null, null, [], []);
+    const prompt = buildDistillFactsPrompt('theme', facts, null, null, [], [], []);
 
     expect(prompt).toContain('ID 1: "First fact" [a, b]');
     expect(prompt).toContain('ID 2: "Second fact" [c]');
+  });
+
+  it('includes recent log entries', () => {
+    const facts: Array<ThemeFact> = [];
+    const prompt = buildDistillFactsPrompt('theme', facts, null, null, [], [], ['log a', 'log b']);
+    expect(prompt).toContain('log a');
+    expect(prompt).toContain('log b');
   });
 });
 


### PR DESCRIPTION
## Summary
- include new constant `RECENT_LOG_COUNT_FOR_DISTILL`
- supply last 20 log entries to `buildDistillFactsPrompt`
- update loremaster distill system prompt
- pass recent log to distill in hooks
- test new prompt behavior

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68840a4b82c08324ae54ffe3e1e39d26