### PR TITLE
Expand loremaster integration

### DIFF
--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -589,6 +589,8 @@ export const useProcessAiResponse = ({
           themeName: themeContextForResponse.name,
           turnContext: contextParts,
           existingFacts: draftState.themeFacts,
+          logMessage: aiData.logMessage ?? '',
+          currentScene: aiData.sceneDescription,
           onFactsExtracted: debugLore
             ? async (facts) =>
                 new Promise<{ proceed: boolean }>(resolve => {

--- a/services/loremaster/promptBuilder.ts
+++ b/services/loremaster/promptBuilder.ts
@@ -13,6 +13,7 @@ import {
   formatWorldFactsForPrompt,
   formatHeroSheetForPrompt,
   formatHeroBackstoryForPrompt,
+  formatRecentEventsForPrompt,
 } from '../../utils/promptFormatters';
 
 export const buildExtractFactsPrompt = (
@@ -42,6 +43,8 @@ export const buildIntegrateFactsPrompt = (
   themeName: string,
   existingFacts: Array<ThemeFact>,
   newFacts: Array<FactWithEntities>,
+  logMessage: string,
+  currentScene: string,
 ): string => {
   const existing =
     existingFacts
@@ -51,14 +54,20 @@ export const buildIntegrateFactsPrompt = (
     newFacts
       .map(f => `- ${f.text} [${f.entities.join(', ')}]`)
       .join('\n') || 'None.';
+  const events = formatRecentEventsForPrompt(
+    [logMessage, currentScene].filter(e => e.trim() !== ''),
+  );
   return `Theme: ${themeName}
 
   ## Known Facts:
 ${existing}
 
   ## New Candidate Facts:
-${proposed}
-  
+  ${proposed}
+
+  ## Recent Events:
+  ${events || 'None'}
+
 Provide integration instructions acording to your instructions.
 `;
 };

--- a/services/loremaster/systemPrompt.ts
+++ b/services/loremaster/systemPrompt.ts
@@ -69,8 +69,8 @@ Each fact must aid long-term continuity and world-building.
 CRITICALLY IMPORTANT: DO NOT include bad quality and irrelevant facts.
 `;
 
-export const INTEGRATE_ADD_ONLY_SYSTEM_INSTRUCTION = `You are the Loremaster integrating newly discovered facts with existing lore, while avoiding overlaps and potential contradictions.
-In your JSON response, 'action' field MUST always be 'add'.`;
+export const INTEGRATE_SYSTEM_INSTRUCTION = `You are the Loremaster integrating newly discovered facts with existing lore, while avoiding overlaps and potential contradictions.
+Use the "add", "change" or "delete" actions to update the lore based on recent events.`;
 
 export const COLLECT_SYSTEM_INSTRUCTION = `You are the Loremaster selecting relevant known facts.
 Relevant facts are those that directly inform the next scene: details the NPCs might reference, rules that shape the environment, or recent events likely to influence decisions.


### PR DESCRIPTION
## Summary
- allow lore facts integration to add, change, or delete facts
- pass recent log message and scene into integration prompt
- add schema support for change/delete in lore integration
- rename INTEGRATE_ADD_ONLY_SYSTEM_INSTRUCTION to INTEGRATE_SYSTEM_INSTRUCTION

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688413b2e1ec832487e9eab8fefffac4