### PR TITLE
Simplify Loremaster JSON schemas

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -277,7 +277,8 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
               }
               const changes = initialFacts.facts.map(f => ({
                 action: 'add' as const,
-                fact: { text: f.text, entities: f.entities },
+                text: f.text,
+                entities: f.entities,
               }));
               applyThemeFactChanges(
                 draftState,

--- a/services/loremaster/api.ts
+++ b/services/loremaster/api.ts
@@ -60,18 +60,21 @@ export const COLLECT_FACTS_JSON_SCHEMA = {
   items: { type: 'string' },
 } as const;
 
+
 export const INTEGRATE_FACTS_JSON_SCHEMA = {
   type: 'object',
   properties: {
     observations: {
       type: 'string',
       minLength: 500,
-      description: 'Minimum 300 words. Observations about the lore state and the proposed new facts, e.g. There are 3 facts that can be merged. Some of the facts may be too vague or obsolete to be included...'
+      description:
+        'Minimum 300 words. Observations about the lore state and the proposed new facts, e.g. There are 3 facts that can be merged. Some of the facts may be too vague or obsolete to be included...'
     },
     rationale: {
       type: 'string',
       minLength: 500,
-      description: 'Minimum 300 words. Rationale for and against including the proposed facts into the lore, e.g. Most facts are good enough to be included in the lore. However, the facts about the old tavern are no longer relevant. The fact about *a path* leading to the church is too vague - a more concrete named path should have been mentioned instead. I will omit these facts.'
+      description:
+        'Minimum 300 words. Rationale for and against including the proposed facts into the lore, e.g. Most facts are good enough to be included in the lore. However, the facts about the old tavern are no longer relevant. The fact about *a path* leading to the church is too vague - a more concrete named path should have been mentioned instead. I will omit these facts.'
     },
     factsChange: {
       type: 'array',
@@ -81,47 +84,33 @@ export const INTEGRATE_FACTS_JSON_SCHEMA = {
             type: 'object',
             properties: {
               action: { enum: ['add'] },
-              fact: {
-                type: 'object',
-                properties: {
-                  text: { type: 'string', description: 'Must be one of the accepted *New Candidate Facts*.' },
-                  entities: { type: 'array', items: { type: 'string' } },
-                },
-                propertyOrdering: ['entities', 'text'],
-                required: ['entities', 'text'],
-                additionalProperties: false,
+              text: {
+                type: 'string',
+                description: 'Must be one of the accepted *New Candidate Facts*.',
               },
+              entities: { type: 'array', items: { type: 'string' } },
             },
-            propertyOrdering: ['action', 'fact'],
-            required: ['action', 'fact'],
+            propertyOrdering: ['action', 'entities', 'text'],
+            required: ['action', 'entities', 'text'],
             additionalProperties: false,
           },
           {
             type: 'object',
-            description: 'Change or delete the lore facts that are no longer relevant according to Recent Events',
+            description:
+              'Change or delete the lore facts that are no longer relevant according to Recent Events',
             properties: {
-              action: {
-                enum: ['delete', 'change']
-              },
+              action: { enum: ['delete', 'change'] },
               id: { type: 'integer', description: 'ID of the fact to change or remove.' },
-              fact: {
-                type: 'object',
-                properties: {
-                  text: { type: 'string', description: 'Updated fact text for the change action.' },
-                  entities: { type: 'array', items: { type: 'string' } },
-                },
-                propertyOrdering: ['entities', 'text'],
-                required: ['entities', 'text'],
-                additionalProperties: false,
-              },
+              text: { type: 'string', description: 'Updated fact text for the change action.' },
+              entities: { type: 'array', items: { type: 'string' } },
             },
-            propertyOrdering: ['action', 'id', 'fact'],
+            propertyOrdering: ['action', 'id', 'entities', 'text'],
             required: ['action', 'id'],
             additionalProperties: false,
           },
         ],
       },
-    }
+    },
   },
   required: ['observations', 'rationale', 'factsChange'],
   propertyOrdering: ['observations', 'rationale', 'factsChange'],
@@ -145,23 +134,24 @@ export const DISTILL_FACTS_JSON_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
+        description: 'REQUIRED for the *add* and *change* actions. Omitted for the *delete* action.',
         properties: {
           action: { enum: ['add', 'change', 'delete'] },
-          fact: {
-            type: 'object',
-            description: 'REQUIRED for the *add* and *change* actions. Omitted for the *delete* action.',
-            properties: {
-              entities: { type: 'array', items: { type: 'string' } },
-              text: { type: 'string', maxLength: 2000, description: 'REQUIRED for the *add* and *change* actions. MUST be under 200 words.' },
-              tier: { type: 'integer', description: 'Omit tier for *add* action. Increase tier by one for *change* action, when any number of other facts are merged into this one.', default: 1 },
-            },
-            propertyOrdering: ['entities', 'text', 'tier'],
-            required: ['entities', 'text'],
-            additionalProperties: false,
+          entities: { type: 'array', items: { type: 'string' } },
+          text: {
+            type: 'string',
+            maxLength: 2000,
+            description: 'REQUIRED for the *add* and *change* actions. MUST be under 200 words.',
+          },
+          tier: {
+            type: 'integer',
+            description:
+              'Omit tier for *add* action. Increase tier by one for *change* action, when any number of other facts are merged into this one.',
+            default: 1,
           },
           id: { type: 'integer', description: "Required for *change* and *delete* actions." }
         },
-        propertyOrdering: ['action', 'fact', 'id'],
+        propertyOrdering: ['action', 'entities', 'text', 'tier', 'id'],
         required: ['action'],
         additionalProperties: false,
       }

--- a/services/loremaster/responseParser.ts
+++ b/services/loremaster/responseParser.ts
@@ -9,15 +9,13 @@ const isThemeFactChange = (value: unknown): value is ThemeFactChange => {
   if (!value || typeof value !== 'object') return false;
   const obj = value as Partial<ThemeFactChange>;
   if (typeof obj.action !== 'string') return false;
-  if (obj.fact) {
-    const fact = obj.fact as Partial<ThemeFactChange['fact']> | undefined;
-    if (
-      fact?.entities !== undefined &&
-      (!Array.isArray(fact.entities) || !fact.entities.every(id => typeof id === 'string'))
-    ) {
-      return false;
-    }
+  if (
+    obj.entities !== undefined &&
+    (!Array.isArray(obj.entities) || !obj.entities.every(id => typeof id === 'string'))
+  ) {
+    return false;
   }
+  if (obj.text !== undefined && typeof obj.text !== 'string') return false;
   return true;
 };
 
@@ -57,10 +55,10 @@ export const parseIntegrationResponse = (
   if (Array.isArray(obj.factsChange)) {
     obj.factsChange.forEach(raw => {
       if (isThemeFactChange(raw)) {
-        if (raw.fact) {
-          raw.fact.entities = Array.isArray(raw.fact.entities)
-            ? raw.fact.entities.filter((id: unknown): id is string => typeof id === 'string')
-            : [];
+        if (Array.isArray(raw.entities)) {
+          raw.entities = raw.entities.filter(
+            (id: unknown): id is string => typeof id === 'string',
+          );
         }
         factsArr.push(raw);
       }

--- a/services/loremaster/systemPrompt.ts
+++ b/services/loremaster/systemPrompt.ts
@@ -81,24 +81,20 @@ export const INTEGRATE_SYSTEM_INSTRUCTION = `You are the Loremaster maintaining 
     },
     {
         "action": "add",
-        "fact": {
         "entities": [
             "node_Whisperwood_Jungle_38ax"
         ],
         "text": "The Whisperwood Jungle is a colossal green wall of ancient trees and tangled vines, characterized by oppressive humidity in its undergrowth and a high canopy with gaps allowing sunlight to filter through. It resonates with exotic bird calls and the distant roar of vast, unseen creatures."
-        }
     },
     {
         "action": "change",
-        "fact": {
         "entities": [
             "node_Whisperwood_Jungle_38ax",
             "node_Jagged_Peaks_44re",
             "item_Ancient_Map_Fragment_mjdl"
         ],
         "text": "From the current location within the Whisperwood Jungle, the colossal green wall appears to stretch limitlessly to the north. To the east, a dip in the terrain suggests a watercourse, while a lone, massive flowering tree with vibrant red blossoms is visible to the south. To the west, a distant jagged peak is discernible, matching a feature marked on the Ancient Map Fragment.",
-        "tier": 2
-        },
+        "tier": 2,
         "id": 3
     }
 ]
@@ -130,24 +126,20 @@ When merging, combine the entity IDs from all merged facts into a single set wit
     },
     {
         "action": "add",
-        "fact": {
         "entities": [
             "node_Whisperwood_Jungle_38ax"
         ],
         "text": "The Whisperwood Jungle is a colossal green wall of ancient trees and tangled vines, characterized by oppressive humidity in its undergrowth and a high canopy with gaps allowing sunlight to filter through. It resonates with exotic bird calls and the distant roar of vast, unseen creatures."
-        }
     },
     {
         "action": "change",
-        "fact": {
         "entities": [
             "node_Whisperwood_Jungle_38ax",
             "node_Jagged_Peaks_44re",
             "item_Ancient_Map_Fragment_mjdl"
         ],
         "text": "From the current location within the Whisperwood Jungle, the colossal green wall appears to stretch limitlessly to the north. To the east, a dip in the terrain suggests a watercourse, while a lone, massive flowering tree with vibrant red blossoms is visible to the south. To the west, a distant jagged peak is discernible, matching a feature marked on the Ancient Map Fragment.",
-        "tier": 2
-        },
+        "tier": 2,
         "id": 3
     }
 ]

--- a/types.ts
+++ b/types.ts
@@ -312,9 +312,10 @@ export interface ThemeFact {
 
 export interface ThemeFactChange {
   action: 'add' | 'change' | 'delete';
-  fact?: Partial<Omit<ThemeFact, 'id' | 'createdTurn'>> & {
-    createdTurn?: number;
-  };
+  text?: string;
+  entities?: Array<string>;
+  tier?: number;
+  createdTurn?: number;
   id?: number;
 }
 

--- a/utils/gameLogicUtils.ts
+++ b/utils/gameLogicUtils.ts
@@ -67,24 +67,26 @@ export const applyThemeFactChanges = (
   for (const change of changes) {
     switch (change.action) {
       case 'add':
-        if (change.fact && change.fact.text && defaultThemeName) {
+        if (change.text && defaultThemeName) {
           const newFact: ThemeFact = {
             id: nextId++,
-            text: change.fact.text,
-            entities: change.fact.entities ?? [],
+            text: change.text,
+            entities: change.entities ?? [],
             themeName: defaultThemeName,
-            createdTurn: change.fact.createdTurn ?? currentTurn,
-            tier: change.fact.tier ?? 1,
+            createdTurn: change.createdTurn ?? currentTurn,
+            tier: change.tier ?? 1,
           };
           state.themeFacts.push(newFact);
         }
         break;
       case 'change': {
         const idx = state.themeFacts.findIndex(f => f.id === change.id);
-        if (idx >= 0 && change.fact) {
+        if (idx >= 0) {
           const updated: ThemeFact = {
             ...state.themeFacts[idx],
-            ...change.fact,
+            text: change.text ?? state.themeFacts[idx].text,
+            entities: change.entities ?? state.themeFacts[idx].entities,
+            tier: change.tier ?? state.themeFacts[idx].tier,
             themeName: state.themeFacts[idx].themeName,
           };
           state.themeFacts[idx] = updated;


### PR DESCRIPTION
## Summary
- flatten `factsChange` objects in Loremaster schemas
- adjust parsing logic and type definitions for flattened structure
- update game logic helper and initialization hook
- revise system prompt examples to match new format

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884b352bfb08324abd8e1a9fb0aeb24