### PR TITLE
Flatten cartographer schema objects

### DIFF
--- a/services/cartographer/request.ts
+++ b/services/cartographer/request.ts
@@ -59,23 +59,28 @@ export const MAP_UPDATE_JSON_SCHEMA = {
       items: {
         type: 'object',
         properties: {
-          data: {
-            type: 'object',
-            properties: {
-              description: { type: 'string', description: EDGE_DESCRIPTION_INSTRUCTION },
-              status: { enum: VALID_EDGE_STATUS_VALUES, description: `One of ${VALID_EDGE_STATUS_STRING}` },
-              travelTime: { type: 'string' },
-              type: { enum: VALID_EDGE_TYPE_VALUES, description: `One of ${VALID_EDGE_TYPE_STRING}` },
-            },
-            propertyOrdering: ['description', 'status', 'travelTime', 'type'],
-            required: ['status', 'type'],
-            additionalProperties: false,
+          description: { type: 'string', description: EDGE_DESCRIPTION_INSTRUCTION },
+          sourcePlaceName: {
+            type: 'string',
+            description: 'Source node ID or placeName. Use placeName when referencing other nodes in this response.',
           },
-          sourcePlaceName: { type: 'string', description: 'Source node ID or placeName. Use placeName when referencing other nodes in this response.' },
-          targetPlaceName: { type: 'string', description: 'Target node ID or placeName. Use placeName when referencing other nodes in this response.' },
+          status: { enum: VALID_EDGE_STATUS_VALUES, description: `One of ${VALID_EDGE_STATUS_STRING}` },
+          targetPlaceName: {
+            type: 'string',
+            description: 'Target node ID or placeName. Use placeName when referencing other nodes in this response.',
+          },
+          travelTime: { type: 'string' },
+          type: { enum: VALID_EDGE_TYPE_VALUES, description: `One of ${VALID_EDGE_TYPE_STRING}` },
         },
-        propertyOrdering: ['data', 'sourcePlaceName', 'targetPlaceName'],
-        required: ['data', 'sourcePlaceName', 'targetPlaceName'],
+        propertyOrdering: [
+          'description',
+          'sourcePlaceName',
+          'status',
+          'targetPlaceName',
+          'travelTime',
+          'type',
+        ],
+        required: ['sourcePlaceName', 'status', 'targetPlaceName', 'type'],
         additionalProperties: false,
       },
     },
@@ -94,22 +99,28 @@ export const MAP_UPDATE_JSON_SCHEMA = {
       items: {
         type: 'object',
         properties: {
-          newData: {
-            type: 'object',
-            properties: {
-              description: { type: 'string', description: EDGE_DESCRIPTION_INSTRUCTION },
-              status: { enum: VALID_EDGE_STATUS_VALUES, description: `One of ${VALID_EDGE_STATUS_STRING}` },
-              travelTime: { type: 'string', description: 'Approximate travel time for the route.' },
-              type: { enum: VALID_EDGE_TYPE_VALUES, description: `One of ${VALID_EDGE_TYPE_STRING}` },
-            },
-            propertyOrdering: ['description', 'status', 'travelTime', 'type'],
-            additionalProperties: false,
+          description: { type: 'string', description: EDGE_DESCRIPTION_INSTRUCTION },
+          sourcePlaceName: {
+            type: 'string',
+            description: 'Source node ID or placeName. Use placeName when referencing other nodes in this response.',
           },
-          sourcePlaceName: { type: 'string', description: 'Source node ID or placeName. Use placeName when referencing other nodes in this response.' },
-          targetPlaceName: { type: 'string', description: 'Target node ID or placeName. Use placeName when referencing other nodes in this response.' },
+          status: { enum: VALID_EDGE_STATUS_VALUES, description: `One of ${VALID_EDGE_STATUS_STRING}` },
+          targetPlaceName: {
+            type: 'string',
+            description: 'Target node ID or placeName. Use placeName when referencing other nodes in this response.',
+          },
+          travelTime: { type: 'string', description: 'Approximate travel time for the route.' },
+          type: { enum: VALID_EDGE_TYPE_VALUES, description: `One of ${VALID_EDGE_TYPE_STRING}` },
         },
-        propertyOrdering: ['newData', 'sourcePlaceName', 'targetPlaceName'],
-        required: ['newData', 'sourcePlaceName', 'targetPlaceName'],
+        propertyOrdering: [
+          'description',
+          'sourcePlaceName',
+          'status',
+          'targetPlaceName',
+          'travelTime',
+          'type',
+        ],
+        required: ['sourcePlaceName', 'targetPlaceName'],
         additionalProperties: false,
       },
     },
@@ -118,39 +129,45 @@ export const MAP_UPDATE_JSON_SCHEMA = {
       items: {
         type: 'object',
         properties: {
+          aliases: {
+            type: 'array',
+            minItems: 1,
+            items: { type: 'string' },
+            description: ALIAS_INSTRUCTION,
+          },
+          description: {
+            type: 'string',
+            minLength: 30,
+            description: NODE_DESCRIPTION_INSTRUCTION,
+          },
+          initialPosition: {
+            type: 'object',
+            properties: { x: { type: 'number' }, y: { type: 'number' } },
+            required: ['x', 'y'],
+            additionalProperties: false,
+          },
+          nodeType: { enum: VALID_NODE_TYPE_VALUES, description: `One of ${VALID_NODE_TYPE_STRING}` },
+          parentNodeId: {
+            type: 'string',
+            description: 'Parent Node ID, or "Universe" for top-level nodes. Use placeName when referencing other nodes in this response.',
+          },
           placeName: {
             type: 'string',
             description:
               'Name of the node. Should not contain a comma. For sub-locations this can be a descriptive feature name.',
           },
-          data: {
-            type: 'object',
-            properties: {
-              aliases: {
-                type: 'array',
-                minItems: 1,
-                items: { type: 'string' },
-                description: ALIAS_INSTRUCTION,
-              },
-              description: {
-                type: 'string',
-                minLength: 30,
-                description: NODE_DESCRIPTION_INSTRUCTION,
-              },
-              nodeType: { enum: VALID_NODE_TYPE_VALUES, description: `One of ${VALID_NODE_TYPE_STRING}` },
-              parentNodeId: {
-                type: 'string',
-                description: 'Parent Node ID, or "Universe" for top-level nodes. Use placeName when referencing other nodes in this response.',
-              },
-              status: { enum: VALID_NODE_STATUS_VALUES, description: `One of ${VALID_NODE_STATUS_STRING}` },
-            },
-            propertyOrdering: ['aliases', 'description', 'nodeType', 'parentNodeId', 'status'],
-            required: ['aliases', 'description', 'nodeType', 'parentNodeId', 'status'],
-            additionalProperties: false,
-          },
+          status: { enum: VALID_NODE_STATUS_VALUES, description: `One of ${VALID_NODE_STATUS_STRING}` },
         },
-        propertyOrdering: ['data', 'placeName'],
-        required: ['data', 'placeName'],
+        propertyOrdering: [
+          'aliases',
+          'description',
+          'initialPosition',
+          'nodeType',
+          'parentNodeId',
+          'placeName',
+          'status',
+        ],
+        required: ['aliases', 'description', 'nodeType', 'parentNodeId', 'placeName', 'status'],
         additionalProperties: false,
       },
     },
@@ -169,37 +186,28 @@ export const MAP_UPDATE_JSON_SCHEMA = {
       items: {
         type: 'object',
         properties: {
-          newData: {
-            type: 'object',
-            properties: {
-              aliases: { type: 'array', items: { type: 'string' }, minItems: 1, description: ALIAS_INSTRUCTION },
-              description: { type: 'string', description: NODE_DESCRIPTION_INSTRUCTION },
-              nodeType: { enum: VALID_NODE_TYPE_VALUES, description: `One of ${VALID_NODE_TYPE_STRING}` },
-              parentNodeId: {
-                type: 'string',
-                description:
-                  'Parent Node ID, or "Universe" for top-level nodes. Parent can not be a feature node. Use placeName when referencing other nodes in this response.',
-              },
-              placeName: {
-                type: 'string',
-                description: 'If provided, this will be the new name for the node.',
-              },
-              status: { enum: VALID_NODE_STATUS_VALUES, description: `One of ${VALID_NODE_STATUS_STRING}` },
-            },
-            propertyOrdering: [
-              'aliases',
-              'description',
-              'nodeType',
-              'parentNodeId',
-              'placeName',
-              'status',
-            ],
-            additionalProperties: false,
+          aliases: { type: 'array', items: { type: 'string' }, minItems: 1, description: ALIAS_INSTRUCTION },
+          description: { type: 'string', description: NODE_DESCRIPTION_INSTRUCTION },
+          newPlaceName: { type: 'string', description: 'If provided, this will be the new name for the node.' },
+          nodeType: { enum: VALID_NODE_TYPE_VALUES, description: `One of ${VALID_NODE_TYPE_STRING}` },
+          parentNodeId: {
+            type: 'string',
+            description:
+              'Parent Node ID, or "Universe" for top-level nodes. Parent can not be a feature node. Use placeName when referencing other nodes in this response.',
           },
           placeName: { type: 'string', description: 'Existing node ID or name to identify it.' },
+          status: { enum: VALID_NODE_STATUS_VALUES, description: `One of ${VALID_NODE_STATUS_STRING}` },
         },
-        propertyOrdering: ['newData', 'placeName'],
-        required: ['newData', 'placeName'],
+        propertyOrdering: [
+          'aliases',
+          'description',
+          'newPlaceName',
+          'nodeType',
+          'parentNodeId',
+          'placeName',
+          'status',
+        ],
+        required: ['placeName'],
         additionalProperties: false,
       },
     },

--- a/services/cartographer/systemPrompt.ts
+++ b/services/cartographer/systemPrompt.ts
@@ -21,11 +21,11 @@ CRITICAL INSTRUCTIONS:
 - All nodes MUST represent physical locations. NEVER add small items and NPCs to the map!!! Nodes represent spaces the player can occupy: regions, general locations, settlements, building exteriors or interiors, rooms, and notable landscape or architectural features. Feature-type nodes represent sub-spaces within larger spaces. NEVER create nodes that represent inventory items.
 - IMPORTANT: Large multi-crew vehicles (e.g., ships, airships, spaceships, trains) can be represented as nodes if they are significant locations in the narrative. They should have a "nodeType" of "exterior" and MUST have sub-nodes for their interior spaces. When creating a node for a large vehicle, ensure it has a "description" that indicates its size and purpose, and that it contains a significant number of constituent nodes required for the large vehicle operation (e.g. main deck, engine room, captain's quarters, cargo hold, bridge, observation deck, reactor room, life support, etc.). At least one of the feature nodes must be clearly defined as a connection point to the outer world (e.g., "Docking Bay", "Hangar", "Airlock", "Gang Plank" etc.).
 - When considering a new location, check existing item and NPC names (including aliases). If the name matches or closely resembles one, SKIP adding that node and omit any edges that would connect to it.
-- Node Data for "nodesToAdd":
-    - "description", "aliases", and "status" are ALWAYS REQUIRED in the "data" field for ALL added nodes.
+- Node Fields for "nodesToAdd":
+    - "aliases", "description", and "status" are ALWAYS REQUIRED for ALL added nodes.
     - You MUST provide "parentNodeId" of a node higher in the hierarchy for every node. Top level nodes should be assigned 'Universe' as their parentNodeId.
-- Node Data for "nodesToUpdate":
-    - "description" and "aliases" can be optionally provided in "newData" to update ANY node.
+- Node Fields for "nodesToUpdate":
+    - "aliases" and "description" can be optionally provided to update ANY node.
     - When adding a new main location via "nodesToAdd", the "placeName" MUST correspond to a location name that the Storyteller AI has indicated as significant.
     - You MUST include "parentNodeId" of a node higher in the hierarchy for every node.
 - Node "placeName" (both for identifying nodes and for new names) should be unique within their theme. NEVER create duplicates of existing nodes or edges.
@@ -33,14 +33,14 @@ CRITICAL INSTRUCTIONS:
 - Edges only allowed to connect nodes of type='feature' that have the same parent (siblings), that have the same grandparent (grandchildren), or where one feature's parent is the grandparent of the other (child-grandchild), or edges of type='shortcut'.
 - Edges of type 'shortcut' are exempt from these hierarchy restrictions but still must connect feature nodes.
 - When you add intermediate feature nodes to satisfy hierarchy rules, ALWAYS assign to them the same status as their parent node. Any edges created to replace a prior connection should keep that connection's status unless explicitly updated.
-- If the narrative suggests that a generic feature node (e.g., "Dark Alcove") has become more specific (e.g., "Shrine of Eldras"), UPDATE the existing feature node's "placeName" (if name changed via newData.placeName) and "details" via "nodesToUpdate", rather than adding a new node.
+  - If the narrative suggests that a generic feature node (e.g., "Dark Alcove") has become more specific (e.g., "Shrine of Eldras"), UPDATE the existing feature node's "placeName" (if name changed via newPlaceName) and "details" via "nodesToUpdate", rather than adding a new node.
 - If any new specific places (feature nodes) within or between main locations are described, add them and specify their parent via 'parentNodeId'.
 - Try to assign a definitive parent node to any orphan nodes (Parent node: N/A).
 - Try to fix any illogical inconsistencies in the hierarchy, such as a feature node that has no parent, illogical child-parent relationships, or wrong level of hierarchy.
 - If connections (paths, doors, etc.) are revealed or changed, update edges.
 - If new details are revealed about a location (main or feature), update description and/or aliases.
 - If the Player's new 'localPlace' tells that they are at a specific feature node (existing or newly added), suggest it in 'suggestedCurrentMapNodeId'.
-- When renaming a node using "nodesToUpdate", omit any matching entry in "nodesToRemove" for that node.
+  - When renaming a node using "nodesToUpdate" (via the "newPlaceName" field), omit any matching entry in "nodesToRemove" for that node.
 - Feature Nodes can have any number of edges.
 - CRITICALLY IMPORTANT: Delete Nodes ONLY in EXTREME CASES when the Scene unambiguously implies that they will no longer ever be relevant to the Player.
 - CRITICALLY IMPORTANT: Delete edges ONLY in EXTREME CASES when the Scene description mentions an absolutely certain destruction of the path. In all  other cases, avoid deleting edges and nodes.


### PR DESCRIPTION
## Summary
- flatten cartographer request schema objects
- adjust instructions for cartographer prompt accordingly

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884bd0eeba083248048f26c715e456e