### PR TITLE
Fix validation after cartographer schema update

### DIFF
--- a/services/cartographer/mapUpdateValidation.ts
+++ b/services/cartographer/mapUpdateValidation.ts
@@ -2,190 +2,218 @@
  * @file mapUpdateValidation.ts
  * @description Utilities for validating the AIMapUpdatePayload structure from the map update AI.
  */
-import { AIMapUpdatePayload, MapNodeData, MapEdgeData } from '../../types'; // AINodeUpdate is implicitly part of AIMapUpdatePayload
+import {
+  AIMapUpdatePayload,
+  AINodeAdd,
+  AINodeUpdate,
+  AIEdgeAdd,
+  AIEdgeUpdate,
+  MapNodeData,
+  MapEdgeData,
+} from '../../types';
 import {
   VALID_NODE_STATUS_VALUES,
   VALID_NODE_TYPE_VALUES,
-  VALID_EDGE_TYPE_VALUES,
   VALID_EDGE_STATUS_VALUES,
+  VALID_EDGE_TYPE_VALUES,
 } from '../../constants';
 
-/**
- * Validates a MapNodeData object used in map update operations.
- * @param data - The value to validate.
- * @param isNodeAddContext - Whether the validation is for a node addition.
- */
-function isValidAINodeDataInternal(data: unknown, isNodeAddContext: boolean): boolean {
-  if (typeof data !== 'object' || data === null) {
-    console.warn("Validation Error (NodeData): Data is not an object. Value:", data);
+function isValidAINodeAdd(op: unknown): op is AINodeAdd {
+  if (typeof op !== 'object' || op === null) return false;
+  const n = op as Record<string, unknown>;
+  if (typeof n.placeName !== 'string' || n.placeName.trim() === '') {
+    console.warn("Validation Error (NodeAdd): 'placeName' is required. Value:", n.placeName);
     return false;
   }
-  const node = data as Record<string, unknown>;
-
-  // Status: Required for Add, Optional for Update. Must be valid if present.
-  if (isNodeAddContext) {
-    if (typeof node.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(node.status as MapNodeData['status'])) {
-      console.warn("Validation Error (NodeData - Add): 'status' is mandatory and invalid. Value:", node.status, "Valid are:", VALID_NODE_STATUS_VALUES);
-      return false;
-    }
-  } else { // Update context
-    if (node.status !== undefined && (typeof node.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(node.status as MapNodeData['status']))) {
-      console.warn("Validation Error (NodeData - Update): Invalid 'status'. Value:", node.status);
-      return false;
-    }
-  }
-
-  // Description: Required for Add (non-empty string), Optional for Update (string if present).
-  if (isNodeAddContext) {
-    if (typeof node.description !== 'string' || node.description.trim() === '') {
-      console.warn("Validation Error (NodeData - Add): 'description' is mandatory and must be a non-empty string. Value:", node.description);
-      return false;
-    }
-  } else { // Update context
-    if (node.description !== undefined && typeof node.description !== 'string') {
-      console.warn("Validation Error (NodeData - Update): 'description' if present must be a string. Value:", node.description);
-      return false;
-    }
-  }
-
-  // Aliases: Required for Add (array of strings, can be empty), Optional for Update (array of strings if present).
-  if (isNodeAddContext) {
-    if (!Array.isArray(node.aliases) || !node.aliases.every(a => typeof a === 'string')) {
-      console.warn("Validation Error (NodeData - Add): 'aliases' is mandatory and must be an array of strings (can be empty []). Value:", node.aliases);
-      return false;
-    }
-  } else { // Update context
-    if (node.aliases !== undefined && !(Array.isArray(node.aliases) && node.aliases.every(a => typeof a === 'string'))) {
-      console.warn("Validation Error (NodeData - Update): 'aliases' if present must be an array of strings. Value:", node.aliases);
-      return false;
-    }
-  }
-  
-
-  if (isNodeAddContext) {
-    if (typeof node.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(node.nodeType as NonNullable<MapNodeData['nodeType']>)) {
-      console.warn("Validation Error (NodeData - Add): 'nodeType' is mandatory and invalid. Value:", node.nodeType, "Valid are:", VALID_NODE_TYPE_VALUES);
-      return false;
-    }
-  } else {
-    if (node.nodeType !== undefined && (typeof node.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(node.nodeType as NonNullable<MapNodeData['nodeType']>))) {
-      console.warn("Validation Error (NodeData - Update): 'nodeType' is invalid. Value:", node.nodeType);
-      return false;
-    }
-  }
-
-  // parentNodeId: Required for Add, Optional for Update
-  if (isNodeAddContext) {
-    if (
-      typeof node.parentNodeId !== 'string' ||
-      node.parentNodeId.trim() === ''
-    ) {
-      console.warn(
-        "Validation Error (NodeData - Add): 'parentNodeId' is mandatory and must be a non-empty string. Value:",
-        node.parentNodeId
-      );
-      return false;
-    }
-  } else {
-    if (
-      node.parentNodeId !== undefined &&
-      node.parentNodeId !== null &&
-      (typeof node.parentNodeId !== 'string' || node.parentNodeId.trim() === '')
-    ) {
-      console.warn(
-        "Validation Error (NodeData - Update): 'parentNodeId' must be a non-empty string or null if present. Value:",
-        node.parentNodeId
-      );
-      return false;
-    }
-  }
-  
-  return true;
-}
-
-
-/**
- * Validates a MapEdgeData object used in map update operations.
- * @param data - The value to validate.
- * @param isEdgeAddContext - Whether the validation is for adding a new edge.
- */
-function isValidAIEdgeDataInternal(data: unknown, isEdgeAddContext: boolean): boolean {
-  if (typeof data !== 'object' || data === null) return false;
-  const edge = data as Record<string, unknown>;
-  
-  if (isEdgeAddContext) { // Type and status are required for new edges
-    if (typeof edge.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(edge.type as NonNullable<MapEdgeData['type']>)) {
-      console.warn("Validation Error (EdgeData - Add): 'type' is required and invalid. Value:", edge.type, "Valid are:", VALID_EDGE_TYPE_VALUES);
-      return false;
-    }
-    if (typeof edge.status !== 'string' || !VALID_EDGE_STATUS_VALUES.includes(edge.status as NonNullable<MapEdgeData['status']>)) {
-      console.warn("Validation Error (EdgeData - Add): 'status' is required and invalid. Value:", edge.status, "Valid are:", VALID_EDGE_STATUS_VALUES);
-      return false;
-    }
-  } else { // For updates, type and status are optional
-    if (edge.type !== undefined && (typeof edge.type !== 'string' || !VALID_EDGE_TYPE_VALUES.includes(edge.type as NonNullable<MapEdgeData['type']>))) {
-        console.warn("Validation Error (EdgeData - Update): Invalid 'type'. Value:", edge.type, "Valid are:", VALID_EDGE_TYPE_VALUES);
-        return false;
-    }
-    if (edge.status !== undefined && (typeof edge.status !== 'string' || !VALID_EDGE_STATUS_VALUES.includes(edge.status as NonNullable<MapEdgeData['status']>))) {
-        console.warn("Validation Error (EdgeData - Update): Invalid 'status'. Value:", edge.status, "Valid are:", VALID_EDGE_STATUS_VALUES);
-        return false;
-    }
-  }
-
-  if (edge.description !== undefined && typeof edge.description !== 'string') {
-    console.warn("Validation Error (EdgeData): Invalid 'description'. Value:", edge.description);
+  if (!Array.isArray(n.aliases) || !n.aliases.every(a => typeof a === 'string')) {
+    console.warn("Validation Error (NodeAdd): 'aliases' must be an array of strings. Value:", n.aliases);
     return false;
   }
-  if (edge.travelTime !== undefined && typeof edge.travelTime !== 'string') {
-    console.warn("Validation Error (EdgeData): Invalid 'travelTime'. Value:", edge.travelTime);
+  if (typeof n.description !== 'string' || n.description.trim() === '') {
+    console.warn("Validation Error (NodeAdd): 'description' is required and must be a non-empty string. Value:", n.description);
+    return false;
+  }
+  if (typeof n.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(n.nodeType as MapNodeData['nodeType'])) {
+    console.warn("Validation Error (NodeAdd): 'nodeType' is invalid. Value:", n.nodeType);
+    return false;
+  }
+  if (typeof n.parentNodeId !== 'string' || n.parentNodeId.trim() === '') {
+    console.warn("Validation Error (NodeAdd): 'parentNodeId' is required. Value:", n.parentNodeId);
+    return false;
+  }
+  if (typeof n.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(n.status as MapNodeData['status'])) {
+    console.warn("Validation Error (NodeAdd): 'status' is invalid. Value:", n.status);
     return false;
   }
   return true;
 }
 
-/**
- * Validates a node add/update operation object.
- * @param nodeOp - The node operation data.
- * @param isNodeAddOperation - Whether this validation is for adding a node.
- */
-function isValidAINodeOperationInternal(nodeOp: unknown, isNodeAddOperation: boolean): boolean {
-  if (typeof nodeOp !== 'object' || nodeOp === null) return false;
-  const op = nodeOp as Record<string, unknown>;
-  if (typeof op.placeName !== 'string' || op.placeName.trim() === '') {
-    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): 'placeName' is required. Value:`, op.placeName);
+function isValidAINodeUpdate(op: unknown): op is AINodeUpdate {
+  if (typeof op !== 'object' || op === null) return false;
+  const n = op as Record<string, unknown>;
+  if (typeof n.placeName !== 'string' || n.placeName.trim() === '') {
+    console.warn("Validation Error (NodeUpdate): 'placeName' is required. Value:", n.placeName);
     return false;
   }
-
-  const dataFieldKey = isNodeAddOperation ? 'data' : 'newData';
-  const dataField = op[dataFieldKey];
-
-  if (typeof dataField !== 'object' || dataField === null) {
-    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): '${dataFieldKey}' field is required. Value:`, dataField);
+  if (n.aliases !== undefined && !(Array.isArray(n.aliases) && n.aliases.every(a => typeof a === 'string'))) {
+    console.warn("Validation Error (NodeUpdate): 'aliases' must be an array of strings if provided. Value:", n.aliases);
     return false;
   }
-
-  if (!isValidAINodeDataInternal(dataField, isNodeAddOperation)) {
-    console.warn(`Validation Error (Node${isNodeAddOperation ? 'Add' : 'Update'}): Invalid '${dataFieldKey}' for placeName "${op.placeName}". Details above.`);
+  if (n.description !== undefined && typeof n.description !== 'string') {
+    console.warn("Validation Error (NodeUpdate): 'description' must be a string if provided. Value:", n.description);
     return false;
   }
-
-  if (isNodeAddOperation && op.initialPosition !== undefined) {
-    const pos = op.initialPosition as Record<string, unknown>;
-    if (typeof pos.x !== 'number' || typeof pos.y !== 'number') {
-      console.warn(
-        "Validation Error (NodeAdd): 'initialPosition' must be {x: number, y: number}. Value:",
-        op.initialPosition,
-      );
-      return false;
-    }
+  if (n.nodeType !== undefined && (typeof n.nodeType !== 'string' || !VALID_NODE_TYPE_VALUES.includes(n.nodeType as MapNodeData['nodeType']))) {
+    console.warn("Validation Error (NodeUpdate): 'nodeType' is invalid. Value:", n.nodeType);
+    return false;
+  }
+  if (n.parentNodeId !== undefined && typeof n.parentNodeId !== 'string') {
+    console.warn("Validation Error (NodeUpdate): 'parentNodeId' must be a string if provided. Value:", n.parentNodeId);
+    return false;
+  }
+  if (n.status !== undefined && (typeof n.status !== 'string' || !VALID_NODE_STATUS_VALUES.includes(n.status as MapNodeData['status']))) {
+    console.warn("Validation Error (NodeUpdate): 'status' is invalid. Value:", n.status);
+    return false;
+  }
+  if (n.newPlaceName !== undefined && (typeof n.newPlaceName !== 'string' || n.newPlaceName.trim() === '')) {
+    console.warn("Validation Error (NodeUpdate): 'newPlaceName' must be a non-empty string if provided. Value:", n.newPlaceName);
+    return false;
   }
   return true;
 }
 
-/**
- * Validates a node removal operation object.
- */
+function isValidAIEdgeAdd(op: unknown): op is AIEdgeAdd {
+  if (typeof op !== 'object' || op === null) return false;
+  const e = op as Record<string, unknown>;
+  if (typeof e.sourcePlaceName !== 'string' || e.sourcePlaceName.trim() === '') {
+    console.warn("Validation Error (EdgeAdd): 'sourcePlaceName' is required. Value:", e.sourcePlaceName);
+    return false;
+  }
+  if (typeof e.targetPlaceName !== 'string' || e.targetPlaceName.trim() === '') {
+    console.warn("Validation Error (EdgeAdd): 'targetPlaceName' is required. Value:", e.targetPlaceName);
+    return false;
+  }
+  if (typeof e.type !== 'string') {
+    console.warn("Validation Error (EdgeAdd): 'type' is invalid. Value:", e.type);
+    return false;
+  }
+  const edgeType = e.type as MapEdgeData['type'];
+  if (!VALID_EDGE_TYPE_VALUES.includes(edgeType as unknown as string)) {
+    console.warn("Validation Error (EdgeAdd): 'type' is invalid. Value:", e.type);
+    return false;
+  }
+  if (typeof e.status !== 'string') {
+    console.warn("Validation Error (EdgeAdd): 'status' is invalid. Value:", e.status);
+    return false;
+  }
+  const edgeStatus = e.status as MapEdgeData['status'];
+  if (!VALID_EDGE_STATUS_VALUES.includes(edgeStatus as unknown as string)) {
+    console.warn("Validation Error (EdgeAdd): 'status' is invalid. Value:", e.status);
+    return false;
+  }
+  if (e.description !== undefined && typeof e.description !== 'string') {
+    console.warn("Validation Error (EdgeAdd): 'description' must be a string if provided. Value:", e.description);
+    return false;
+  }
+  if (e.travelTime !== undefined && typeof e.travelTime !== 'string') {
+    console.warn("Validation Error (EdgeAdd): 'travelTime' must be a string if provided. Value:", e.travelTime);
+    return false;
+  }
+  return true;
+}
+
+function isValidAIEdgeUpdate(op: unknown): op is AIEdgeUpdate {
+  if (typeof op !== 'object' || op === null) return false;
+  const e = op as Record<string, unknown>;
+  if (typeof e.sourcePlaceName !== 'string' || e.sourcePlaceName.trim() === '') {
+    console.warn("Validation Error (EdgeUpdate): 'sourcePlaceName' is required. Value:", e.sourcePlaceName);
+    return false;
+  }
+  if (typeof e.targetPlaceName !== 'string' || e.targetPlaceName.trim() === '') {
+    console.warn("Validation Error (EdgeUpdate): 'targetPlaceName' is required. Value:", e.targetPlaceName);
+    return false;
+  }
+  if (e.type !== undefined) {
+    if (typeof e.type !== 'string') {
+      console.warn("Validation Error (EdgeUpdate): 'type' is invalid. Value:", e.type);
+      return false;
+    }
+    const updEdgeType = e.type as MapEdgeData['type'];
+    if (!VALID_EDGE_TYPE_VALUES.includes(updEdgeType as unknown as string)) {
+      console.warn("Validation Error (EdgeUpdate): 'type' is invalid. Value:", e.type);
+      return false;
+    }
+  }
+  if (e.status !== undefined) {
+    if (typeof e.status !== 'string') {
+      console.warn("Validation Error (EdgeUpdate): 'status' is invalid. Value:", e.status);
+      return false;
+    }
+    const updEdgeStatus = e.status as MapEdgeData['status'];
+    if (!VALID_EDGE_STATUS_VALUES.includes(updEdgeStatus as unknown as string)) {
+      console.warn("Validation Error (EdgeUpdate): 'status' is invalid. Value:", e.status);
+      return false;
+    }
+  }
+  if (e.description !== undefined && typeof e.description !== 'string') {
+    console.warn("Validation Error (EdgeUpdate): 'description' must be a string if provided. Value:", e.description);
+    return false;
+  }
+  if (e.travelTime !== undefined && typeof e.travelTime !== 'string') {
+    console.warn("Validation Error (EdgeUpdate): 'travelTime' must be a string if provided. Value:", e.travelTime);
+    return false;
+  }
+  return true;
+}
+
+export function isValidAIMapUpdatePayload(payload: AIMapUpdatePayload | null): payload is AIMapUpdatePayload {
+  if (typeof payload !== 'object' || payload === null) {
+    console.warn('Validation Error (AIMapUpdatePayload): Payload is not an object or is null.');
+    return false;
+  }
+  if (payload.nodesToAdd != null) {
+    if (!Array.isArray(payload.nodesToAdd) || !payload.nodesToAdd.every(isValidAINodeAdd)) {
+      console.warn("Validation Error (AIMapUpdatePayload): 'nodesToAdd' is invalid.");
+      return false;
+    }
+  }
+  if (payload.nodesToUpdate != null) {
+    if (!Array.isArray(payload.nodesToUpdate) || !payload.nodesToUpdate.every(isValidAINodeUpdate)) {
+      console.warn("Validation Error (AIMapUpdatePayload): 'nodesToUpdate' is invalid.");
+      return false;
+    }
+  }
+  if (payload.nodesToRemove != null) {
+    if (!Array.isArray(payload.nodesToRemove) || !payload.nodesToRemove.every(isValidAINodeRemovalInternal)) {
+      console.warn("Validation Error (AIMapUpdatePayload): 'nodesToRemove' is invalid.");
+      return false;
+    }
+  }
+  if (payload.edgesToAdd != null) {
+    if (!Array.isArray(payload.edgesToAdd) || !payload.edgesToAdd.every(isValidAIEdgeAdd)) {
+      console.warn("Validation Error (AIMapUpdatePayload): 'edgesToAdd' is invalid.");
+      return false;
+    }
+  }
+  if (payload.edgesToUpdate != null) {
+    if (!Array.isArray(payload.edgesToUpdate) || !payload.edgesToUpdate.every(isValidAIEdgeUpdate)) {
+      console.warn("Validation Error (AIMapUpdatePayload): 'edgesToUpdate' is invalid.");
+      return false;
+    }
+  }
+  if (payload.edgesToRemove != null) {
+    if (!Array.isArray(payload.edgesToRemove) || !payload.edgesToRemove.every(isValidAIEdgeRemovalInternal)) {
+      console.warn("Validation Error (AIMapUpdatePayload): 'edgesToRemove' is invalid.");
+      return false;
+    }
+  }
+  if (payload.suggestedCurrentMapNodeId != null && typeof payload.suggestedCurrentMapNodeId !== 'string') {
+    console.warn("Validation Error (AIMapUpdatePayload): 'suggestedCurrentMapNodeId' must be a string or null if present. Value:", payload.suggestedCurrentMapNodeId);
+    return false;
+  }
+  return true;
+}
+
 function isValidAINodeRemovalInternal(nodeRemove: unknown): boolean {
   if (typeof nodeRemove !== 'object' || nodeRemove === null) return false;
   const rem = nodeRemove as Record<string, unknown>;
@@ -200,39 +228,6 @@ function isValidAINodeRemovalInternal(nodeRemove: unknown): boolean {
   return true;
 }
 
-/**
- * Validates an edge add/update operation object.
- * @param edgeOp - The edge operation data.
- * @param isEdgeAddOperation - Whether this validation is for adding an edge.
- */
-function isValidAIEdgeOperationInternal(edgeOp: unknown, isEdgeAddOperation: boolean): boolean {
-  if (typeof edgeOp !== 'object' || edgeOp === null) return false;
-  const op = edgeOp as Record<string, unknown>;
-  if (typeof op.sourcePlaceName !== 'string' || op.sourcePlaceName.trim() === '') {
-    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): 'sourcePlaceName' is required. Value:`, op.sourcePlaceName);
-    return false;
-  }
-  if (typeof op.targetPlaceName !== 'string' || op.targetPlaceName.trim() === '') {
-    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): 'targetPlaceName' is required. Value:`, op.targetPlaceName);
-    return false;
-  }
-
-  const dataFieldKey = isEdgeAddOperation ? 'data' : 'newData';
-  const dataField = op[dataFieldKey];
-  if (typeof dataField !== 'object' || dataField === null) {
-     console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): '${dataFieldKey}' field is required. Value:`, dataField);
-    return false;
-  }
-  if (!isValidAIEdgeDataInternal(dataField, isEdgeAddOperation)) {
-    console.warn(`Validation Error (Edge${isEdgeAddOperation ? 'Add' : 'Update'}): Invalid '${dataFieldKey}' for edge between "${op.sourcePlaceName}" and "${op.targetPlaceName}".`);
-    return false;
-  }
-  return true;
-}
-
-/**
- * Validates an edge removal operation object.
- */
 function isValidAIEdgeRemovalInternal(edgeRemove: unknown): boolean {
   if (typeof edgeRemove !== 'object' || edgeRemove === null) return false;
   const rem = edgeRemove as Record<string, unknown>;
@@ -246,55 +241,6 @@ function isValidAIEdgeRemovalInternal(edgeRemove: unknown): boolean {
   }
   if (rem.targetId !== undefined && (typeof rem.targetId !== 'string' || rem.targetId.trim() === '')) {
     console.warn("Validation Error (EdgeRemove): 'targetId' must be a non-empty string if provided. Value:", rem.targetId);
-    return false;
-  }
-  return true;
-}
-
-
-/**
- * Validates a full AIMapUpdatePayload object received from the map AI service.
- * @param payload - The parsed payload to validate.
- * @returns True if the payload conforms to expected structure.
- */
-export function isValidAIMapUpdatePayload(payload: AIMapUpdatePayload | null): payload is AIMapUpdatePayload {
-  if (typeof payload !== 'object' || payload === null) {
-    console.warn("Validation Error (AIMapUpdatePayload): Payload is not an object or is null.");
-    return false;
-  }
-
-  if (payload.nodesToAdd != null) {
-    if (!Array.isArray(payload.nodesToAdd) || !payload.nodesToAdd.every((n: unknown) => isValidAINodeOperationInternal(n, true))) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'nodesToAdd' is invalid."); return false;
-    }
-  }
-  if (payload.nodesToUpdate != null) {
-    if (!Array.isArray(payload.nodesToUpdate) || !payload.nodesToUpdate.every((n: unknown) => isValidAINodeOperationInternal(n, false))) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'nodesToUpdate' is invalid."); return false;
-    }
-  }
-  if (payload.nodesToRemove != null) {
-    if (!Array.isArray(payload.nodesToRemove) || !payload.nodesToRemove.every(isValidAINodeRemovalInternal)) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'nodesToRemove' is invalid."); return false;
-    }
-  }
-  if (payload.edgesToAdd != null) {
-    if (!Array.isArray(payload.edgesToAdd) || !payload.edgesToAdd.every((e: unknown) => isValidAIEdgeOperationInternal(e, true))) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'edgesToAdd' is invalid."); return false;
-    }
-  }
-  if (payload.edgesToUpdate != null) {
-    if (!Array.isArray(payload.edgesToUpdate) || !payload.edgesToUpdate.every((e: unknown) => isValidAIEdgeOperationInternal(e, false))) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'edgesToUpdate' is invalid."); return false;
-    }
-  }
-  if (payload.edgesToRemove != null) {
-    if (!Array.isArray(payload.edgesToRemove) || !payload.edgesToRemove.every(isValidAIEdgeRemovalInternal)) {
-      console.warn("Validation Error (AIMapUpdatePayload): 'edgesToRemove' is invalid."); return false;
-    }
-  }
-  if (payload.suggestedCurrentMapNodeId != null && typeof payload.suggestedCurrentMapNodeId !== 'string') {
-    console.warn("Validation Error (AIMapUpdatePayload): 'suggestedCurrentMapNodeId' must be a string or null if present. Value:", payload.suggestedCurrentMapNodeId);
     return false;
   }
   return true;

--- a/services/cartographer/processNodeAdds.ts
+++ b/services/cartographer/processNodeAdds.ts
@@ -47,8 +47,9 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
   for (const e of context.edgesToAdd_mut) {
     const src = e.sourcePlaceName.toLowerCase();
     const tgt = e.targetPlaceName.toLowerCase();
-    const type = e.data.type ?? 'path';
-    const key = src < tgt ? `${src}|${tgt}|${type}` : `${tgt}|${src}|${type}`;
+    const type = e.type;
+    const typeStr = String(type);
+    const key = src < tgt ? `${src}|${tgt}|${typeStr}` : `${tgt}|${src}|${typeStr}`;
     if (!edgeKeySet.has(key)) {
       edgeKeySet.add(key);
       dedupedEdges.push(e);
@@ -72,7 +73,7 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
 
   (context.payload.nodesToUpdate ?? []).forEach(upd => {
     const updNames = [upd.placeName.toLowerCase()];
-    if (upd.newData.placeName) updNames.push(upd.newData.placeName.toLowerCase());
+    if (upd.newPlaceName) updNames.push(upd.newPlaceName.toLowerCase());
     for (const name of updNames) {
       const idx = context.nodesToRemove_mut.findIndex(
         r => r.nodeName && r.nodeName.toLowerCase() === name
@@ -89,18 +90,18 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
     for (const nodeAddOp of unresolvedQueue) {
       let resolvedParentId: string | undefined = undefined;
       let sameTypeParent: MapNode | null = null;
-      if (nodeAddOp.data.parentNodeId) {
-        if (nodeAddOp.data.parentNodeId === 'Universe') {
+      if (nodeAddOp.parentNodeId) {
+        if (nodeAddOp.parentNodeId === 'Universe') {
           resolvedParentId = undefined;
         } else {
           const parent = findMapNodeByIdentifier(
-            nodeAddOp.data.parentNodeId,
+            nodeAddOp.parentNodeId,
             context.newMapData.nodes,
             context.newMapData,
             context.referenceMapNodeId,
           ) as MapNode | undefined;
           if (parent) {
-            let childType = nodeAddOp.data.nodeType ?? 'feature';
+            let childType = nodeAddOp.nodeType;
             if (parent.data.nodeType === childType) {
               const downgraded = suggestNodeTypeDowngrade(
                 {
@@ -109,9 +110,9 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
                   placeName: nodeAddOp.placeName,
                   position: { x: 0, y: 0 },
                   data: {
-                    description: nodeAddOp.data.description ?? '',
-                    aliases: nodeAddOp.data.aliases ?? [],
-                    status: nodeAddOp.data.status,
+                    description: nodeAddOp.description,
+                    aliases: nodeAddOp.aliases,
+                    status: nodeAddOp.status,
                     parentNodeId: parent.id,
                     nodeType: childType,
                   },
@@ -120,7 +121,7 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
                 context.newMapData.nodes,
               );
               if (downgraded) {
-                nodeAddOp.data.nodeType = downgraded;
+                nodeAddOp.nodeType = downgraded;
                 childType = downgraded;
                 resolvedParentId = parent.id;
               } else {
@@ -156,23 +157,16 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
         ((resolvedParentId === undefined && !existingNode.data.parentNodeId) ||
           existingNode.data.parentNodeId === resolvedParentId) &&
         (existingNode.placeName.toLowerCase() === nodeAddOp.placeName.toLowerCase() ||
-          (existingNode.data.aliases?.some(a => a.toLowerCase() === nodeAddOp.placeName.toLowerCase()) ??
-            false) ||
-          (nodeAddOp.data.aliases?.some(a => a.toLowerCase() === existingNode.placeName.toLowerCase()) ??
-            false));
+          (existingNode.data.aliases?.some(a => a.toLowerCase() === nodeAddOp.placeName.toLowerCase()) ?? false) ||
+          nodeAddOp.aliases.some(a => a.toLowerCase() === existingNode.placeName.toLowerCase()));
 
       if (canReuseExisting) {
         const existing = existingNode;
-        if (nodeAddOp.data.aliases) {
-          const aliasSet = new Set([...(existing.data.aliases ?? [])]);
-          nodeAddOp.data.aliases.forEach(a => aliasSet.add(a));
-          existing.data.aliases = Array.from(aliasSet);
-        }
-        if (
-          nodeAddOp.data.description &&
-          existing.data.description.trim().length === 0
-        ) {
-          existing.data.description = nodeAddOp.data.description;
+        const aliasSet = new Set([...(existing.data.aliases ?? [])]);
+        nodeAddOp.aliases.forEach(a => aliasSet.add(a));
+        existing.data.aliases = Array.from(aliasSet);
+        if (nodeAddOp.description && existing.data.description.trim().length === 0) {
+          existing.data.description = nodeAddOp.description;
         }
         Reflect.deleteProperty(
           context.newNodesInBatchIdNameMap,
@@ -185,17 +179,15 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
         string | undefined;
       const newNodeId = preId ?? buildNodeId(nodeAddOp.placeName);
 
-      const { description, aliases, parentNodeId: _ignoredParent, status, nodeType, visited: _ignoredVisited, ...rest } =
-        nodeAddOp.data;
-      void _ignoredParent;
-      void _ignoredVisited;
+      const { description, aliases, status, nodeType, parentNodeId: _unused, ...rest } = nodeAddOp;
+      void _unused;
 
       const newNodeData: MapNodeData = {
-        description: description ?? '',
-        aliases: aliases ?? [],
+        description,
+        aliases,
         status,
         parentNodeId: resolvedParentId,
-        nodeType: nodeType ?? 'feature',
+        nodeType,
         ...rest,
       };
 
@@ -203,7 +195,7 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
         id: newNodeId,
         themeName: context.currentTheme.name,
         placeName: nodeAddOp.placeName,
-        position: nodeAddOp.initialPosition ?? { x: 0, y: 0 },
+        position: { x: 0, y: 0 },
         data: newNodeData,
       };
 
@@ -239,10 +231,10 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
           const guessed = await fetchLikelyParentNode_Service(
             {
               placeName: unresolved.placeName,
-              description: unresolved.data.description,
-              nodeType: unresolved.data.nodeType,
-              status: unresolved.data.status,
-              aliases: unresolved.data.aliases,
+              description: unresolved.description,
+              nodeType: unresolved.nodeType,
+              status: unresolved.status,
+              aliases: unresolved.aliases,
             },
             {
               sceneDescription: context.sceneDesc,
@@ -255,7 +247,7 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
             },
             context.minimalModelCalls
           );
-          unresolved.data.parentNodeId = guessed ?? 'Universe';
+          unresolved.parentNodeId = guessed ?? 'Universe';
         }
         triedParentInference = true;
         unresolvedQueue = nextQueue;

--- a/tests/applyUpdatesPartialId.test.ts
+++ b/tests/applyUpdatesPartialId.test.ts
@@ -45,30 +45,28 @@ const payload: AIMapUpdatePayload = {
   nodesToAdd: [
     {
       placeName: 'Side Tunnel',
-      data: {
-        description: '',
-        aliases: [],
-        status: 'rumored',
-        parentNodeId: 'Universe',
-        nodeType: 'location',
-      },
+      description: '',
+      aliases: [],
+      status: 'rumored',
+      parentNodeId: 'Universe',
+      nodeType: 'location',
     },
     {
       placeName: 'Hidden Door',
-      data: {
-        description: '',
-        aliases: [],
-        status: 'rumored',
-        parentNodeId: 'node_side_tunnel_fake',
-        nodeType: 'feature',
-      },
+      description: '',
+      aliases: [],
+      status: 'rumored',
+      parentNodeId: 'node_side_tunnel_fake',
+      nodeType: 'feature',
     },
   ],
   edgesToAdd: [
     {
       sourcePlaceName: existingFeature.id,
       targetPlaceName: 'node_hidden_door_fake',
-      data: { type: 'path', status: 'rumored', description: '' },
+      type: 'path',
+      status: 'rumored',
+      description: '',
     },
   ],
 };

--- a/types.ts
+++ b/types.ts
@@ -471,16 +471,36 @@ export interface MapData {
 // --- End Map Data Structures ---
 
 // --- Map Update Service Payload ---
-export interface AIEdgeUpdate { 
-  sourcePlaceName: string; 
-  targetPlaceName: string; 
-  newData: MapEdge['data']; 
+export interface AIEdgeUpdate {
+  sourcePlaceName: string;
+  targetPlaceName: string;
+  description?: string;
+  status?: MapEdgeData['status'];
+  travelTime?: string;
+  type?: MapEdgeData['type'];
+}
+
+export interface AIEdgeAdd extends AIEdgeUpdate {
+  status: MapEdgeData['status'];
+  type: MapEdgeData['type'];
 }
 
 export interface AINodeUpdate {
-  placeName: string; // User-facing name to identify the node for update or to set for a new node.
-  data: Partial<MapNodeData> & { description?: string }; // 'description' mainly provided for feature-level nodes.
-  initialPosition?: { x: number; y: number };
+  placeName: string; // Existing node ID or name to identify it.
+  aliases?: Array<string>;
+  description?: string;
+  nodeType?: MapNodeData['nodeType'];
+  parentNodeId?: string;
+  status?: MapNodeData['status'];
+  newPlaceName?: string;
+}
+
+export interface AINodeAdd extends AINodeUpdate {
+  aliases: Array<string>;
+  description: string;
+  nodeType: MapNodeData['nodeType'];
+  parentNodeId: string;
+  status: MapNodeData['status'];
 }
 
 export interface AIMapUpdatePayload {
@@ -489,15 +509,10 @@ export interface AIMapUpdatePayload {
   // Description and aliases are required for all new nodes.
   observations?: string | null;
   rationale?: string | null;
-  nodesToAdd?: Array<AINodeUpdate & {
-    data: {
-      status: MapNodeData['status'];
-      parentNodeId: string;
-    } & Partial<Omit<MapNodeData, 'status' | 'parentNodeId'>>;
-  }> | null;
-  nodesToUpdate?: Array<{ placeName: string; newData: Partial<MapNodeData> & { placeName?: string }; }> | null; // Added placeName to newData for renaming
+  nodesToAdd?: Array<AINodeAdd> | null;
+  nodesToUpdate?: Array<AINodeUpdate> | null;
   nodesToRemove?: Array<{ nodeId: string; nodeName?: string; }> | null;
-  edgesToAdd?: Array<{ sourcePlaceName: string; targetPlaceName: string; data: MapEdge['data']; }> | null;
+  edgesToAdd?: Array<AIEdgeAdd> | null;
   edgesToUpdate?: Array<AIEdgeUpdate> | null;
   edgesToRemove?: Array<{ edgeId: string; sourceId?: string; targetId?: string; }> | null;
   suggestedCurrentMapNodeId?: string | null | undefined;


### PR DESCRIPTION
## Summary
- update node and edge validation after schema update
- ensure processNodeAdds handles required fields without defaults
- clean up parent node update logic and connector refinement

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884c46fe7b48324bb392e432ee8c17d