### PR TITLE
Fix repeated Loremaster integrations

### DIFF
--- a/services/loremaster/promptBuilder.ts
+++ b/services/loremaster/promptBuilder.ts
@@ -48,7 +48,7 @@ export const buildIntegrateFactsPrompt = (
 ): string => {
   const existing =
     existingFacts
-      .map(f => `- ${f.text} [${f.entities.join(', ')}]`)
+      .map(f => `- ID ${String(f.id)}: ${f.text} [${f.entities.join(', ')}]`)
       .join('\n') || 'None.';
   const proposed =
     newFacts

--- a/services/loremaster/systemPrompt.ts
+++ b/services/loremaster/systemPrompt.ts
@@ -72,6 +72,7 @@ CRITICALLY IMPORTANT: DO NOT include bad quality and irrelevant facts.
 export const INTEGRATE_SYSTEM_INSTRUCTION = `You are the Loremaster maintaining up-to-date set of facts about the game world.
 1. Compare Recent Events and Known Facts, then change or delete any Known Facts that are obsolete and no longer in effect based on the story developments described in Recent Events.
 2. Compare Candidate Facts with existing Known Facts, then add good Known Facts that don't lead to overlaps and potential contradictions with Known Facts.
+Known Facts are listed with their numeric IDs. Use these IDs when specifying which fact to change or delete.
 
 ## Examples:
 "factsChange": [


### PR DESCRIPTION
## Summary
- include fact IDs in the integrate prompt
- clarify system prompt about using IDs

## Testing
- `npm run typecheck` *(fails: Argument of type 'string' is not assignable to parameter of type)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884d2759ed883248f8ab5b034ea1fee