### PR TITLE
Add narrative arc context

### DIFF
--- a/docs/worldGenPrompts.md
+++ b/docs/worldGenPrompts.md
@@ -88,13 +88,24 @@ const heroBackstory: HeroBackstory;
 
 *Data Stored*:
 ```ts
-interface ActInfo {
+interface StoryAct {
+  actNumber: number;
+  title: string;
   description: string;
-  mainQuest: string;
-  sideQuests: Array<string>;
+  mainObjective: string;
+  sideObjectives: Array<string>;
   successCondition: string;
 }
-const narrativeArc: Array<ActInfo>; // length 5
+
+interface StoryArc {
+  id: string;
+  title: string;
+  overview: string;
+  acts: Array<StoryAct>; // length 5
+  currentAct: number;
+  completed: boolean;
+}
+const narrativeArc: StoryArc;
 ```
 
 ## 7. Consolidated World Data
@@ -107,7 +118,7 @@ interface GameWorld {
   world: WorldFacts;
   hero: HeroSheet;
   backstory: HeroBackstory;
-  arc: Array<ActInfo>;
+  arc: StoryArc;
 }
 const gameWorld: GameWorld;
 ```

--- a/hooks/initPromptHelpers.ts
+++ b/hooks/initPromptHelpers.ts
@@ -11,6 +11,7 @@ import {
   WorldFacts,
   HeroSheet,
   HeroBackstory,
+  StoryArc,
 } from '../types';
 import { PLAYER_HOLDER_ID } from '../constants';
 import {
@@ -21,6 +22,7 @@ import {
 
 export interface BuildInitialGamePromptOptions {
   theme: AdventureTheme;
+  storyArc?: StoryArc | null;
   inventory: Array<Item>;
   playerGender: string;
   isTransitioningFromShift: boolean;
@@ -40,6 +42,7 @@ export const buildInitialGamePrompt = (
 ): string => {
   const {
     theme,
+    storyArc,
     inventory,
     playerGender,
     isTransitioningFromShift,
@@ -57,6 +60,7 @@ export const buildInitialGamePrompt = (
   if (isTransitioningFromShift && themeMemory && mapDataForTheme && npcsForTheme) {
     prompt = buildReturnToThemePostShiftPrompt(
       theme,
+      storyArc ?? null,
       inventoryForPrompt,
       playerGender,
       themeMemory,
@@ -66,12 +70,14 @@ export const buildInitialGamePrompt = (
   } else if (isTransitioningFromShift) {
     prompt = buildNewThemePostShiftPrompt(
       theme,
+      storyArc ?? null,
       inventoryForPrompt,
       playerGender,
     );
   } else {
     prompt = buildNewGameFirstTurnPrompt(
       theme,
+      storyArc ?? null,
       playerGender,
       worldFacts ?? {
         geography: '',

--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -146,6 +146,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
       dialogueParticipants: finalParticipants,
       themeName: currentThemeObj.name,
       currentThemeObject: currentThemeObj,
+      storyArc: workingGameState.storyArc,
     };
     const {
       parsed: summaryUpdatePayload,

--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -103,6 +103,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
         const relevantFacts = collectResult?.facts ?? [];
         const { parsed: turnData, prompt: turnPrompt, rawResponse, thoughts } = await executeDialogueTurn(
           currentThemeObj,
+          stateAfterPlayerChoice.storyArc,
           stateAfterPlayerChoice.mainQuest,
           stateAfterPlayerChoice.currentObjective,
           stateAfterPlayerChoice.currentScene,

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -271,7 +271,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         currentFullState.themeHistory,
         currentMapNodeDetails,
         currentFullState.mapData,
-        currentFullState.destinationNodeId
+        currentFullState.destinationNodeId,
+        currentFullState.storyArc
       );
 
       let draftState = structuredCloneGameState(currentFullState);

--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -2,7 +2,7 @@
  * @file api.ts
  * @description High level cartographer service functions.
  */
-import {
+import type {
   GameStateFromAI,
   AdventureTheme,
   MapData,
@@ -10,6 +10,7 @@ import {
   Item,
   NPC,
   MinimalModelCallRecord,
+  StoryArc,
 } from '../../types';
 import { CARTOGRAPHER_SYSTEM_INSTRUCTION as MAP_UPDATE_SYSTEM_INSTRUCTION } from './systemPrompt';
 import { buildMapUpdatePrompt } from './promptBuilder';
@@ -33,6 +34,7 @@ export const updateMapFromAIData_Service = async (
   previousMapNodeId: string | null,
   inventoryItems: Array<Item>,
   knownNPCs: Array<NPC>,
+  storyArc: StoryArc | null,
 ): Promise<MapUpdateServiceResult | null> => {
   if (!isApiConfigured()) {
     console.error('API Key not configured for Map Update Service.');
@@ -121,6 +123,7 @@ export const updateMapFromAIData_Service = async (
     allKnownMainPlacesString,
     itemNames,
     npcNames,
+    storyArc,
   );
 
   const { payload, debugInfo } = await fetchMapUpdatePayload(

--- a/services/cartographer/promptBuilder.ts
+++ b/services/cartographer/promptBuilder.ts
@@ -2,7 +2,7 @@
  * @file promptBuilder.ts
  * @description Utilities for constructing prompts for the cartographer AI.
  */
-import { AdventureTheme, MapData } from '../../types';
+import type { AdventureTheme, MapData, StoryArc } from '../../types';
 
 /**
  * Builds a simple map update prompt using the provided context.
@@ -34,9 +34,11 @@ export const buildMapUpdatePrompt = (
   allKnownMainPlaces: string,
   itemNames: Array<string>,
   npcNames: Array<string>,
+  storyArc?: StoryArc | null,
 ): string => `## Narrative Context for Map Update:
   - Current Theme: "${currentTheme.name}";
   - System Modifier for Theme: "${currentTheme.systemInstructionModifier}";
+${storyArc ? `  - Current Arc: "${storyArc.title}" (Act ${String(storyArc.currentAct)}: ${storyArc.acts[storyArc.currentAct - 1].title});\n` : ''}
   - Scene Description: "${sceneDesc}";
   - Log Message (outcome of last action): "${logMsg}";
   - Player's Current Location Description (localPlace): "${localPlace}".

--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -2,7 +2,7 @@
  * @file api.ts
  * @description Wrapper functions for dialogue-related AI interactions.
  */
-import {
+import type {
   DialogueAIResponse,
   DialogueHistoryEntry,
   DialogueSummaryContext,
@@ -12,6 +12,7 @@ import {
   MapNode,
   DialogueMemorySummaryContext,
   AdventureTheme,
+  StoryArc,
   HeroSheet,
 } from '../../types';
 import {
@@ -88,6 +89,7 @@ export const DIALOGUE_TURN_JSON_SCHEMA = {
  */
 export const executeDialogueTurn = async (
   currentTheme: AdventureTheme,
+  storyArc: StoryArc | null,
   currentQuest: string | null,
   currentObjective: string | null,
   currentScene: string,
@@ -122,6 +124,7 @@ export const executeDialogueTurn = async (
     inventory,
     playerGender,
     heroSheet,
+    storyArc,
     dialogueHistory,
     playerLastUtterance,
     dialogueParticipants,

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -10,7 +10,7 @@ import { MAIN_TURN_OPTIONS_COUNT, LOCAL_STORAGE_SAVE_KEY } from '../constants';
 import { saveGameStateToLocalStorage } from '../services/storage';
 import { getInitialGameStates } from '../utils/initialStates';
 import type { GenerateContentResponse } from '@google/genai';
-import type { WorldFacts, HeroSheet, HeroBackstory } from '../types';
+import type { WorldFacts, HeroSheet, HeroBackstory, StoryArc } from '../types';
 
 vi.mock('../services/storyteller/api', () => ({
   executeAIMainTurn: vi.fn(),
@@ -67,6 +67,24 @@ const dummyHeroBackstory: HeroBackstory = {
   now: 'Standing in the town square.',
 };
 
+const dummyArc: StoryArc = {
+  id: 'arc1',
+  title: 'Heroic Trials',
+  overview: 'A journey of hardship and triumph.',
+  acts: [
+    {
+      actNumber: 1,
+      title: 'Call to Adventure',
+      description: 'The hero faces the first challenge.',
+      mainObjective: 'Escape the cell.',
+      sideObjectives: ['Find equipment'],
+      successCondition: 'Reach freedom',
+    },
+  ],
+  currentAct: 1,
+  completed: false,
+};
+
 describe('game start sequence', () => {
   it('generates a valid initial scene', async () => {
     mockedExecute.mockResolvedValue({
@@ -80,6 +98,7 @@ describe('game start sequence', () => {
     const theme = FANTASY_AND_MYTH_THEMES[0];
     const prompt = buildNewGameFirstTurnPrompt(
       theme,
+      dummyArc,
       'Male',
       dummyWorldFacts,
       dummyHeroSheet,
@@ -144,6 +163,7 @@ describe('game start sequence', () => {
     const theme = FANTASY_AND_MYTH_THEMES[0];
     const prompt = buildNewGameFirstTurnPrompt(
       theme,
+      dummyArc,
       'Male',
       dummyWorldFacts,
       dummyHeroSheet,

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -74,6 +74,7 @@ const baseState: FullGameState = {
   worldFacts: null,
   heroSheet: null,
   heroBackstory: null,
+  storyArc: null,
   pendingNewThemeNameAfterShift: null,
   allNPCs: [],
   mapData: structuredCloneGameState(mapData),

--- a/types.ts
+++ b/types.ts
@@ -188,6 +188,7 @@ export interface DialogueTurnContext {
   currentQuest: string | null;
   currentObjective: string | null;
   currentScene: string;
+  storyArc?: StoryArc | null;
   localTime: string | null;
   localEnvironment: string | null;
   localPlace: string | null;
@@ -206,6 +207,7 @@ export interface DialogueSummaryContext {
   mainQuest: string | null;
   currentObjective: string | null;
   currentScene: string;
+  storyArc?: StoryArc | null;
   localTime: string | null;
   localEnvironment: string | null;
   localPlace: string | null; // The free-text local place string
@@ -224,6 +226,7 @@ export interface DialogueMemorySummaryContext {
   themeName: string; // Retained for direct theme name access if needed
   currentThemeObject: AdventureTheme | null; // Added for full theme object access
   currentScene: string; // Scene at the START of the dialogue
+  storyArc?: StoryArc | null;
   localTime: string | null;
   localEnvironment: string | null;
   localPlace: string | null;
@@ -363,6 +366,24 @@ export interface HeroBackstory {
 export interface CharacterOption {
   name: string;
   description: string;
+}
+
+export interface StoryAct {
+  actNumber: number;
+  title: string;
+  description: string;
+  mainObjective: string;
+  sideObjectives: Array<string>;
+  successCondition: string;
+}
+
+export interface StoryArc {
+  id: string;
+  title: string;
+  overview: string;
+  acts: Array<StoryAct>;
+  currentAct: number;
+  completed: boolean;
 }
 
 
@@ -626,6 +647,7 @@ export interface FullGameState {
   worldFacts: WorldFacts | null;
   heroSheet: HeroSheet | null;
   heroBackstory: HeroBackstory | null;
+  storyArc: StoryArc | null;
   pendingNewThemeNameAfterShift: string | null;
   allNPCs: Array<NPC>;
   mapData: MapData; // Single source of truth for map/location data
@@ -681,6 +703,7 @@ export type SavedGameDataShape = Pick<
   | 'worldFacts'
   | 'heroSheet'
   | 'heroBackstory'
+  | 'storyArc'
   | 'pendingNewThemeNameAfterShift'
   | 'allNPCs'
   | 'mapData'

--- a/utils/initialStates.ts
+++ b/utils/initialStates.ts
@@ -65,6 +65,7 @@ export const getInitialGameStates = (): FullGameState => {
     worldFacts: null,
     heroSheet: null,
     heroBackstory: null,
+    storyArc: null,
     pendingNewThemeNameAfterShift: null,
     allNPCs: [],
     mapData: { nodes: [], edges: [] },

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -57,7 +57,8 @@ export const handleMapUpdates = async (
       knownMainMapNodesForTheme,
       baseStateSnapshot.currentMapNodeId,
       draftState.inventory,
-      draftState.allNPCs
+      draftState.allNPCs,
+      draftState.storyArc
     );
     setLoadingReason(originalLoadingReason);
 

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -11,6 +11,7 @@ import {
   WorldFacts,
   HeroSheet,
   HeroBackstory,
+  StoryArc,
 } from '../../types';
 import { formatKnownPlacesForPrompt } from './map';
 import { findTravelPath, buildTravelAdjacency } from '../mapPathfinding';
@@ -227,3 +228,17 @@ export const formatHeroBackstoryForPrompt = (
     `Yesterday: ${backstory.yesterday}`,
     `Now: ${backstory.now}`,
   ].join('\n');
+
+export const formatStoryArcContext = (arc: StoryArc): string => {
+  const act = arc.acts[arc.currentAct - 1];
+  const side = act.sideObjectives.join(', ');
+  return [
+    `Arc Title: ${arc.title}`,
+    `Overview: ${arc.overview}`,
+    `Current Act ${String(act.actNumber)}: ${act.title}`,
+    `Act Description: ${act.description}`,
+    `Main Objective: ${act.mainObjective}`,
+    `Side Objectives: ${side}`,
+    `Success Condition: ${act.successCondition}`,
+  ].join('\n');
+};


### PR DESCRIPTION
## Summary
- integrate `StoryArc` state and formatting utilities
- include story arc context in storyteller, cartographer, and dialogue prompts
- update initialization and dialogue logic to pass the story arc
- adjust tests and initial state for new field

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68852a5698788324a358ef3a0f4296dc