### PR TITLE
Add story arc exposition generation

### DIFF
--- a/docs/worldGenPrompts.md
+++ b/docs/worldGenPrompts.md
@@ -95,15 +95,14 @@ interface StoryAct {
   mainObjective: string;
   sideObjectives: Array<string>;
   successCondition: string;
+  completed: boolean;
 }
 
 interface StoryArc {
-  id: string;
   title: string;
   overview: string;
-  acts: Array<StoryAct>; // length 5
+  acts: Array<StoryAct>; // starts with 1 act, up to 5
   currentAct: number;
-  completed: boolean;
 }
 const narrativeArc: StoryArc;
 ```

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -68,7 +68,6 @@ const dummyHeroBackstory: HeroBackstory = {
 };
 
 const dummyArc: StoryArc = {
-  id: 'arc1',
   title: 'Heroic Trials',
   overview: 'A journey of hardship and triumph.',
   acts: [
@@ -79,10 +78,10 @@ const dummyArc: StoryArc = {
       mainObjective: 'Escape the cell.',
       sideObjectives: ['Find equipment'],
       successCondition: 'Reach freedom',
+      completed: false,
     },
   ],
   currentAct: 1,
-  completed: false,
 };
 
 describe('game start sequence', () => {

--- a/types.ts
+++ b/types.ts
@@ -375,15 +375,14 @@ export interface StoryAct {
   mainObjective: string;
   sideObjectives: Array<string>;
   successCondition: string;
+  completed: boolean;
 }
 
 export interface StoryArc {
-  id: string;
   title: string;
   overview: string;
   acts: Array<StoryAct>;
   currentAct: number;
-  completed: boolean;
 }
 
 


### PR DESCRIPTION
## Summary
- generate the narrative arc when producing hero data
- include story arc in world data results
- remove arc id field
- document revised story arc structure
- refactor hero generation so world data calls the shared helper
- store story arc fields programmatically

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68853641eb2483249aa7c1748980850b