### PR TITLE
Use act objective as main quest

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -212,7 +212,7 @@ function App() {
 
   const {
     currentTheme,
-    currentScene, mainQuest, currentObjective, actionOptions,
+    currentScene, mainQuest, currentObjective, actionOptions, storyArc,
     inventory, itemsHere, itemPresenceByNode, gameLog, isLoading, error, lastActionLog, themeHistory, mapData,
     currentMapNodeId, mapLayoutConfig,
     allNPCs,
@@ -853,7 +853,7 @@ function App() {
                 globalTurnNumber={globalTurnNumber}
                 inventory={inventory}
                 itemsHere={itemsHere}
-                mainQuest={mainQuest}
+                storyArc={storyArc}
                 mapNodes={mapData.nodes}
                 objectiveAnimationType={objectiveAnimationType}
                 onDropItem={gameLogic.handleDropItem}

--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Item,
   KnownUse,
   MapNode,
+  StoryArc,
 } from '../../types';
 
 interface GameSidebarProps {
@@ -20,7 +21,7 @@ interface GameSidebarProps {
   readonly enableMobileTap: boolean;
   readonly inventory: Array<Item>;
   readonly itemsHere: Array<Item>;
-  readonly mainQuest: string | null;
+  readonly storyArc: StoryArc | null;
   readonly mapNodes: Array<MapNode>;
   readonly objectiveAnimationType: 'success' | 'neutral' | null;
   readonly onDropItem: (itemName: string) => void;
@@ -45,7 +46,7 @@ function GameSidebar({
   enableMobileTap,
   inventory,
   itemsHere,
-  mainQuest,
+  storyArc,
   mapNodes,
   objectiveAnimationType,
   onDropItem,
@@ -67,6 +68,10 @@ function GameSidebar({
       ),
     [inventory, mapNodes, allNPCs, currentThemeName],
   );
+
+  const act = storyArc?.acts[storyArc.currentAct - 1];
+  const mainQuest = act?.mainObjective ?? null;
+  const actHeader = act ? `Act ${String(storyArc.currentAct)}: ${act.title}` : '';
 
   return (
     <>
@@ -95,7 +100,7 @@ function GameSidebar({
           contentColorClass="text-purple-200"
           contentFontClass="text-lg"
           enableMobileTap={enableMobileTap}
-          header="Main Quest"
+          header={actHeader}
           headerFont="lg"
           headerPreset="purple"
           highlightEntities={questHighlightEntities}

--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -131,8 +131,12 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
         return sourceNode?.themeName === currentThemeObj.name && targetNode?.themeName === currentThemeObj.name;
       }),
     };
+    const act =
+      workingGameState.storyArc?.acts[
+        workingGameState.storyArc.currentAct - 1
+      ];
     const summaryContextForUpdates: DialogueSummaryContext = {
-      mainQuest: workingGameState.mainQuest,
+      mainQuest: act?.mainObjective ?? null,
       currentObjective: workingGameState.currentObjective,
       currentScene: workingGameState.currentScene,
       localTime: workingGameState.localTime,

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -407,10 +407,15 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     const mapNodeNames = currentThemeNodes.map(n => n.placeName);
     const recentLogs = currentFullState.gameLog.slice(-RECENT_LOG_COUNT_FOR_DISTILL);
     setLoadingReasonRef('loremaster_refine');
+    const act =
+      currentFullState.storyArc?.acts[
+        currentFullState.storyArc.currentAct - 1
+      ];
+    const actQuest = act?.mainObjective ?? null;
     const result = await distillFacts_Service({
       themeName: themeObj.name,
       facts: currentFullState.themeFacts,
-      currentQuest: currentFullState.mainQuest,
+      currentQuest: actQuest,
       currentObjective: currentFullState.currentObjective,
       inventoryItemNames,
       mapNodeNames,
@@ -470,11 +475,18 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     currentFullState.dialogueState,
   ]);
 
+  const currentAct =
+    currentFullState.storyArc?.acts[
+      currentFullState.storyArc.currentAct - 1
+    ];
+  const mainQuest = currentAct?.mainObjective ?? null;
+
   return {
     currentTheme: currentFullState.currentThemeObject,
     currentScene: currentFullState.currentScene,
     actionOptions: currentFullState.actionOptions,
-    mainQuest: currentFullState.mainQuest,
+    mainQuest,
+    storyArc: currentFullState.storyArc,
     currentObjective: currentFullState.currentObjective,
     inventory: currentFullState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID),
     playerJournal: currentFullState.playerJournal,

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -141,10 +141,12 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         const mapNodeNames = currentThemeNodes.map(n => n.placeName);
         const recentLogs = state.gameLog.slice(-RECENT_LOG_COUNT_FOR_DISTILL);
         setLoadingReason('loremaster_refine');
+        const act =
+          state.storyArc?.acts[state.storyArc.currentAct - 1];
         const result = await distillFacts_Service({
           themeName: themeObj.name,
           facts: state.themeFacts,
-          currentQuest: state.mainQuest,
+          currentQuest: act?.mainObjective ?? null,
           currentObjective: state.currentObjective,
           inventoryItemNames,
           mapNodeNames,
@@ -255,7 +257,9 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         action,
         currentFullState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID),
         locationItems,
-        currentFullState.mainQuest,
+        currentFullState.storyArc?.acts[
+          currentFullState.storyArc.currentAct - 1
+        ]?.mainObjective ?? null,
         currentFullState.currentObjective,
         currentThemeObj,
         recentLogs,


### PR DESCRIPTION
## Summary
- compute main quest from the current act and show it in the sidebar
- expose `storyArc` from `useGameLogic`
- pass `storyArc` to `GameSidebar`
- propagate act objective through prompts and summaries

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68855af35904832490fef2afd572b4a6