### PR TITLE
Add manual Main Quest completion debug tool

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -241,6 +241,7 @@ function App() {
     debugPacketStack,
     handleMapLayoutConfigChange,
     handleUndoTurn,
+    triggerMainQuestAchieved,
     destinationNodeId,
     handleSelectDestinationNode,
     mapViewBox,
@@ -266,6 +267,10 @@ function App() {
     (state: FullGameState) => { commitGameState(state); },
     [commitGameState]
   );
+
+  const handleTriggerMainQuestAchievedClick = useCallback(() => {
+    void triggerMainQuestAchieved();
+  }, [triggerMainQuestAchieved]);
 
   const handleSaveFacts = useCallback((data: string) => {
     const blob = new Blob([data], { type: 'application/json' });
@@ -916,6 +921,7 @@ function App() {
         onDistillFacts={handleDistillClick}
         onSaveFacts={handleSaveFacts}
         onToggleDebugLore={toggleDebugLore}
+        onTriggerMainQuestAchieved={handleTriggerMainQuestAchievedClick}
         onUndoTurn={handleUndoTurn}
         travelPath={travelPath}
       />

--- a/components/debug/DebugView.tsx
+++ b/components/debug/DebugView.tsx
@@ -35,6 +35,7 @@ interface DebugViewProps {
   readonly gameStateStack: GameStateStack;
   readonly onUndoTurn: () => void; // New prop for undoing turn
   readonly onApplyGameState: (state: FullGameState) => void;
+  readonly onTriggerMainQuestAchieved: () => void;
   readonly travelPath: Array<TravelStep> | null;
   readonly onDistillFacts: () => void;
   readonly debugLore: boolean;
@@ -74,6 +75,7 @@ function DebugView({
   gameStateStack,
   onUndoTurn,
   onApplyGameState,
+  onTriggerMainQuestAchieved,
   travelPath,
   onDistillFacts,
   debugLore,
@@ -126,6 +128,7 @@ function DebugView({
             currentState={currentState}
             onApplyGameState={onApplyGameState}
             onUndoTurn={onUndoTurn}
+            onTriggerMainQuestAchieved={onTriggerMainQuestAchieved}
             previousState={previousState}
           />
         );

--- a/components/debug/tabs/GameStateTab.tsx
+++ b/components/debug/tabs/GameStateTab.tsx
@@ -12,10 +12,11 @@ interface GameStateTabProps {
   readonly currentState: FullGameState;
   readonly onUndoTurn: () => void;
   readonly onApplyGameState: (state: FullGameState) => void;
+  readonly onTriggerMainQuestAchieved: () => void;
   readonly previousState?: FullGameState;
 }
 
-function GameStateTab({ currentState, onUndoTurn, onApplyGameState, previousState = undefined }: GameStateTabProps) {
+function GameStateTab({ currentState, onUndoTurn, onApplyGameState, onTriggerMainQuestAchieved, previousState = undefined }: GameStateTabProps) {
   const [editableText, setEditableText] = useState<string>('');
   const [parseError, setParseError] = useState<string | null>(null);
 
@@ -72,6 +73,15 @@ function GameStateTab({ currentState, onUndoTurn, onApplyGameState, previousStat
         label={`Undo Turn (Global Turn: ${String(currentState.globalTurnNumber)})`}
         onClick={onUndoTurn}
         preset="orange"
+        size="sm"
+        variant="compact"
+      />
+
+      <Button
+        ariaLabel="Trigger main quest achieved"
+        label="Main Quest Achieved"
+        onClick={onTriggerMainQuestAchieved}
+        preset="purple"
         size="sm"
         variant="compact"
       />

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -210,6 +210,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     recordPlayerJournalInspect,
     handleFreeFormActionSubmit,
     handleUndoTurn,
+    triggerMainQuestAchieved,
   } = useGameTurn({
     getCurrentGameState,
     commitGameState,
@@ -574,6 +575,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     handleMapNodesPositionChange,
     handleSelectDestinationNode,
     handleUndoTurn,
+    triggerMainQuestAchieved,
     handleStashToggle,
     addJournalEntry,
     addPlayerJournalEntry,


### PR DESCRIPTION
## Summary
- enable triggering the Main Quest completion procedure from Debug View
- expose a `triggerMainQuestAchieved` function via game logic
- wire up GameStateTab to invoke this function

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688573de2b6083248b541d83a8386e68