### PR TITLE
Remove themeName filtering

### DIFF
--- a/components/ActionOptions.tsx
+++ b/components/ActionOptions.tsx
@@ -19,7 +19,6 @@ interface ActionOptionsProps {
   readonly inventory: Array<Item>;
   readonly mapData: Array<MapNode>;
   readonly allNPCs: Array<NPC>;
-  readonly currentThemeName: string | null;
 }
 
 /**
@@ -33,12 +32,11 @@ function ActionOptions({
   inventory,
   mapData,
   allNPCs,
-  currentThemeName
 }: ActionOptionsProps) {
 
   const entitiesForHighlighting = useMemo(
-    () => buildHighlightableEntities(inventory, mapData, allNPCs, currentThemeName),
-    [inventory, mapData, allNPCs, currentThemeName]
+    () => buildHighlightableEntities(inventory, mapData, allNPCs),
+    [inventory, mapData, allNPCs]
   );
 
 

--- a/components/DialogueDisplay.tsx
+++ b/components/DialogueDisplay.tsx
@@ -23,9 +23,8 @@ interface DialogueDisplayProps {
   readonly isLoading: boolean; 
   readonly isDialogueExiting?: boolean;
   readonly inventory: Array<Item>;
-  readonly mapData: Array<MapNode>; 
+  readonly mapData: Array<MapNode>;
   readonly allNPCs: Array<NPC>;
-  readonly currentThemeName: string | null;
 }
 
 /**
@@ -43,7 +42,6 @@ function DialogueDisplay({
   inventory,
   mapData,
   allNPCs: allNPCs,
-  currentThemeName,
 }: DialogueDisplayProps) {
   const dialogueFrameRef = useRef<HTMLDivElement | null>(null); 
   const lastHistoryEntryRef = useRef<HTMLDivElement | null>(null);
@@ -70,8 +68,8 @@ function DialogueDisplay({
   }, [isLoading, isDialogueExiting, options.length, isVisible, history.length]);
 
   const entitiesForHighlighting = useMemo(
-    () => buildHighlightableEntities(inventory, mapData, allNPCs, currentThemeName),
-    [inventory, mapData, allNPCs, currentThemeName]
+    () => buildHighlightableEntities(inventory, mapData, allNPCs),
+    [inventory, mapData, allNPCs]
   );
 
 

--- a/components/SceneDisplay.tsx
+++ b/components/SceneDisplay.tsx
@@ -16,7 +16,6 @@ interface SceneDisplayProps {
   readonly inventory: Array<Item>;
   readonly mapData: Array<MapNode>;
   readonly allNPCs: Array<NPC>;
-  readonly currentThemeName: string | null;
   readonly localTime?: string | null;
   readonly localEnvironment?: string | null;
   readonly localPlace?: string | null;
@@ -31,15 +30,14 @@ function SceneDisplay({
   inventory,
   mapData,
   allNPCs,
-  currentThemeName,
   localTime,
   localEnvironment,
   localPlace,
 }: SceneDisplayProps) {
 
   const entitiesForHighlighting = useMemo(
-    () => buildHighlightableEntities(inventory, mapData, allNPCs, currentThemeName),
-    [inventory, mapData, allNPCs, currentThemeName]
+    () => buildHighlightableEntities(inventory, mapData, allNPCs),
+    [inventory, mapData, allNPCs]
   );
 
   const enableMobileTap =

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -408,12 +408,11 @@ function App() {
       if (!currentTheme) { setIsPlayerJournalWriting(false); return; }
       const { name: themeName, themeGuidance } = currentTheme;
       const nodes = mapData.nodes.filter(
-        node => node.themeName === themeName && node.data.nodeType !== 'feature' && node.data.nodeType !== 'room'
+        node => node.data.nodeType !== 'feature' && node.data.nodeType !== 'room'
       );
       const knownPlaces = formatKnownPlacesForPrompt(nodes, true);
-      const npcs = allNPCs.filter(npc => npc.themeName === themeName);
-      const knownNPCs = npcs.length > 0
-        ? npcsToString(npcs, ' - ', false, false, false, true)
+      const knownNPCs = allNPCs.length > 0
+        ? npcsToString(allNPCs, ' - ', false, false, false, true)
         : 'None specifically known in this theme yet.';
       const prev = playerJournal[playerJournal.length - 1]?.actualContent ?? '';
       const entryLength = Math.floor(Math.random() * 50) + 100;
@@ -633,7 +632,7 @@ function App() {
   useEffect(() => {
     if (isMapVisible && !prevMapVisibleRef.current) {
       const layoutNodes = applyNestedCircleLayout(
-        mapData.nodes.filter(n => n.themeName === currentTheme?.name).map(n => ({ ...n })),
+        mapData.nodes.map(n => ({ ...n })),
           {
             padding: mapLayoutConfig.NESTED_PADDING,
             anglePadding: mapLayoutConfig.NESTED_ANGLE_PADDING,
@@ -728,7 +727,6 @@ function App() {
                   <div className="relative">
                     <SceneDisplay
                       allNPCs={allNPCs}
-                      currentThemeName={currentTheme ? currentTheme.name : null}
                       description={currentScene}
                       inventory={inventory}
                       lastActionLog={lastActionLog}
@@ -747,7 +745,6 @@ function App() {
 
                   <ActionOptions
                     allNPCs={allNPCs}
-                    currentThemeName={currentTheme ? currentTheme.name : null}
                     disabled={isLoading || !!dialogueState}
                     inventory={inventory}
                     mapData={mapData.nodes}
@@ -772,7 +769,6 @@ function App() {
                 allNPCs={allNPCs}
                 currentMapNodeId={currentMapNodeId}
                 currentObjective={currentObjective}
-                currentThemeName={currentTheme ? currentTheme.name : null}
                 disabled={isLoading || isAnyModalOrDialogueActive}
                 enableMobileTap={enableMobileTap}
                 globalTurnNumber={globalTurnNumber}
@@ -815,7 +811,6 @@ function App() {
 
       <DialogueDisplay
         allNPCs={allNPCs}
-        currentThemeName={currentTheme ? currentTheme.name : null}
         history={dialogueState?.history ?? []}
         inventory={inventory}
         isDialogueExiting={isDialogueExiting}

--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -17,7 +17,6 @@ interface GameSidebarProps {
   readonly allNPCs: Array<NPC>;
   readonly currentMapNodeId: string | null;
   readonly currentObjective: string | null;
-  readonly currentThemeName: string | null;
   readonly enableMobileTap: boolean;
   readonly inventory: Array<Item>;
   readonly itemsHere: Array<Item>;
@@ -42,7 +41,6 @@ function GameSidebar({
   allNPCs: allNPCs,
   currentMapNodeId,
   currentObjective,
-  currentThemeName,
   enableMobileTap,
   inventory,
   itemsHere,
@@ -59,14 +57,8 @@ function GameSidebar({
   disabled,
 }: GameSidebarProps) {
   const questHighlightEntities = useMemo(
-    () =>
-      buildHighlightableEntities(
-        inventory,
-        mapNodes,
-        allNPCs,
-        currentThemeName,
-      ),
-    [inventory, mapNodes, allNPCs, currentThemeName],
+    () => buildHighlightableEntities(inventory, mapNodes, allNPCs),
+    [inventory, mapNodes, allNPCs],
   );
 
   const act = storyArc?.acts[storyArc.currentAct - 1];

--- a/components/debug/DebugView.tsx
+++ b/components/debug/DebugView.tsx
@@ -155,9 +155,7 @@ function DebugView({
       case 'Lore':
         return (
           <LoreTab
-            themeFacts={currentState.themeFacts.filter(
-              fact => fact.themeName === currentState.currentThemeName
-            )}
+            themeFacts={currentState.themeFacts}
           />
         );
       case 'GameLog':

--- a/components/map/MapDisplay.tsx
+++ b/components/map/MapDisplay.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 
-import { MapData, MapNode, MapEdge, MapLayoutConfig } from '../../types';
+import { MapData, MapNode, MapLayoutConfig } from '../../types';
 import {
   DEFAULT_IDEAL_EDGE_LENGTH,
   DEFAULT_NESTED_PADDING,
@@ -121,21 +121,10 @@ function MapDisplay({
   }, [currentConfigToPropagate, onLayoutConfigChange]);
 
   /** Nodes belonging to the current theme. */
-  const currentThemeNodes = useMemo(() => {
-    if (!currentThemeName) return [] as Array<MapNode>;
-    return mapData.nodes.filter(node => node.themeName === currentThemeName);
-  }, [mapData.nodes, currentThemeName]);
+  const currentThemeNodes = useMemo(() => mapData.nodes, [mapData.nodes]);
 
   /** Edges belonging to the current theme. */
-  const currentThemeEdges = useMemo(() => {
-    if (!currentThemeName) return [] as Array<MapEdge>;
-    const themeNodeIds = new Set(currentThemeNodes.map(node => node.id));
-    return mapData.edges.filter(
-      edge =>
-        themeNodeIds.has(edge.sourceNodeId) &&
-        themeNodeIds.has(edge.targetNodeId)
-    );
-  }, [mapData.edges, currentThemeNodes, currentThemeName]);
+  const currentThemeEdges = useMemo(() => mapData.edges, [mapData.edges]);
 
   /**
    * Prepares nodes for display. The force-directed layout algorithm is

--- a/components/modals/ImageVisualizer.tsx
+++ b/components/modals/ImageVisualizer.tsx
@@ -186,7 +186,6 @@ function ImageVisualizer({
     const mentionedPlaces: Array<string> = [];
     // Derive places from mapData (main nodes)
     mapData
-      .filter(node => node.themeName === currentTheme.name)
       .forEach(node => {
         if (currentSceneDescription.toLowerCase().includes(node.placeName.toLowerCase())) {
           rawPrompt += ` The ${node.placeName} is prominent, described as: ${node.data.description || 'A notable location.'}.`;
@@ -196,7 +195,7 @@ function ImageVisualizer({
 
     const mentionedNPCs: Array<string> = [];
     allNPCs.forEach(npc => {
-      if (npc.themeName === currentTheme.name && currentSceneDescription.toLowerCase().includes(npc.name.toLowerCase())) {
+      if (currentSceneDescription.toLowerCase().includes(npc.name.toLowerCase())) {
         rawPrompt += ` ${npc.name} here, appearing as: ${npc.description}.`;
         mentionedNPCs.push(npc.name);
       }

--- a/components/modals/KnowledgeBase.tsx
+++ b/components/modals/KnowledgeBase.tsx
@@ -15,10 +15,8 @@ interface KnowledgeBaseProps {
   readonly onClose: () => void;
 }
 
-type GroupedEntities = Record<string, Array<NPC> | undefined>;
-
 /**
- * Lists discovered NPCs grouped by their associated theme.
+ * Lists discovered NPCs.
  */
 function KnowledgeBase({
   allNPCs: allNPCs,
@@ -26,27 +24,10 @@ function KnowledgeBase({
   isVisible,
   onClose,
 }: KnowledgeBaseProps) {
-  const groupedEntities = React.useMemo(() => {
-    const grouped: GroupedEntities = {};
-
-    allNPCs.forEach(npc => {
-      let bucket = grouped[npc.themeName];
-      if (!bucket) {
-        bucket = [];
-        grouped[npc.themeName] = bucket;
-      }
-      bucket.push(npc);
-    });
-    return grouped;
-  }, [allNPCs]);
-
-  const sortedThemeNames = React.useMemo(() => {
-    return Object.keys(groupedEntities).sort((a, b) => {
-      if (currentTheme && a === currentTheme.name) return -1;
-      if (currentTheme && b === currentTheme.name) return 1;
-      return a.localeCompare(b);
-    });
-  }, [groupedEntities, currentTheme]);
+  const sortedNPCs = React.useMemo(
+    () => [...allNPCs].sort((a, b) => a.name.localeCompare(b.name)),
+    [allNPCs],
+  );
 
   return (
     <div
@@ -75,43 +56,18 @@ function KnowledgeBase({
             Knowledge Base
           </h1>
           
-          {sortedThemeNames.length === 0 && isVisible ? <p className="text-slate-300 italic text-center">
+          {sortedNPCs.length === 0 && isVisible ? <p className="text-slate-300 italic text-center">
             No knowledge has been recorded yet.
           </p> : null}
 
-          {isVisible ? sortedThemeNames.map(themeName => {
-            const npcs = groupedEntities[themeName] ?? [];
-
-            if (npcs.length === 0) { 
-              return null; 
-            }
-
-            return (
-              <section
-                className="mb-8"
-                key={themeName}
-              >
-                <h2 className="kb-theme-group-title">
-                  Theme: 
-                  {' '}
-
-                  {themeName}
-
-                  {currentTheme && themeName === currentTheme.name ? <span className="text-sm text-purple-400 ml-2">
-                    (Current Active Theme)
-                  </span> : null}
-                </h2>
-                
-                {npcs.length > 0 && (
-                  <>
-                    <h3 className="text-xl font-semibold text-emerald-400 mt-4 mb-2">
-                      NPCs
-                    </h3>
-
-                    <div className="kb-card-grid">
-                      {npcs.map(npc => {
+          {isVisible ? (
+            <section className="mb-8">
+              <h2 className="kb-theme-group-title">NPCs</h2>
+              {sortedNPCs.length > 0 && (
+                <div className="kb-card-grid">
+                  {sortedNPCs.map(npc => {
                         let locationDisplay: React.ReactNode;
-                        const isCurrentThemeNPC = currentTheme && themeName === currentTheme.name;
+                        const isCurrentThemeNPC = Boolean(currentTheme);
 
                         if (isCurrentThemeNPC && (npc.presenceStatus === 'companion' || npc.presenceStatus === 'nearby')) {
                           const iconName = npc.presenceStatus === 'companion' ? 'companion' : 'nearbyNpc';
@@ -165,7 +121,7 @@ function KnowledgeBase({
                         return (
                           <div
                             className="kb-card"
-                            key={`${themeName}-npc-${npc.name}`}
+                            key={npc.name}
                           >
                             <div className="kb-card-name-header">
                               {npc.name}
@@ -185,13 +141,11 @@ function KnowledgeBase({
                             </div>
                           </div>
                         );
-                      })}
-                    </div>
-                  </>
-                )}
-              </section>
-            );
-          }) : null}
+                  })}
+                </div>
+              )}
+            </section>
+          ) : null}
         </div>
       </div>
     </div>

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -204,19 +204,17 @@ function PageView({
   const knownPlaces = useMemo(() => {
     const nodes = mapData.nodes.filter(
       n =>
-        n.themeName === themeName &&
         n.data.nodeType !== 'feature' &&
         n.data.nodeType !== 'room',
     );
     return formatKnownPlacesForPrompt(nodes, true);
-  }, [mapData, themeName]);
+  }, [mapData]);
 
   const knownNPCs = useMemo(() => {
-    const npcs = allNPCs.filter(npc => npc.themeName === themeName);
-    return npcs.length > 0
-      ? npcsToString(npcs, ' - ', false, false, false, true)
+    return allNPCs.length > 0
+      ? npcsToString(allNPCs, ' - ', false, false, false, true)
       : 'None specifically known in this theme yet.';
-  }, [allNPCs, themeName]);
+  }, [allNPCs]);
 
   useEffect(() => {
     if (!isVisible || !item) {

--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -112,7 +112,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
     };
 
     workingGameState.allNPCs = workingGameState.allNPCs.map((npc) => {
-      if (finalParticipants.includes(npc.name) && npc.themeName === currentThemeObj.name) {
+      if (finalParticipants.includes(npc.name)) {
         const newSummaries = [...(npc.dialogueSummaries ?? []), newSummaryRecord];
         if (newSummaries.length > MAX_DIALOGUE_SUMMARIES_PER_NPC) {
           newSummaries.shift();
@@ -123,14 +123,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
     });
 
     setLoadingReason('dialogue_conclusion_summary');
-    const mapDataForSummary: MapData = {
-      nodes: workingGameState.mapData.nodes.filter((node) => node.themeName === currentThemeObj.name),
-      edges: workingGameState.mapData.edges.filter((edge) => {
-        const sourceNode = workingGameState.mapData.nodes.find((n) => n.id === edge.sourceNodeId);
-        const targetNode = workingGameState.mapData.nodes.find((n) => n.id === edge.targetNodeId);
-        return sourceNode?.themeName === currentThemeObj.name && targetNode?.themeName === currentThemeObj.name;
-      }),
-    };
+    const mapDataForSummary: MapData = workingGameState.mapData;
     const act =
       workingGameState.storyArc?.acts[
         workingGameState.storyArc.currentAct - 1
@@ -143,7 +136,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
       localEnvironment: workingGameState.localEnvironment,
       localPlace: workingGameState.localPlace,
       mapDataForTheme: mapDataForSummary,
-      knownNPCsInTheme: workingGameState.allNPCs.filter((npc) => npc.themeName === currentThemeObj.name),
+      knownNPCsInTheme: workingGameState.allNPCs,
       inventory: workingGameState.inventory.filter(item => item.holderId === PLAYER_HOLDER_ID),
       playerGender: playerGenderProp,
       dialogueLog: finalHistory,

--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -76,9 +76,9 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
 
       try {
         const currentThemeMapNodes = stateAfterPlayerChoice.mapData.nodes.filter(
-          node => node.themeName === currentThemeObj.name && node.data.nodeType !== 'feature'
+          node => node.data.nodeType !== 'feature'
         );
-        const currentThemeNPCs = stateAfterPlayerChoice.allNPCs.filter(npc => npc.themeName === currentThemeObj.name);
+        const currentThemeNPCs = stateAfterPlayerChoice.allNPCs;
         const recentLogs = stateAfterPlayerChoice.gameLog.slice(-RECENT_LOG_COUNT_FOR_PROMPT);
         const detailedContextForFacts = formatDetailedContextForMentionedEntities(
           currentThemeMapNodes,
@@ -111,7 +111,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
           stateAfterPlayerChoice.localEnvironment,
           stateAfterPlayerChoice.localPlace,
           currentThemeMapNodes,
-          stateAfterPlayerChoice.allNPCs.filter((npc) => npc.themeName === currentThemeObj.name),
+          stateAfterPlayerChoice.allNPCs,
           stateAfterPlayerChoice.inventory.filter(item => item.holderId === PLAYER_HOLDER_ID),
           playerGenderProp,
           stateAfterPlayerChoice.heroSheet,

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -274,7 +274,6 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
                 draftState,
                 changes,
                 draftState.globalTurnNumber,
-                themeObjToLoad.name,
               );
             }
           }
@@ -324,14 +323,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
         draftState.lastDebugPacket.jsonSchema = jsonSchemaUsed;
         draftState.lastDebugPacket.prompt = promptUsed;
 
-        const currentThemeMapDataForParse = {
-          nodes: draftState.mapData.nodes.filter((n) => n.themeName === themeObjToLoad.name),
-          edges: draftState.mapData.edges.filter((e) => {
-            const sourceNode = draftState.mapData.nodes.find((node) => node.id === e.sourceNodeId);
-            const targetNode = draftState.mapData.nodes.find((node) => node.id === e.targetNodeId);
-            return sourceNode?.themeName === themeObjToLoad.name && targetNode?.themeName === themeObjToLoad.name;
-          }),
-        };
+        const currentThemeMapDataForParse = draftState.mapData;
         const parsedData = await parseAIResponse(
           response.text ?? '',
           playerGenderProp,
@@ -339,7 +331,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
           () => { setParseErrorCounter(1); },
           undefined,
           undefined,
-          draftState.allNPCs.filter((npc) => npc.themeName === themeObjToLoad.name),
+          draftState.allNPCs,
           currentThemeMapDataForParse,
           draftState.inventory.filter(i => i.holderId === PLAYER_HOLDER_ID)
         );
@@ -519,26 +511,8 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
       draftState.lastDebugPacket.jsonSchema = jsonSchemaUsed;
       draftState.lastDebugPacket.prompt = promptUsed;
 
-      const currentThemeNPCs = draftState.allNPCs.filter(
-        (npc) => npc.themeName === currentThemeObj.name,
-      );
-      const currentThemeMapDataForParse = {
-        nodes: draftState.mapData.nodes.filter(
-          (node) => node.themeName === currentThemeObj.name,
-        ),
-        edges: draftState.mapData.edges.filter((e) => {
-          const sourceNode = draftState.mapData.nodes.find(
-            (node) => node.id === e.sourceNodeId,
-          );
-          const targetNode = draftState.mapData.nodes.find(
-            (node) => node.id === e.targetNodeId,
-          );
-          return (
-            sourceNode?.themeName === currentThemeObj.name &&
-            targetNode?.themeName === currentThemeObj.name
-          );
-        }),
-      };
+      const currentThemeNPCs = draftState.allNPCs;
+      const currentThemeMapDataForParse = draftState.mapData;
 
       const parsedData = await parseAIResponse(
         response.text ?? '',

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -344,9 +344,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     if (!themeObj) return;
     setIsLoading(true);
     setError(null);
-    const currentThemeNodes = currentFullState.mapData.nodes.filter(
-      n => n.themeName === themeObj.name,
-    );
+    const currentThemeNodes = currentFullState.mapData.nodes;
     const inventoryItemNames = Array.from(
       new Set(
         currentFullState.inventory
@@ -354,7 +352,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
             if (item.holderId === PLAYER_HOLDER_ID) return true;
             if (currentThemeNodes.some(node => node.id === item.holderId)) return true;
             const holderNpc = currentFullState.allNPCs.find(
-              npc => npc.id === item.holderId && npc.themeName === themeObj.name,
+              npc => npc.id === item.holderId,
             );
             return Boolean(holderNpc);
           })
@@ -400,7 +398,6 @@ export const useGameLogic = (props: UseGameLogicProps) => {
         draftState,
         result.refinementResult.factsChange,
         draftState.globalTurnNumber,
-        themeObj.name,
       );
     }
     commitGameState(draftState);

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -115,9 +115,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         state.globalTurnNumber % DISTILL_LORE_INTERVAL === 0 &&
         state.lastLoreDistillTurn !== state.globalTurnNumber
       ) {
-        const currentThemeNodes = state.mapData.nodes.filter(
-          n => n.themeName === themeObj.name,
-        );
+        const currentThemeNodes = state.mapData.nodes;
         const inventoryItemNames = Array.from(
           new Set(
             state.inventory
@@ -125,7 +123,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
                 if (item.holderId === PLAYER_HOLDER_ID) return true;
                 if (currentThemeNodes.some(node => node.id === item.holderId)) return true;
                 const holderNpc = state.allNPCs.find(
-                  npc => npc.id === item.holderId && npc.themeName === themeObj.name,
+                  npc => npc.id === item.holderId,
                 );
                 return Boolean(holderNpc);
               })
@@ -167,7 +165,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
             state,
             result.refinementResult.factsChange,
             state.globalTurnNumber,
-            themeObj.name,
           );
         }
       }
@@ -206,13 +203,10 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       }
 
       const recentLogs = currentFullState.gameLog.slice(-RECENT_LOG_COUNT_FOR_PROMPT);
-        const currentThemeMainMapNodes = currentFullState.mapData.nodes.filter(
-          n =>
-            n.themeName === currentThemeObj.name &&
-            n.data.nodeType !== 'feature' &&
-            n.data.nodeType !== 'room'
-        );
-      const currentThemeNPCs = currentFullState.allNPCs.filter((npc) => npc.themeName === currentThemeObj.name);
+      const currentThemeMainMapNodes = currentFullState.mapData.nodes.filter(
+        n => n.data.nodeType !== 'feature' && n.data.nodeType !== 'room'
+      );
+      const currentThemeNPCs = currentFullState.allNPCs;
       const currentMapNodeDetails = currentFullState.currentMapNodeId
         ? currentFullState.mapData.nodes.find((n) => n.id === currentFullState.currentMapNodeId) ?? null
         : null;
@@ -315,14 +309,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           prompt: promptUsed,
         };
 
-        const currentThemeMapDataForParse = {
-          nodes: draftState.mapData.nodes.filter((n) => n.themeName === currentThemeObj.name),
-          edges: draftState.mapData.edges.filter((e) => {
-            const sourceNode = draftState.mapData.nodes.find((node) => node.id === e.sourceNodeId);
-            const targetNode = draftState.mapData.nodes.find((node) => node.id === e.targetNodeId);
-            return sourceNode?.themeName === currentThemeObj.name && targetNode?.themeName === currentThemeObj.name;
-          }),
-        };
+        const currentThemeMapDataForParse = draftState.mapData;
 
         const parsedData = await parseAIResponse(
           response.text ?? '',

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -620,10 +620,10 @@ export const useProcessAiResponse = ({
             if (!chapter) continue;
             const { name: themeName, themeGuidance } = themeContextForResponse;
             const nodes = draftState.mapData.nodes.filter(
-              n => n.themeName === themeName && n.data.nodeType !== 'feature' && n.data.nodeType !== 'room'
+              n => n.data.nodeType !== 'feature' && n.data.nodeType !== 'room'
             );
             const knownPlaces = formatKnownPlacesForPrompt(nodes, true);
-            const npcs = draftState.allNPCs.filter(npc => npc.themeName === themeName);
+            const npcs = draftState.allNPCs;
             const knownNPCs = npcs.length > 0
               ? npcsToString(npcs, ' - ', false, false, false, true)
               : 'None specifically known in this theme yet.';
@@ -698,9 +698,9 @@ export const useProcessAiResponse = ({
               .join('\n');
 
         const nodesForTheme = draftState.mapData.nodes.filter(
-          n => n.themeName === themeContextForResponse.name && n.data.nodeType !== 'feature' && n.data.nodeType !== 'room',
+          n => n.data.nodeType !== 'feature' && n.data.nodeType !== 'room',
         );
-        const npcsForTheme = draftState.allNPCs.filter(npc => npc.themeName === themeContextForResponse.name);
+        const npcsForTheme = draftState.allNPCs;
         const itemsForTheme = draftState.inventory.filter(
           item =>
             item.holderId === PLAYER_HOLDER_ID ||
@@ -747,7 +747,6 @@ export const useProcessAiResponse = ({
             draftState,
             refineResult.refinementResult.factsChange,
             draftState.globalTurnNumber,
-            themeContextForResponse.name,
           );
         }
         setLoadingReason(original);

--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -50,12 +50,8 @@ export const updateMapFromAIData_Service = async (
       ? aiData.currentMapNodeId
       : previousMapNodeId;
 
-  const currentThemeNodesFromMapData = currentMapData.nodes.filter(
-    n => n.themeName === currentTheme.name,
-  );
-  const currentThemeNodeIdsSet = new Set(
-    currentThemeNodesFromMapData.map(n => n.id),
-  );
+  const currentThemeNodesFromMapData = currentMapData.nodes;
+  const currentThemeNodeIdsSet = new Set(currentThemeNodesFromMapData.map(n => n.id));
   const currentThemeEdgesFromMapData = currentMapData.edges.filter(e =>
     currentThemeNodeIdsSet.has(e.sourceNodeId) &&
     currentThemeNodeIdsSet.has(e.targetNodeId),

--- a/services/cartographer/applyUpdates.ts
+++ b/services/cartographer/applyUpdates.ts
@@ -65,12 +65,8 @@ export const applyMapUpdates = async ({
       ? aiData.currentMapNodeId
       : previousMapNodeId;
 
-  const currentThemeNodesFromMapData = currentMapData.nodes.filter(
-    n => n.themeName === currentTheme.name,
-  );
-  const currentThemeNodeIdsSet = new Set(
-    currentThemeNodesFromMapData.map(n => n.id),
-  );
+  const currentThemeNodesFromMapData = currentMapData.nodes;
+  const currentThemeNodeIdsSet = new Set(currentThemeNodesFromMapData.map(n => n.id));
   const currentThemeEdgesFromMapData = currentMapData.edges.filter(e =>
     currentThemeNodeIdsSet.has(e.sourceNodeId) &&
     currentThemeNodeIdsSet.has(e.targetNodeId),
@@ -122,9 +118,7 @@ export const applyMapUpdates = async ({
       const corrected = await fetchCorrectedNodeIdentifier_Service(
         identifier,
         {
-          themeNodes: newMapData.nodes.filter(
-            n => n.themeName === currentTheme.name,
-          ),
+          themeNodes: newMapData.nodes,
           currentLocationId: referenceMapNodeId,
         },
         minimalModelCalls,
@@ -194,9 +188,7 @@ export const applyMapUpdates = async ({
   themeNodeNameMap.clear();
   themeNodeAliasMap.clear();
   themeEdgesMap.clear();
-  newMapData.nodes
-    .filter(n => n.themeName === currentTheme.name)
-    .forEach(n => {
+  newMapData.nodes.forEach(n => {
       themeNodeIdMap.set(n.id, n);
       themeNodeNameMap.set(n.placeName, n);
       if (n.data.aliases) n.data.aliases.forEach(a => themeNodeAliasMap.set(a.toLowerCase(), n));
@@ -310,9 +302,7 @@ export const applyMapUpdates = async ({
     (npc.aliases ?? []).forEach(a => npcNameSet.add(normalizeName(a)));
   });
 
-  ctx.newMapData.nodes
-    .filter(n => n.themeName === ctx.currentTheme.name)
-    .forEach(node => {
+  ctx.newMapData.nodes.forEach(node => {
       const norm = normalizeName(node.placeName);
       if (itemNameSet.has(norm) || npcNameSet.has(norm)) {
         removeNode(node);

--- a/services/cartographer/hierarchyResolver.ts
+++ b/services/cartographer/hierarchyResolver.ts
@@ -15,7 +15,7 @@ interface Net {
 }
 
 export async function resolveHierarchyConflicts(ctx: ApplyUpdatesContext): Promise<void> {
-  for (const node of ctx.newMapData.nodes.filter(n => n.themeName === ctx.currentTheme.name)) {
+  for (const node of ctx.newMapData.nodes) {
     const parentId = node.data.parentNodeId;
     if (!parentId || parentId === 'Universe') continue;
     const parent = ctx.themeNodeIdMap.get(parentId);

--- a/services/cartographer/processNodeAdds.ts
+++ b/services/cartographer/processNodeAdds.ts
@@ -106,7 +106,6 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
               const downgraded = suggestNodeTypeDowngrade(
                 {
                   id: 'temp',
-                  themeName: parent.themeName,
                   placeName: nodeAddOp.placeName,
                   position: { x: 0, y: 0 },
                   data: {
@@ -153,7 +152,6 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
 
       const canReuseExisting =
         existingNode !== undefined &&
-        existingNode.themeName === context.currentTheme.name &&
         ((resolvedParentId === undefined && !existingNode.data.parentNodeId) ||
           existingNode.data.parentNodeId === resolvedParentId) &&
         (existingNode.placeName.toLowerCase() === nodeAddOp.placeName.toLowerCase() ||
@@ -193,7 +191,6 @@ export async function processNodeAdds(context: ApplyUpdatesContext): Promise<voi
 
       const newNode: MapNode = {
         id: newNodeId,
-        themeName: context.currentTheme.name,
         placeName: nodeAddOp.placeName,
         position: { x: 0, y: 0 },
         data: newNodeData,

--- a/services/cartographer/promptBuilder.ts
+++ b/services/cartographer/promptBuilder.ts
@@ -13,7 +13,6 @@ export const buildCartographerPrompt = (
   narrativeContext: string,
 ): string => {
   const mapNodes = mapData.nodes
-    .filter(n => n.themeName === theme.name)
     .map(n => `- "${n.placeName}" (${n.data.nodeType})`)
     .join('\n');
 

--- a/services/cartographer/refineConnectorChains.ts
+++ b/services/cartographer/refineConnectorChains.ts
@@ -16,7 +16,7 @@ export async function refineConnectorChains(ctx: ApplyUpdatesContext): Promise<v
     sceneDescription: ctx.sceneDesc,
     logMessage: ctx.logMsg,
     currentTheme: ctx.currentTheme,
-    themeNodes: ctx.newMapData.nodes.filter(n => n.themeName === ctx.currentTheme.name),
+    themeNodes: ctx.newMapData.nodes,
   };
 
   while (chainRequests.length > 0 && refineAttempts < MAX_CHAIN_REFINEMENT_ROUNDS) {
@@ -81,7 +81,6 @@ export async function refineConnectorChains(ctx: ApplyUpdatesContext): Promise<v
         const newId = generateUniqueId(`node_${nAdd.placeName}_`);
         const node: MapNode = {
           id: newId,
-          themeName: ctx.currentTheme.name,
           placeName: nAdd.placeName,
           position: parent ? { ...parent.position } : { x: 0, y: 0 },
           data: { ...nodeData, parentNodeId: parentId },
@@ -145,9 +144,7 @@ export async function refineConnectorChains(ctx: ApplyUpdatesContext): Promise<v
           }
         }
       });
-      chainContext.themeNodes = ctx.newMapData.nodes.filter(
-        n => n.themeName === ctx.currentTheme.name
-      );
+      chainContext.themeNodes = ctx.newMapData.nodes;
     } else {
       console.warn(
         `Connector Chains Refinement failed after ${String(MAX_RETRIES)} attempts for round ${String(

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -109,7 +109,6 @@ export function isValidThemeFact(fact: unknown): fact is ThemeFact {
     typeof maybe.text === 'string' &&
     Array.isArray(maybe.entities) &&
     maybe.entities.every(id => typeof id === 'string') &&
-    typeof maybe.themeName === 'string' &&
     typeof maybe.createdTurn === 'number' &&
     typeof maybe.tier === 'number'
   );
@@ -161,7 +160,6 @@ export function isValidNPCForSave(npc: unknown): npc is NPC {
   return (
     typeof maybe.id === 'string' &&
     maybe.id.trim() !== '' &&
-    typeof maybe.themeName === 'string' &&
     typeof maybe.name === 'string' &&
     maybe.name.trim() !== '' &&
     typeof maybe.description === 'string' &&
@@ -210,7 +208,6 @@ export function isValidMapNode(node: unknown): node is MapNode {
   return (
     typeof maybe.id === 'string' &&
     maybe.id.trim() !== '' &&
-    typeof maybe.themeName === 'string' &&
     typeof maybe.placeName === 'string' &&
     maybe.placeName.trim() !== '' &&
     pos !== undefined &&

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -127,7 +127,7 @@ export const buildMainGameTurnPrompt = (
   const recentEventsContext = formatRecentEventsForPrompt(recentLogEntries);
   const arcContext = storyArc ? formatStoryArcContext(storyArc) : '';
 
-  const allNodesForCurrentTheme = fullMapData.nodes.filter(node => node.themeName === currentTheme.name);
+  const allNodesForCurrentTheme = fullMapData.nodes;
   const allEdgesForCurrentTheme = fullMapData.edges.filter(edge => {
     const sourceNode = allNodesForCurrentTheme.find(n => n.id === edge.sourceNodeId);
     const targetNode = allNodesForCurrentTheme.find(n => n.id === edge.targetNodeId);

--- a/services/storyteller/responseParser.ts
+++ b/services/storyteller/responseParser.ts
@@ -121,7 +121,6 @@ async function handleDialogueSetup(
                     NPCsForDialogueContext.push({
                         ...npcAdd,
                         id: buildNPCId(npcAdd.name),
-                        themeName: '',
                           presenceStatus: npcAdd.presenceStatus ?? 'unknown',
                           lastKnownLocation: npcAdd.lastKnownLocation ?? null,
                           preciseLocation: npcAdd.preciseLocation ?? null,
@@ -136,7 +135,6 @@ async function handleDialogueSetup(
                         name: npcUpd.name,
                           description: npcUpd.newDescription ?? existing?.description ?? 'Updated NPC',
                           aliases: npcUpd.newAliases ?? existing?.aliases ?? [],
-                        themeName: '',
                           presenceStatus: npcUpd.newPresenceStatus ?? existing?.presenceStatus ?? 'unknown',
                           lastKnownLocation: npcUpd.newLastKnownLocation ?? (existing?.lastKnownLocation ?? null),
                           preciseLocation: npcUpd.newPreciseLocation ?? (existing?.preciseLocation ?? null),
@@ -206,7 +204,6 @@ async function handleNPCChanges(
                     presenceStatus: originalNPCAdd.presenceStatus ?? 'unknown',
                     lastKnownLocation: originalNPCAdd.lastKnownLocation ?? null,
                     preciseLocation: originalNPCAdd.preciseLocation ?? null,
-                    themeName: '',
                 });
             } else {
                 console.warn(`parseAIResponse ('npcsAdded'): Invalid NPC structure for "${originalName ?? 'Unknown Name'}". Attempting correction.`);
@@ -228,7 +225,7 @@ async function handleNPCChanges(
                         preciseLocation: correctedDetails.preciseLocation,
                     };
                     if (isValidNewNPCPayload(correctedNPCAddPayload)) {
-                        finalNPCsAdded.push({ ...correctedNPCAddPayload, id: buildNPCId(correctedNPCAddPayload.name), themeName: '' } as NPC);
+                        finalNPCsAdded.push({ ...correctedNPCAddPayload, id: buildNPCId(correctedNPCAddPayload.name) } as NPC);
                         console.log(`parseAIResponse ('npcsAdded'): Successfully corrected NPC:`, correctedNPCAddPayload.name);
                     } else {
                         console.warn(`parseAIResponse ('npcsAdded'): Corrected NPC "${originalName ?? 'Unknown Name'}" still invalid. Discarding. Corrected Data:`, correctedNPCAddPayload);
@@ -341,7 +338,6 @@ async function handleNPCChanges(
                     name: targetName,
                     description: npcUpdatePayload.newDescription ?? `Details for ${targetName} are emerging.`,
                     aliases: npcUpdatePayload.newAliases ?? (npcUpdatePayload.addAlias ? [npcUpdatePayload.addAlias] : []),
-                    themeName: '',
                     presenceStatus: npcUpdatePayload.newPresenceStatus ?? 'unknown',
                     lastKnownLocation: npcUpdatePayload.newLastKnownLocation ?? null,
                     preciseLocation: npcUpdatePayload.newPreciseLocation ?? null,

--- a/tests/adjacentItems.test.ts
+++ b/tests/adjacentItems.test.ts
@@ -11,7 +11,6 @@ const makeNode = (
   parent = 'universe',
 ): MapData['nodes'][number] => ({
   id,
-  themeName: 'theme',
   placeName: id,
   position: { x: 0, y: 0 },
   data: { description: '', status, nodeType: 'location', parentNodeId: parent },

--- a/tests/applyUpdatesPartialId.test.ts
+++ b/tests/applyUpdatesPartialId.test.ts
@@ -24,7 +24,6 @@ const theme: AdventureTheme = { name: 'TestTheme' } as AdventureTheme;
 
 const existingFeature: MapNode = {
   id: 'node_gate_real1',
-  themeName: theme.name,
   placeName: 'Ancient Gate',
   position: { x: 0, y: 0 },
   data: {

--- a/tests/characterUtils.test.ts
+++ b/tests/characterUtils.test.ts
@@ -8,7 +8,7 @@ describe('npcUtils', () => {
       name: 'Alice',
       description: 'An adventurer',
     };
-    const result = applyAllNPCChanges([newNPC], [], 'theme', []);
+    const result = applyAllNPCChanges([newNPC], [], []);
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('Alice');
   });
@@ -18,7 +18,7 @@ describe('npcUtils', () => {
       name: 'Bob',
       description: 'NPC',
     };
-    const records = buildNPCChangeRecords([newNPC], [], 'theme', []);
+    const records = buildNPCChangeRecords([newNPC], [], []);
     expect(records[0].npcName).toBe('Bob');
     expect(records[0].type).toBe('add');
   });

--- a/tests/formatKnownPlacesForPrompt.test.ts
+++ b/tests/formatKnownPlacesForPrompt.test.ts
@@ -5,14 +5,12 @@ import type { MapNode } from '../types';
 const baseNodes: Array<MapNode> = [
   {
     id: 'loc1',
-    themeName: 'theme',
     placeName: 'Town',
     position: { x: 0, y: 0 },
     data: { description: 'Desc', status: 'discovered', nodeType: 'location' },
   },
   {
     id: 'loc2',
-    themeName: 'theme',
     placeName: 'Forest',
     position: { x: 0, y: 0 },
     data: { description: 'Trees', status: 'discovered', nodeType: 'location' },

--- a/tests/loremasterPromptDistill.test.ts
+++ b/tests/loremasterPromptDistill.test.ts
@@ -5,8 +5,8 @@ import type { ThemeFact } from '../types';
 describe('buildDistillFactsPrompt', () => {
   it('includes entity IDs for each fact', () => {
     const facts: Array<ThemeFact> = [
-      { id: 1, text: 'First fact', entities: ['a', 'b'], themeName: 'theme', createdTurn: 1, tier: 1 },
-      { id: 2, text: 'Second fact', entities: ['c'], themeName: 'theme', createdTurn: 1, tier: 1 },
+      { id: 1, text: 'First fact', entities: ['a', 'b'], createdTurn: 1, tier: 1 },
+      { id: 2, text: 'Second fact', entities: ['c'], createdTurn: 1, tier: 1 },
     ];
 
     const prompt = buildDistillFactsPrompt('theme', facts, null, null, [], [], []);

--- a/tests/mapGraphUtils.test.ts
+++ b/tests/mapGraphUtils.test.ts
@@ -18,7 +18,6 @@ type Node = MapData['nodes'][number];
 
 const makeNode = (id: string): Node => ({
   id,
-  themeName: 'theme',
   placeName: id,
   position: { x: 0, y: 0 },
   data: { description: '', status: 'discovered', nodeType: 'location', parentNodeId: 'universe' },

--- a/tests/mapNodeMatcher.test.ts
+++ b/tests/mapNodeMatcher.test.ts
@@ -7,28 +7,24 @@ const theme: AdventureTheme = { name: 'TestTheme' } as AdventureTheme;
 const nodes: Array<MapNode> = [
   {
     id: 'node_area',
-    themeName: theme.name,
     placeName: 'Coast',
     position: { x: 0, y: 0 },
     data: { description: '', aliases: ['Sea Side'], status: 'rumored', nodeType: 'location', parentNodeId: 'universe' }
   },
   {
     id: 'node_feature',
-    themeName: theme.name,
     placeName: 'Utility Entrance',
     position: { x: 0, y: 0 },
     data: { description: '', aliases: ['Utility Hatch'], status: 'rumored', nodeType: 'feature', parentNodeId: 'node_area' }
   },
   {
     id: 'node_alt_feature',
-    themeName: theme.name,
     placeName: 'Narrow Passage',
     position: { x: 0, y: 0 },
     data: { description: '', aliases: [], status: 'rumored', nodeType: 'feature', parentNodeId: 'node_area' }
   },
   {
     id: 'node_location_same_name',
-    themeName: theme.name,
     placeName: 'Narrow Passage',
     position: { x: 0, y: 0 },
     data: { description: '', aliases: [], status: 'rumored', nodeType: 'location', parentNodeId: 'universe' }
@@ -37,7 +33,7 @@ const nodes: Array<MapNode> = [
 
 const mapData: MapData = { nodes, edges: [] };
 
-const themeNodes = nodes.filter(n => n.themeName === theme.name);
+const themeNodes = nodes;
 
 describe('selectBestMatchingMapNode', () => {
   it('matches exact name', () => {

--- a/tests/mapPathfinding.test.ts
+++ b/tests/mapPathfinding.test.ts
@@ -4,7 +4,6 @@ import type { MapData, MapEdgeStatus } from '../types';
 
 const makeNode = (id: string, parentId = 'universe'): MapData['nodes'][number] => ({
   id,
-  themeName: 'theme',
   placeName: id,
   position: { x: 0, y: 0 },
   data: { description: '', status: 'discovered', nodeType: 'location', parentNodeId: parentId }

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -9,35 +9,30 @@ const mapData: MapData = {
   nodes: [
     {
       id: 'node_rim_test',
-      themeName: theme.name,
       placeName: 'Neo-Atlantic Rim',
       position: { x: 0, y: 0 },
       data: { description: 'waters', aliases: ['Open Waters', "The Rim"], status: 'rumored', nodeType: 'region', parentNodeId: 'universe' }
     },
     {
       id: 'node_coast_test',
-      themeName: theme.name,
       placeName: 'Coast',
       position: { x: 0, y: 0 },
       data: { description: 'distant coast', aliases: ['Coast', "Outpost"], status: 'rumored', nodeType: 'location', parentNodeId: 'universe' }
     },
     {
       id: 'node_coastal_outpost_test',
-      themeName: theme.name,
       placeName: 'Coastal Outpost',
       position: { x: 0, y: 0 },
       data: { description: 'coastal outpost', aliases: ['Outer Base', "Outpost"], status: 'rumored', nodeType: 'exterior', parentNodeId: 'node_coast_test' }
     },
     {
       id: 'node_utility_entrance_test',
-      themeName: theme.name,
       placeName: 'Utility Entrance',
       position: { x: 0, y: 0 },
       data: { description: 'utility entrance', aliases: ['Utility Hatch', 'Metal Door'], status: 'rumored', nodeType: 'feature', parentNodeId: 'node_coastal_outpost_test' }
     },
     {
       id: 'node_main_entrance_test',
-      themeName: theme.name,
       placeName: 'Main Entrance',
       position: { x: 0, y: 0 },
       data: { description: 'utility entrance', aliases: ['Marked Door', 'Yellow Door'], status: 'rumored', nodeType: 'feature', parentNodeId: 'node_coastal_outpost_test' }

--- a/types.ts
+++ b/types.ts
@@ -141,7 +141,6 @@ export interface DialogueSummaryRecord {
 
 export interface NPC {
   id: string;
-  themeName: string;
   name: string;
   description: string;
   aliases?: Array<string>;
@@ -297,7 +296,6 @@ export interface ThemeFact {
   id: number;
   text: string;
   entities: Array<string>;
-  themeName: string;
   createdTurn: number;
   tier: number;
 }
@@ -453,7 +451,6 @@ export interface MapNodeData {
 
 export interface MapNode {
   id: string; // Unique identifier for the node
-  themeName: string;
   placeName: string; // User-facing name of the location/feature. Must be unique within its theme.
   position: { x: number; y: number }; // For map visualization
   data: MapNodeData;

--- a/utils/gameLogicUtils.ts
+++ b/utils/gameLogicUtils.ts
@@ -40,19 +40,17 @@ export const applyThemeFactChanges = (
   state: FullGameState,
   changes: Array<ThemeFactChange>,
   currentTurn: number,
-  defaultThemeName?: string,
 ): void => {
   let nextId =
     state.themeFacts.length > 0 ? Math.max(...state.themeFacts.map(f => f.id)) + 1 : 1;
   for (const change of changes) {
     switch (change.action) {
       case 'add':
-        if (change.text && defaultThemeName) {
+        if (change.text) {
           const newFact: ThemeFact = {
             id: nextId++,
             text: change.text,
             entities: change.entities ?? [],
-            themeName: defaultThemeName,
             createdTurn: change.createdTurn ?? currentTurn,
             tier: change.tier ?? 1,
           };
@@ -67,7 +65,6 @@ export const applyThemeFactChanges = (
             text: change.text ?? state.themeFacts[idx].text,
             entities: change.entities ?? state.themeFacts[idx].entities,
             tier: change.tier ?? state.themeFacts[idx].tier,
-            themeName: state.themeFacts[idx].themeName,
           };
           state.themeFacts[idx] = updated;
         }

--- a/utils/highlightHelper.tsx
+++ b/utils/highlightHelper.tsx
@@ -195,13 +195,12 @@ export const highlightEntitiesInText = (
 
 /**
  * Builds a list of highlightable entities from inventory items, map nodes and
- * NPCs for the current theme.
+ * NPCs for the current game state.
  */
 export const buildHighlightableEntities = (
   inventory: Array<Item>,
   mapData: Array<MapNode>,
-  allNPCs: Array<NPC>,
-  currentThemeName: string | null
+  allNPCs: Array<NPC>
 ): Array<HighlightableEntity> => {
   const items: Array<HighlightableEntity> = inventory.map(item => ({
     name: item.name,
@@ -211,27 +210,19 @@ export const buildHighlightableEntities = (
     item,
   }));
 
-  const places: Array<HighlightableEntity> = currentThemeName
-    ? mapData
-        .filter(node => node.themeName === currentThemeName)
-        .map(node => ({
-          name: node.placeName,
-          type: 'place',
-          description: node.data.description,
-          aliases: node.data.aliases ?? [],
-        }))
-    : [];
+  const places: Array<HighlightableEntity> = mapData.map(node => ({
+    name: node.placeName,
+    type: 'place',
+    description: node.data.description,
+    aliases: node.data.aliases ?? [],
+  }));
 
-  const npcs: Array<HighlightableEntity> = currentThemeName
-    ? allNPCs
-        .filter(npc => npc.themeName === currentThemeName)
-        .map(npc => ({
-          name: npc.name,
-          type: 'npc',
-          description: npc.description,
-          aliases: npc.aliases,
-        }))
-    : [];
+  const npcs: Array<HighlightableEntity> = allNPCs.map(npc => ({
+    name: npc.name,
+    type: 'npc',
+    description: npc.description,
+    aliases: npc.aliases,
+  }));
 
   return [...items, ...places, ...npcs];
 };

--- a/utils/mapHierarchyUpgradeUtils.ts
+++ b/utils/mapHierarchyUpgradeUtils.ts
@@ -129,7 +129,6 @@ export const upgradeFeatureToRegion = (
   const connectorId = generateUniqueId(`node_${connectorName}_`);
   const connectorNode: MapNode = {
     id: connectorId,
-    themeName: featureNode.themeName,
     placeName: connectorName,
     position: { ...featureNode.position },
     data: {

--- a/utils/mapLayoutUtils.ts
+++ b/utils/mapLayoutUtils.ts
@@ -134,7 +134,6 @@ export const applyNestedCircleLayout = (
   childrenByParent.set(pseudoRootId, rootIds);
   const pseudoRootNode: MapNode = {
     id: pseudoRootId,
-    themeName: 'root',
     placeName: 'root',
     position: { x: 0, y: 0 },
     data: { description: 'root', nodeType: 'region', status: 'discovered' },

--- a/utils/mapUpdateHandlers.ts
+++ b/utils/mapUpdateHandlers.ts
@@ -48,7 +48,7 @@ export const handleMapUpdates = async (
     const originalLoadingReason = loadingReason;
     setLoadingReason('map');
     const knownMainMapNodesForTheme: Array<MapNode> = draftState.mapData.nodes.filter(
-      node => node.themeName === themeContextForResponse.name && node.data.nodeType !== 'feature'
+      node => node.data.nodeType !== 'feature'
     );
     mapUpdateResult = await updateMapFromAIData_Service(
       aiData,
@@ -119,7 +119,7 @@ export const handleMapUpdates = async (
     }
 
       const renameResults = await assignSpecificNamesToDuplicateNodes_Service(
-        draftState.mapData.nodes.filter(n => n.themeName === themeContextForResponse.name),
+        draftState.mapData.nodes,
         themeContextForResponse,
         mapUpdateResult?.debugInfo?.minimalModelCalls,
       );
@@ -158,17 +158,16 @@ export const handleMapUpdates = async (
     (mapUpdateResult?.newlyAddedEdges ?? []).map(e => e.id)
   );
 
-  const themeName = themeContextForResponse.name;
   const npcsAddedFromAI = ('npcsAdded' in aiData && aiData.npcsAdded ? aiData.npcsAdded : []) as Array<ValidNewNPCPayload>;
   const npcsUpdatedFromAI = ('npcsUpdated' in aiData && aiData.npcsUpdated ? aiData.npcsUpdated : []) as Array<ValidNPCUpdatePayload>;
   if (npcsAddedFromAI.length > 0 || npcsUpdatedFromAI.length > 0) {
-    turnChanges.npcChanges = buildNPCChangeRecords(npcsAddedFromAI, npcsUpdatedFromAI, themeName, draftState.allNPCs);
-    draftState.allNPCs = applyAllNPCChanges(npcsAddedFromAI, npcsUpdatedFromAI, themeName, draftState.allNPCs);
+    turnChanges.npcChanges = buildNPCChangeRecords(npcsAddedFromAI, npcsUpdatedFromAI, draftState.allNPCs);
+    draftState.allNPCs = applyAllNPCChanges(npcsAddedFromAI, npcsUpdatedFromAI, draftState.allNPCs);
   }
 
   const oldMapNodeId = baseStateSnapshot.currentMapNodeId;
   let finalChosenNodeId: string | null = oldMapNodeId;
-  const currentThemeNodesFromDraftState = draftState.mapData.nodes.filter(n => n.themeName === themeContextForResponse.name);
+  const currentThemeNodesFromDraftState = draftState.mapData.nodes;
 
   if (mapAISuggestedNodeIdentifier) {
     const matchResult = attemptMatchAndSetNode(mapAISuggestedNodeIdentifier, 'mapAI', oldMapNodeId, themeContextForResponse.name, currentThemeNodesFromDraftState);

--- a/utils/npcUtils.ts
+++ b/utils/npcUtils.ts
@@ -14,7 +14,6 @@ import { buildNPCId } from './entityUtils';
 export const buildNPCChangeRecords = (
   npcsAddedFromAI: Array<ValidNewNPCPayload>,
   npcsUpdatedFromAI: Array<ValidNPCUpdatePayload>,
-  currentThemeName: string,
   currentAllNPCs: Array<NPC>,
 ): Array<NPCChangeRecord> => {
   const records: Array<NPCChangeRecord> = [];
@@ -22,7 +21,6 @@ export const buildNPCChangeRecords = (
     const newNPC: NPC = {
       ...npcAdd,
       id: buildNPCId(npcAdd.name),
-      themeName: currentThemeName,
       aliases: npcAdd.aliases ?? [],
       presenceStatus: npcAdd.presenceStatus ?? 'unknown',
       lastKnownLocation: npcAdd.lastKnownLocation ?? null,
@@ -34,7 +32,7 @@ export const buildNPCChangeRecords = (
 
   npcsUpdatedFromAI.forEach(npcUpdate => {
     const oldNPC = currentAllNPCs.find(
-      npc => npc.name === npcUpdate.name && npc.themeName === currentThemeName,
+      npc => npc.name === npcUpdate.name,
     );
     if (oldNPC) {
       const newNPCData: NPC = { ...oldNPC, dialogueSummaries: oldNPC.dialogueSummaries ?? [] };
@@ -67,16 +65,14 @@ export const buildNPCChangeRecords = (
 export const applyAllNPCChanges = (
   npcsAddedFromAI: Array<ValidNewNPCPayload>,
   npcsUpdatedFromAI: Array<ValidNPCUpdatePayload>,
-  currentThemeName: string,
   currentAllNPCs: Array<NPC>,
 ): Array<NPC> => {
   const newAllNPCs = [...currentAllNPCs];
   npcsAddedFromAI.forEach(npcAdd => {
-    if (!newAllNPCs.some(npc => npc.name === npcAdd.name && npc.themeName === currentThemeName)) {
+    if (!newAllNPCs.some(npc => npc.name === npcAdd.name)) {
       const newNPC: NPC = {
         ...npcAdd,
         id: buildNPCId(npcAdd.name),
-        themeName: currentThemeName,
         aliases: npcAdd.aliases ?? [],
         presenceStatus: npcAdd.presenceStatus ?? 'unknown',
         lastKnownLocation: npcAdd.lastKnownLocation ?? null,
@@ -92,7 +88,7 @@ export const applyAllNPCChanges = (
 
   npcsUpdatedFromAI.forEach(npcUpdate => {
     const idx = newAllNPCs.findIndex(
-      npc => npc.name === npcUpdate.name && npc.themeName === currentThemeName,
+      npc => npc.name === npcUpdate.name,
     );
     if (idx !== -1) {
       const npcToUpdate: NPC = {


### PR DESCRIPTION
## Summary
- drop theme-based filtering when listing map nodes and highlightable entities
- update UI components to stop passing currentThemeName unnecessarily
- simplify MapDisplay logic to always return all nodes and edges

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886362d36188324923f8c760c53d8a7