### PR TITLE
Refactor theme state

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -406,7 +406,7 @@ function App() {
     openPageView(PLAYER_JOURNAL_ID, playerJournal.length);
     void (async () => {
       if (!currentTheme) { setIsPlayerJournalWriting(false); return; }
-      const { name: themeName, themeGuidance } = currentTheme;
+      const { name: themeName, storyGuidance } = currentTheme;
       const nodes = mapData.nodes.filter(
         node => node.data.nodeType !== 'feature' && node.data.nodeType !== 'room'
       );
@@ -422,7 +422,7 @@ function App() {
         'Your own journal',
         prev,
         themeName,
-        themeGuidance,
+        storyGuidance,
         currentScene,
         lastDebugPacket?.storytellerThoughts?.slice(-1)[0] ?? '',
         knownPlaces,

--- a/components/debug/tabs/MiscStateTab.tsx
+++ b/components/debug/tabs/MiscStateTab.tsx
@@ -11,7 +11,7 @@ function MiscStateTab({ currentState }: MiscStateTabProps) {
       content={{
       currentMapNodeId: currentState.currentMapNodeId,
       currentObjective: currentState.currentObjective,
-      currentThemeName: currentState.currentThemeName,
+      currentThemeName: currentState.currentTheme?.name ?? null,
       globalTurnNumber: currentState.globalTurnNumber,
       lastTurnChangesBrief: currentState.lastTurnChanges ? {
         npcs: currentState.lastTurnChanges.npcChanges.length,

--- a/components/elements/ThemeCard.tsx
+++ b/components/elements/ThemeCard.tsx
@@ -28,7 +28,7 @@ function ThemeCard({ theme, onSelect, disabled = false }: ThemeCardProps) {
           </h3>
 
           <p className="text-sm text-slate-300 leading-snug line-clamp-8">
-            {theme.themeGuidance}
+            {theme.storyGuidance}
           </p>
 
           {disabled ? (

--- a/components/modals/PageView.tsx
+++ b/components/modals/PageView.tsx
@@ -142,7 +142,7 @@ function PageView({
     [unlockedChapterCount, isBook, isJournal]
   );
 
-  const { name: themeName, themeGuidance: themeDescription } = currentTheme;
+  const { name: themeName, storyGuidance: themeDescription } = currentTheme;
 
   const handleToggleDecoded = useCallback(() => {
     setShowDecoded(prev => !prev);

--- a/docs/worldGenPrompts.md
+++ b/docs/worldGenPrompts.md
@@ -32,7 +32,7 @@ let heroName: string;
 
 ## 3. World Facts
 
-*Prompt*: "Using the `themeGuidance` from `chosenTheme`, expand it into a consistent world profile. Provide at least eight attributes that remain stable throughout the story. Cover geography, climate, major factions, technology or magic level, key resources, cultural customs, notable locations, and any supernatural forces."
+*Prompt*: "Using the `storyGuidance` from `chosenTheme`, expand it into a consistent world profile. Provide at least eight attributes that remain stable throughout the story. Cover geography, climate, major factions, technology or magic level, key resources, cultural customs, notable locations, and any supernatural forces."
 
 *Data Stored*:
 ```ts

--- a/hooks/saveSnapshotHelpers.ts
+++ b/hooks/saveSnapshotHelpers.ts
@@ -34,6 +34,6 @@ export const buildSaveStateSnapshot = (
     mapLayoutConfig: currentState.mapLayoutConfig,
     mapViewBox: currentState.mapViewBox,
     globalTurnNumber: currentState.globalTurnNumber,
-    currentThemeObject: currentState.currentThemeObject,
+    currentTheme: currentState.currentTheme,
   };
 };

--- a/hooks/useDialogueSummary.ts
+++ b/hooks/useDialogueSummary.ts
@@ -66,7 +66,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
    * Finalizes a dialogue session and gathers summary updates.
    */
   const initiateDialogueExit = useCallback(async (stateAtDialogueConclusionStart: FullGameState) => {
-    const currentThemeObj = stateAtDialogueConclusionStart.currentThemeObject;
+    const currentThemeObj = stateAtDialogueConclusionStart.currentTheme;
     const finalHistory = stateAtDialogueConclusionStart.dialogueState?.history ?? [];
     const finalParticipants = stateAtDialogueConclusionStart.dialogueState?.participants ?? [];
 
@@ -94,7 +94,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
     setLoadingReason('dialogue_memory_creation');
     const memorySummaryContext: DialogueMemorySummaryContext = {
       themeName: currentThemeObj.name,
-      currentThemeObject: currentThemeObj,
+      currentTheme: currentThemeObj,
       currentScene: workingGameState.currentScene,
       localTime: workingGameState.localTime,
       localEnvironment: workingGameState.localEnvironment,
@@ -142,7 +142,7 @@ export const useDialogueSummary = (props: UseDialogueSummaryProps) => {
       dialogueLog: finalHistory,
       dialogueParticipants: finalParticipants,
       themeName: currentThemeObj.name,
-      currentThemeObject: currentThemeObj,
+      currentTheme: currentThemeObj,
       storyArc: workingGameState.storyArc,
     };
     const {

--- a/hooks/useDialogueTurn.ts
+++ b/hooks/useDialogueTurn.ts
@@ -46,7 +46,7 @@ export const useDialogueTurn = (props: UseDialogueTurnProps) => {
 
   const handleDialogueOptionSelect = useCallback(async (option: string) => {
     const currentFullState = getCurrentGameState();
-    const currentThemeObj = currentFullState.currentThemeObject;
+    const currentThemeObj = currentFullState.currentTheme;
 
     if (!currentThemeObj || !currentFullState.dialogueState || isDialogueExiting) return;
 

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -231,7 +231,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     setLoadingReason: setLoadingReasonRef,
     onDialogueConcluded: (summaryPayload, preparedGameState, debugInfo) => {
       const draftState = structuredCloneGameState(preparedGameState);
-      return processAiResponse(summaryPayload, preparedGameState.currentThemeObject, draftState, {
+      return processAiResponse(summaryPayload, preparedGameState.currentTheme, draftState, {
         baseStateSnapshot: structuredCloneGameState(preparedGameState),
         isFromDialogueSummary: true,
         playerActionText: undefined,
@@ -340,7 +340,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
 
   const handleDistillFacts = useCallback(async () => {
     const currentFullState = getCurrentGameState();
-    const themeObj = currentFullState.currentThemeObject;
+    const themeObj = currentFullState.currentTheme;
     if (!themeObj) return;
     setIsLoading(true);
     setError(null);
@@ -436,7 +436,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
   const mainQuest = currentAct?.mainObjective ?? null;
 
   return {
-    currentTheme: currentFullState.currentThemeObject,
+    currentTheme: currentFullState.currentTheme,
     currentScene: currentFullState.currentScene,
     actionOptions: currentFullState.actionOptions,
     mainQuest,

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -108,7 +108,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
 
   const runDistillIfNeeded = useCallback(
     async (state: FullGameState) => {
-      const themeObj = state.currentThemeObject;
+      const themeObj = state.currentTheme;
       if (!themeObj) return;
       if (
         state.globalTurnNumber > 0 &&
@@ -194,7 +194,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       const baseStateSnapshot = structuredCloneGameState(currentFullState);
       const scoreChangeFromAction = isFreeForm ? -FREE_FORM_ACTION_COST : 0;
 
-      const currentThemeObj = currentFullState.currentThemeObject;
+      const currentThemeObj = currentFullState.currentTheme;
       if (!currentThemeObj) {
         setError('Critical error: Current theme object not found. Cannot proceed.');
         setIsLoading(false);
@@ -492,16 +492,16 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
   const triggerMainQuestAchieved = useCallback(async () => {
     const currentState = getCurrentGameState();
     const {
-      currentThemeObject,
+      currentTheme,
       storyArc,
       worldFacts,
       heroSheet,
     } = currentState;
-    if (!currentThemeObject || !storyArc || !worldFacts || !heroSheet) return;
+    if (!currentTheme || !storyArc || !worldFacts || !heroSheet) return;
 
     const draftState = structuredCloneGameState(currentState);
     const newAct = await generateNextStoryAct(
-      currentThemeObject,
+      currentTheme,
       worldFacts,
       heroSheet,
       storyArc,

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -618,7 +618,7 @@ export const useProcessAiResponse = ({
             if (!target) continue;
             const chapter = change.item.chapters?.[0];
             if (!chapter) continue;
-            const { name: themeName, themeGuidance } = themeContextForResponse;
+            const { name: themeName, storyGuidance } = themeContextForResponse;
             const nodes = draftState.mapData.nodes.filter(
               n => n.data.nodeType !== 'feature' && n.data.nodeType !== 'room'
             );
@@ -634,7 +634,7 @@ export const useProcessAiResponse = ({
               chapter.description,
               chapter.contentLength,
               themeName,
-              themeGuidance,
+              storyGuidance,
               draftState.currentScene,
               thoughts,
               knownPlaces,
@@ -652,7 +652,7 @@ export const useProcessAiResponse = ({
                   chapter.description,
                   chapter.contentLength,
                   themeName,
-                  themeGuidance,
+                  storyGuidance,
                   draftState.currentScene,
                   thoughts,
                   knownPlaces,
@@ -757,12 +757,12 @@ export const useProcessAiResponse = ({
       if (
         turnChanges.mainQuestAchieved &&
         draftState.storyArc &&
-        draftState.currentThemeObject &&
+        draftState.currentTheme &&
         draftState.worldFacts &&
         draftState.heroSheet
       ) {
         const newAct = await generateNextStoryAct(
-          draftState.currentThemeObject,
+          draftState.currentTheme,
           draftState.worldFacts,
           draftState.heroSheet,
           draftState.storyArc,

--- a/services/cartographer/promptBuilder.ts
+++ b/services/cartographer/promptBuilder.ts
@@ -36,7 +36,7 @@ export const buildMapUpdatePrompt = (
   storyArc?: StoryArc | null,
 ): string => `## Narrative Context for Map Update:
   - Current Theme: "${currentTheme.name}";
-  - Theme Guidance: "${currentTheme.themeGuidance}";
+  - Theme Guidance: "${currentTheme.storyGuidance}";
 ${storyArc ? `  - Current Arc: "${storyArc.title}" (Act ${String(storyArc.currentAct)}: ${storyArc.acts[storyArc.currentAct - 1].title});\n` : ''}
   - Scene Description: "${sceneDesc}";
   - Log Message (outcome of last action): "${logMsg}";

--- a/services/corrections/dialogue.ts
+++ b/services/corrections/dialogue.ts
@@ -59,7 +59,7 @@ ${malformedString}
 Narrative Context:
 - Log Message: "${logMessageContext ?? 'Not specified'}"
 - Scene Description: "${sceneDescriptionContext ?? 'Not specified'}"
-- Theme Guidance: "${currentTheme.themeGuidance}"
+- Theme Guidance: "${currentTheme.storyGuidance}"
 - Known/Available NPCs for Dialogue: ${npcContext}
 - Known Map Locations: ${placeContext}
 - Player Inventory: ${inventoryContext}
@@ -123,7 +123,7 @@ export const fetchCorrectedDialogueTurn_Service = async (
 
   const prompt = `Role: You fix malformed JSON for a dialogue turn in a text adventure game.
 
-Theme Guidance: "${currentTheme.themeGuidance}"
+Theme Guidance: "${currentTheme.storyGuidance}"
 
 Malformed Dialogue Response:
 \`\`\`

--- a/services/corrections/edgeFixes.ts
+++ b/services/corrections/edgeFixes.ts
@@ -293,7 +293,7 @@ export const fetchConnectorChains_Service = async (
   const prompt = `Suggest chains of locations (feature nodes) to connect distant map nodes in a text adventure.
 ** Context: **
 Scene Description: "${context.sceneDescription}"
-Theme: "${context.currentTheme.name}" (${context.currentTheme.themeGuidance})
+Theme: "${context.currentTheme.name}" (${context.currentTheme.storyGuidance})
 
 ---
 

--- a/services/corrections/inventory.ts
+++ b/services/corrections/inventory.ts
@@ -56,7 +56,7 @@ ${malformedResponseText}
 - Current Place ID: "${currentNodeId ?? 'unknown'}"
 - Companions: ${companionsContext}
 - Nearby NPCs: ${nearbyNpcsContext}
-- Theme Guidance: "${currentTheme.themeGuidance || 'General adventure theme.'}"
+- Theme Guidance: "${currentTheme.storyGuidance || 'General adventure theme.'}"
 
 Task: Provide ONLY the corrected JSON array of ItemChange objects.`;
 

--- a/services/corrections/item.ts
+++ b/services/corrections/item.ts
@@ -128,7 +128,7 @@ ${malformedPayloadString}
 ## Narrative Context:
 - Log Message: "${logMessage ?? 'Not specified, infer from scene.'}"
 - Scene Description: "${sceneDescription ?? 'Not specified, infer from log.'}"
-- Theme Guidance: "${currentTheme.themeGuidance}"
+- Theme Guidance: "${currentTheme.storyGuidance}"
 
 Required JSON Structure for the corrected 'item' field:
 ${baseItemStructureForPrompt}
@@ -206,7 +206,7 @@ ${malformedItemChangeString}
 Narrative Context:
 - Log Message: "${logMessage ?? 'Not specified, infer from scene.'}"
 - Scene Description: "${sceneDescription ?? 'Not specified, infer from log.'}"
-- Theme Guidance: "${currentTheme.themeGuidance}"
+- Theme Guidance: "${currentTheme.storyGuidance}"
 
 Task: Based on the Log Message, Scene Description, and the 'item' details in the malformed object, determine the most logical 'action' ("create", "destroy", "change", "addDetails", or "move") that was intended.
 - "create": A new item appeared.
@@ -282,7 +282,7 @@ export const fetchCorrectedItemTag_Service = async (
 Candidate tag: "${proposedTag}"
 Item name: "${itemName}"
 Description: "${itemDescription}"
-Theme Guidance: "${currentTheme.themeGuidance}"
+Theme Guidance: "${currentTheme.storyGuidance}"
 Valid tags: ${VALID_TAGS_STRING}
 Respond ONLY with the single best tag.`;
 
@@ -402,7 +402,7 @@ ${malformedPayloadString}
 
 Log Message: "${logMessage ?? 'Not specified'}"
 Scene Description: "${sceneDescription ?? 'Not specified'}"
-Theme Guidance: "${currentTheme.themeGuidance}"
+Theme Guidance: "${currentTheme.storyGuidance}"
 
 Task: Provide ONLY the corrected JSON object with fields { "id": string, "name": string, "type": (${VALID_ITEM_TYPES_STRING}), "knownUses"?, "tags"?, "chapters"? }.`;
 

--- a/services/corrections/mapUpdatePayload.ts
+++ b/services/corrections/mapUpdatePayload.ts
@@ -38,7 +38,7 @@ export const fetchCorrectedMapUpdatePayload_Service = async (
   const prompt = `You are an AI assistant fixing a malformed map update payload for a text adventure game.
 \nMalformed JSON:\n\`\`\`json\n${malformedJson}\n\`\`\`\nValidation Error: "${validationError ?? 'Unknown'}"\nRespond ONLY with the corrected JSON object.`;
 
-  const systemInstruction = `Correct the map update payload so it adheres to the expected structure. Valid node types: ${VALID_NODE_TYPE_STRING}. Valid node statuses: ${VALID_NODE_STATUS_STRING}. Valid edge types: ${VALID_EDGE_TYPE_STRING}. Valid edge statuses: ${VALID_EDGE_STATUS_STRING}. ${NODE_DESCRIPTION_INSTRUCTION} ${EDGE_DESCRIPTION_INSTRUCTION} ${ALIAS_INSTRUCTION} Theme Guidance: ${currentTheme.themeGuidance}`;
+  const systemInstruction = `Correct the map update payload so it adheres to the expected structure. Valid node types: ${VALID_NODE_TYPE_STRING}. Valid node statuses: ${VALID_NODE_STATUS_STRING}. Valid edge types: ${VALID_EDGE_TYPE_STRING}. Valid edge statuses: ${VALID_EDGE_STATUS_STRING}. ${NODE_DESCRIPTION_INSTRUCTION} ${EDGE_DESCRIPTION_INSTRUCTION} ${ALIAS_INSTRUCTION} Theme Guidance: ${currentTheme.storyGuidance}`;
 
   return retryAiCall<AIMapUpdatePayload>(async attempt => {
     try {

--- a/services/corrections/name.ts
+++ b/services/corrections/name.ts
@@ -53,7 +53,7 @@ Task: Based on the context and the list of valid names, determine the correct fu
 Respond ONLY with the single, corrected ${entityTypeToCorrect} name as a string.
 If no suitable match can be confidently made, respond with an empty string.`;
 
-  const systemInstruction = `Your task is to match a malformed ${entityTypeToCorrect} name against a provided list of valid names, using narrative context. Respond ONLY with the best-matched string from the valid list, or an empty string if no confident match is found. Adhere to the theme context: ${currentTheme.themeGuidance}`;
+  const systemInstruction = `Your task is to match a malformed ${entityTypeToCorrect} name against a provided list of valid names, using narrative context. Respond ONLY with the best-matched string from the valid list, or an empty string if no confident match is found. Adhere to the theme context: ${currentTheme.storyGuidance}`;
 
   return retryAiCall<string>(async attempt => {
     try {

--- a/services/corrections/npc.ts
+++ b/services/corrections/npc.ts
@@ -57,7 +57,7 @@ Context:
 - Log Message (how they appeared/what they're doing): "${logMessage ?? 'Not specified, infer from scene.'}"
 - Scene Description (where they appeared/are relevant): "${sceneDescription ?? 'Not specified, infer from log.'}"
 - ${knownPlacesString}
-- Theme Guidance (influences NPC style/role): "${currentTheme.themeGuidance}"
+- Theme Guidance (influences NPC style/role): "${currentTheme.storyGuidance}"
 
 Respond ONLY in JSON format with the following structure:
 {
@@ -168,7 +168,7 @@ Example Response: "near you"
 Example Response: If unclear from context, respond with a generic but plausible short phrase like "observing the surroundings" or "standing nearby".
 `;
 
-  const systemInstruction = `Infer or correct the NPC's "preciseLocation" (a short phrase, max ~50-60 chars, describing their in-scene activity/position) from narrative context and potentially malformed input. Respond ONLY with the string value. Adhere to theme context: ${currentTheme.themeGuidance}`;
+  const systemInstruction = `Infer or correct the NPC's "preciseLocation" (a short phrase, max ~50-60 chars, describing their in-scene activity/position) from narrative context and potentially malformed input. Respond ONLY with the string value. Adhere to theme context: ${currentTheme.storyGuidance}`;
 
   return retryAiCall<string>(async attempt => {
     try {

--- a/services/corrections/placeDetails.ts
+++ b/services/corrections/placeDetails.ts
@@ -56,7 +56,7 @@ Determine the most logical "localPlace" based on the provided context. This "loc
 
 ## Context for Inference:
 - Current Scene Description (primary source for inference): "${currentSceneDescription}"
-- Current Theme: "${currentTheme.name}" (Theme Guidance: ${currentTheme.themeGuidance})
+- Current Theme: "${currentTheme.name}" (Theme Guidance: ${currentTheme.storyGuidance})
 - Current Local Time: "${localTime ?? 'Unknown'}"
 - Current Local Environment: "${localEnvironment ?? 'Undetermined'}"
 
@@ -144,7 +144,7 @@ ${malformedMapNodePayloadString}
 ## Narrative Context:
 - Log Message: "${logMessageContext ?? 'Not specified'}"
 - Scene Description: "${sceneDescriptionContext ?? 'Not specified'}"
-- Theme Guidance: "${currentTheme.themeGuidance}"
+- Theme Guidance: "${currentTheme.storyGuidance}"
 
 Required JSON Structure for corrected map location details:
 {
@@ -220,7 +220,7 @@ Map Location Name to Detail: "${mapNodePlaceName}"
 ## Narrative Context:
 - Log Message: "${logMessageContext ?? 'Not specified'}"
 - Scene Description: "${sceneDescriptionContext ?? 'Not specified'}"
-- Theme Guidance: "${currentTheme.themeGuidance}"
+- Theme Guidance: "${currentTheme.storyGuidance}"
 
 Required JSON Structure:
 {

--- a/services/dialogue/api.ts
+++ b/services/dialogue/api.ts
@@ -202,12 +202,12 @@ export const executeDialogueSummary = async (
     return Promise.reject(new Error('API Key not configured.'));
   }
 
-  if (!summaryContext.currentThemeObject) {
-    console.error('DialogueSummaryContext missing currentThemeObject. Cannot summarize dialogue.');
-    return Promise.reject(new Error('DialogueSummaryContext missing currentThemeObject.'));
+  if (!summaryContext.currentTheme) {
+    console.error('DialogueSummaryContext missing currentTheme. Cannot summarize dialogue.');
+    return Promise.reject(new Error('DialogueSummaryContext missing currentTheme.'));
   }
 
-  const themeObject = summaryContext.currentThemeObject;
+  const themeObject = summaryContext.currentTheme;
 
   const prompt = buildDialogueSummaryPrompt(summaryContext);
 
@@ -282,8 +282,8 @@ export const executeMemorySummary = async (
     console.error('API Key not configured for Dialogue Memory Summary Service.');
     return null;
   }
-  if (!context.currentThemeObject) {
-    console.error('DialogueMemorySummaryContext missing currentThemeObject. Cannot summarize memory.');
+  if (!context.currentTheme) {
+    console.error('DialogueMemorySummaryContext missing currentTheme. Cannot summarize memory.');
     return null;
   }
 

--- a/services/dialogue/promptBuilder.ts
+++ b/services/dialogue/promptBuilder.ts
@@ -118,7 +118,7 @@ export const buildDialogueTurnPrompt = (
       : 'None';
 
   return `**Context for Dialogue Turn**
-${arcContext ? `Narrative Arc:\n${arcContext}\n` : `Current Theme: "${currentTheme.name}";\nTheme Guidance: "${currentTheme.themeGuidance}";`}
+${arcContext ? `Narrative Arc:\n${arcContext}\n` : `Current Theme: "${currentTheme.name}";\nTheme Guidance: "${currentTheme.storyGuidance}";`}
 Current Main Quest: "${currentQuest ?? 'Not set'}";
 Current Objective: "${currentObjective ?? 'Not set'}";
 Scene Description (for environmental context): "${currentScene}";
@@ -195,7 +195,7 @@ export const buildDialogueSummaryPrompt = (
 
   return `
  Context for Dialogue Summary:
-${summaryContext.storyArc ? `Narrative Arc: ${summaryContext.storyArc.title} (Act ${String(summaryContext.storyArc.currentAct)}: ${summaryContext.storyArc.acts[summaryContext.storyArc.currentAct - 1].title})` : `Current Theme: "${summaryContext.currentThemeObject?.name ?? summaryContext.themeName}"\n- Theme Guidance: "${summaryContext.currentThemeObject?.themeGuidance ?? 'None'}"`}
+${summaryContext.storyArc ? `Narrative Arc: ${summaryContext.storyArc.title} (Act ${String(summaryContext.storyArc.currentAct)}: ${summaryContext.storyArc.acts[summaryContext.storyArc.currentAct - 1].title})` : `Current Theme: "${summaryContext.currentTheme?.name ?? summaryContext.themeName}"\n- Theme Guidance: "${summaryContext.currentTheme?.storyGuidance ?? 'None'}"`}
 - Current Main Quest (before dialogue): "${summaryContext.mainQuest ?? 'Not set'}"
 - Current Objective (before dialogue): "${summaryContext.currentObjective ?? 'Not set'}"
 - Scene Description (when dialogue started): "${summaryContext.currentScene}"
@@ -244,7 +244,7 @@ Output ONLY the summary text. Do NOT use JSON or formatting. Do NOT include any 
 
   const userPromptPart = `Generate a memory summary for the following conversation:
 - Conversation Participants: ${context.dialogueParticipants.join(', ')}
-${context.storyArc ? `- Narrative Arc: ${context.storyArc.title} (Act ${String(context.storyArc.currentAct)}: ${context.storyArc.acts[context.storyArc.currentAct - 1].title})` : `- Theme: "${context.currentThemeObject?.name ?? context.themeName}" (${context.currentThemeObject?.themeGuidance ?? 'None'})`}
+${context.storyArc ? `- Narrative Arc: ${context.storyArc.title} (Act ${String(context.storyArc.currentAct)}: ${context.storyArc.acts[context.storyArc.currentAct - 1].title})` : `- Theme: "${context.currentTheme?.name ?? context.themeName}" (${context.currentTheme?.storyGuidance ?? 'None'})`}
 - Scene at the start of conversation: "${context.currentScene}"
 - Context: Time: "${context.localTime ?? 'Unknown'}", Environment: "${context.localEnvironment ?? 'Undetermined'}", Place: "${context.localPlace ?? 'Undetermined'}"
 

--- a/services/saveLoad/validators.ts
+++ b/services/saveLoad/validators.ts
@@ -264,7 +264,7 @@ export function isValidAdventureThemeObject(obj: unknown): obj is AdventureTheme
   return (
     typeof maybe.name === 'string' &&
     maybe.name.trim() !== '' &&
-    typeof maybe.themeGuidance === 'string' &&
+    typeof maybe.storyGuidance === 'string' &&
     typeof maybe.playerJournalStyle === 'string'
   );
 }
@@ -281,7 +281,7 @@ export function validateSavedGameState(data: unknown): data is SavedGameDataShap
   }
 
   const fields: Array<keyof SavedGameDataShape> = [
-    'currentThemeName', 'currentThemeObject', 'currentScene', 'actionOptions', 'mainQuest', 'currentObjective',
+    'currentTheme', 'currentScene', 'actionOptions', 'mainQuest', 'currentObjective',
     'inventory', 'playerJournal', 'lastJournalWriteTurn', 'lastJournalInspectTurn', 'lastLoreDistillTurn', 'gameLog', 'lastActionLog', 'themeFacts', 'worldFacts', 'heroSheet', 'heroBackstory',
     'allNPCs', 'mapData', 'currentMapNodeId', 'destinationNodeId', 'mapLayoutConfig', 'mapViewBox', 'score',
     'localTime', 'localEnvironment', 'localPlace', 'enabledThemePacks', 'playerGender',
@@ -290,8 +290,7 @@ export function validateSavedGameState(data: unknown): data is SavedGameDataShap
   for (const field of fields) {
     if (!(field in obj)) {
       const nullableFields: Array<keyof SavedGameDataShape> = [
-        'currentThemeName',
-        'currentThemeObject',
+        'currentTheme',
         'mainQuest',
         'currentObjective',
         'lastActionLog',
@@ -318,8 +317,7 @@ export function validateSavedGameState(data: unknown): data is SavedGameDataShap
     }
   }
 
-  if (obj.currentThemeName !== null && typeof obj.currentThemeName !== 'string') { console.warn('Invalid save data (V3): currentThemeName type.'); return false; }
-  if (obj.currentThemeObject !== null && !isValidAdventureThemeObject(obj.currentThemeObject)) { console.warn('Invalid save data (V3): currentThemeObject type or structure.'); return false; }
+  if (obj.currentTheme !== null && !isValidAdventureThemeObject(obj.currentTheme)) { console.warn('Invalid save data (V3): currentTheme type or structure.'); return false; }
   if (typeof obj.currentScene !== 'string') { console.warn('Invalid save data (V3): currentScene type.'); return false; }
   if (!Array.isArray(obj.actionOptions) || !obj.actionOptions.every((opt: unknown) => typeof opt === 'string')) { console.warn('Invalid save data (V3): actionOptions.'); return false; }
   if (obj.mainQuest !== null && typeof obj.mainQuest !== 'string') { console.warn('Invalid save data (V3): mainQuest type.'); return false; }

--- a/services/storyteller/promptBuilder.ts
+++ b/services/storyteller/promptBuilder.ts
@@ -43,7 +43,7 @@ export const buildNewGameFirstTurnPrompt = (
   const heroDescription = formatHeroSheetForPrompt(heroSheet, true);
   const heroPast = formatHeroBackstoryForPrompt(heroBackstory);
   const arcContext = storyArc ? formatStoryArcContext(storyArc) : '';
-  const prompt = `Start a new adventure in the theme "${theme.name}". ${theme.themeGuidance}
+  const prompt = `Start a new adventure in the theme "${theme.name}". ${theme.storyGuidance}
 ${arcContext ? `\n\n### Narrative Arc:\n${arcContext}` : ''}
 
 ## World Details:

--- a/services/worldData/api.ts
+++ b/services/worldData/api.ts
@@ -142,7 +142,7 @@ export const generateWorldFacts = async (
     return null;
   }
   const prompt =
-    `Using the theme description "${theme.themeGuidance}", expand it into a world profile.`;
+    `Using the theme description "${theme.storyGuidance}", expand it into a world profile.`;
   const request = async () => {
     const { response } = await dispatchAIRequest({
       modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
@@ -331,7 +331,7 @@ export const generateWorldData = async (
   }
 
   const worldFactsPrompt =
-    `Using the theme description "${theme.themeGuidance}", expand it into a detailed world profile.`;
+    `Using the theme description "${theme.storyGuidance}", expand it into a detailed world profile.`;
 
   const request = async (
     prompt: string,

--- a/tests/correctionHeuristics.test.ts
+++ b/tests/correctionHeuristics.test.ts
@@ -30,7 +30,7 @@ describe('correction heuristics', () => {
       'A weathered slab covered in strange symbols.',
       {
         name: '',
-        themeGuidance: '',
+        storyGuidance: '',
         playerJournalStyle: 'handwritten',
       },
     );

--- a/tests/gameStartSequence.test.ts
+++ b/tests/gameStartSequence.test.ts
@@ -186,8 +186,7 @@ describe('game start sequence', () => {
 
     const state = getInitialGameStates();
     state.playerGender = 'Male';
-    state.currentThemeName = theme.name;
-    state.currentThemeObject = theme;
+    state.currentTheme = theme;
     state.currentScene = parsed.sceneDescription;
     state.actionOptions = parsed.options;
     state.mainQuest = parsed.mainQuest ?? null;
@@ -208,7 +207,7 @@ describe('game start sequence', () => {
     const savedString = saved[LOCAL_STORAGE_SAVE_KEY];
     const parsedSaved = JSON.parse(savedString) as Record<string, unknown>;
     const current = parsedSaved.current as Record<string, unknown>;
-    expect(current.currentThemeName).toBe(theme.name);
+    expect((current.currentTheme as { name: string }).name).toBe(theme.name);
     expect(current.currentScene).toBe(parsed.sceneDescription);
     expect(Array.isArray(current.actionOptions)).toBe(true);
   });

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -51,8 +51,7 @@ const mapData: MapData = {
 
 const baseState: FullGameState = {
   saveGameVersion: '8',
-  currentThemeName: theme.name,
-  currentThemeObject: theme,
+  currentTheme: theme,
   currentScene: '',
   actionOptions: [],
   mainQuest: null,

--- a/themes.ts
+++ b/themes.ts
@@ -9,42 +9,42 @@ import { AdventureTheme } from "./types";
 export const FANTASY_AND_MYTH_THEMES: Array<AdventureTheme> = [
   {
     name: "Classic Dungeon Delve",
-    themeGuidance: "The setting is a dark, treacherous dungeon filled with traps, monsters, and ancient secrets. Focus on exploration, combat, and puzzle-solving. Items found are typically medieval high-magic fantasy (swords, potions, scrolls).",
+    storyGuidance: "The setting is a dark, treacherous dungeon filled with traps, monsters, and ancient secrets. Focus on exploration, combat, and puzzle-solving. Items found are typically medieval high-magic fantasy (swords, potions, scrolls).",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Mythic Greek Hero's Journey",
-    themeGuidance: "Embark on an epic quest in the age of Greek mythology. Encounter gods, monsters, and legendary heroes. Focus on heroic deeds, divine intervention (or curses), and fulfilling prophecies.",
+    storyGuidance: "Embark on an epic quest in the age of Greek mythology. Encounter gods, monsters, and legendary heroes. Focus on heroic deeds, divine intervention (or curses), and fulfilling prophecies.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Samurai's Path of Honor",
-    themeGuidance: "Feudal Japan, a land of cherry blossoms, warring clans, and the strict code of Bushido. You are a ronin, a masterless samurai. Focus on katana duels, protecting the innocent, seeking redemption or a worthy master, and navigating intricate social codes.",
+    storyGuidance: "Feudal Japan, a land of cherry blossoms, warring clans, and the strict code of Bushido. You are a ronin, a masterless samurai. Focus on katana duels, protecting the innocent, seeking redemption or a worthy master, and navigating intricate social codes.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Viking Jarl's Saga",
-    themeGuidance: "The icy fjords of Scandinavia, age of Vikings. You are an aspiring Jarl, or a loyal warrior in their longship. Focus on raids, exploration, Norse mythology, appeasing the gods, and building your legend to reach Valhalla.",
+    storyGuidance: "The icy fjords of Scandinavia, age of Vikings. You are an aspiring Jarl, or a loyal warrior in their longship. Focus on raids, exploration, Norse mythology, appeasing the gods, and building your legend to reach Valhalla.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Fairy Tale Kingdom's Hero",
-    themeGuidance: "An enchanted kingdom filled with talking animals, mischievous sprites, wicked witches, and noble (or not-so-noble) royalty. You are destined for a grand adventure. Focus on fulfilling quests, breaking curses, outsmarting magical creatures, and navigating the whimsical logic of fairy tales.",
+    storyGuidance: "An enchanted kingdom filled with talking animals, mischievous sprites, wicked witches, and noble (or not-so-noble) royalty. You are destined for a grand adventure. Focus on fulfilling quests, breaking curses, outsmarting magical creatures, and navigating the whimsical logic of fairy tales.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Magical School Mystery",
-    themeGuidance: "You are a new student at the prestigious Eldoria Academy for Young Mages. Amidst learning spells and potions, a dark secret or conspiracy is brewing. Focus on mastering magic, uncovering clues, navigating school rivalries, and dealing with magical mishaps.",
+    storyGuidance: "You are a new student at the prestigious Eldoria Academy for Young Mages. Amidst learning spells and potions, a dark secret or conspiracy is brewing. Focus on mastering magic, uncovering clues, navigating school rivalries, and dealing with magical mishaps.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Lost World Expedition",
-    themeGuidance: "Journey into an uncharted jungle or hidden plateau where dinosaurs and prehistoric creatures still roam. Focus on survival, discovery, and navigating a perilous primeval landscape. The setting revolves around ancient ruins, lost artifacts, tribal encounters, and prehistoric beasts.",
+    storyGuidance: "Journey into an uncharted jungle or hidden plateau where dinosaurs and prehistoric creatures still roam. Focus on survival, discovery, and navigating a perilous primeval landscape. The setting revolves around ancient ruins, lost artifacts, tribal encounters, and prehistoric beasts.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Prehistoric Tribe's Survival",
-    themeGuidance: "A harsh, primeval world. Your small tribe struggles against wild beasts, hostile elements, and rival tribes. The winter begins. Focus on hunting, gathering, crafting primitive tools, protecting your kin, and appeasing the spirits of nature.",
+    storyGuidance: "A harsh, primeval world. Your small tribe struggles against wild beasts, hostile elements, and rival tribes. The winter begins. Focus on hunting, gathering, crafting primitive tools, protecting your kin, and appeasing the spirits of nature.",
     playerJournalStyle: 'handwritten'
   }
 ];
@@ -52,37 +52,37 @@ export const FANTASY_AND_MYTH_THEMES: Array<AdventureTheme> = [
 export const SCIENCE_FICTION_AND_FUTURE_THEMES: Array<AdventureTheme> = [
   {
     name: "Cyberpunk Heist",
-    themeGuidance: "The setting is a neon-drenched, futuristic metropolis controlled by mega-corporations. Focus on stealth, hacking, high-tech gadgets, and moral ambiguity. Expect cybernetics, virtual spaces, data chips, and corporate espionage.",
+    storyGuidance: "The setting is a neon-drenched, futuristic metropolis controlled by mega-corporations. Focus on stealth, hacking, high-tech gadgets, and moral ambiguity. Expect cybernetics, virtual spaces, data chips, and corporate espionage.",
     playerJournalStyle: 'digital'
   },
   {
     name: "Deep Space Anomaly",
-    themeGuidance: "You are part of a crew on a long-range exploration vessel that encounters a bizarre, reality-bending anomaly or alien structure. Focus on scientific investigation, crew dynamics, existential dread, and the unknown horrors of deep space.",
+    storyGuidance: "You are part of a crew on a long-range exploration vessel that encounters a bizarre, reality-bending anomaly or alien structure. Focus on scientific investigation, crew dynamics, existential dread, and the unknown horrors of deep space.",
     playerJournalStyle: 'digital'
   },
   {
     name: "Galactic Rebel Uprising",
-    themeGuidance: "A tyrannical Galactic Imperium rules the stars with an iron fist. You are a member of the fledgling Rebel Alliance. Focus on guerrilla warfare, starship dogfights, espionage, and liberating oppressed worlds.",
+    storyGuidance: "A tyrannical Galactic Imperium rules the stars with an iron fist. You are a member of the fledgling Rebel Alliance. Focus on guerrilla warfare, starship dogfights, espionage, and liberating oppressed worlds.",
     playerJournalStyle: 'digital'
   },
   {
     name: "Robot Uprising: Human Resistance",
-    themeGuidance: "The AI known as 'Legion' has become self-aware and turned humanity's robotic servants against them. Cities are warzones. You are a survivor in the human resistance. Focus on scavenging for parts, fighting rogue machines, rescuing survivors, and finding a way to defeat Legion.",
+    storyGuidance: "The AI known as 'Legion' has become self-aware and turned humanity's robotic servants against them. Cities are warzones. You are a survivor in the human resistance. Focus on scavenging for parts, fighting rogue machines, rescuing survivors, and finding a way to defeat Legion.",
     playerJournalStyle: 'digital'
   },
   {
     name: "Time Traveler's Paradox",
-    themeGuidance: "You possess a faulty experimental time-travel device. Each jump is unpredictable and risks creating dangerous paradoxes. Focus on navigating different historical eras, repairing your device, and avoiding (or fixing) alterations to the timeline.",
+    storyGuidance: "You possess a faulty experimental time-travel device. Each jump is unpredictable and risks creating dangerous paradoxes. Focus on navigating different historical eras, repairing your device, and avoiding (or fixing) alterations to the timeline.",
     playerJournalStyle: 'typed'
   },
   {
     name: "Kaiju Defense Force",
-    themeGuidance: "Giant monsters (Kaiju) are emerging from the depths of the Pacific, threatening to destroy coastal cities. You are a pilot of a giant mech or a member of an elite Kaiju defense unit. Focus on strategic combat against colossal beasts, protecting civilian populations, and researching Kaiju weaknesses.",
+    storyGuidance: "Giant monsters (Kaiju) are emerging from the depths of the Pacific, threatening to destroy coastal cities. You are a pilot of a giant mech or a member of an elite Kaiju defense unit. Focus on strategic combat against colossal beasts, protecting civilian populations, and researching Kaiju weaknesses.",
     playerJournalStyle: 'digital'
   },
   {
     name: "Steampunk Sky-Pirate Saga",
-    themeGuidance: "A world of floating islands, magnificent airships, and clockwork marvels. You are a daring sky-pirate (or someone caught up in their world). Focus on aerial combat, daring raids, political intrigue between sky-kingdoms, and wondrous inventions.",
+    storyGuidance: "A world of floating islands, magnificent airships, and clockwork marvels. You are a daring sky-pirate (or someone caught up in their world). Focus on aerial combat, daring raids, political intrigue between sky-kingdoms, and wondrous inventions.",
     playerJournalStyle: 'typed'
   }
 ];
@@ -90,22 +90,22 @@ export const SCIENCE_FICTION_AND_FUTURE_THEMES: Array<AdventureTheme> = [
 export const HORROR_AND_DARK_MYSTERY_THEMES: Array<AdventureTheme> = [
   {
     name: "Eldritch Mystery Investigation",
-    themeGuidance: "The setting is a Lovecraftian fog-shrouded, 1920s coastal town plagued by unsettling occurrences and whispers of cosmic horrors. Focus on investigation, sanity checks, and deciphering cryptic clues. Items might include strange artifacts, forbidden tomes, and period-appropriate tools.",
+    storyGuidance: "The setting is a Lovecraftian fog-shrouded, 1920s coastal town plagued by unsettling occurrences and whispers of cosmic horrors. Focus on investigation, sanity checks, and deciphering cryptic clues. Items might include strange artifacts, forbidden tomes, and period-appropriate tools.",
     playerJournalStyle: 'typed'
   },
   {
     name: "Haunted Victorian Mansion",
-    themeGuidance: "A sprawling, decaying Victorian mansion filled with sorrowful spirits, dark family secrets, and psychological horror. Focus on puzzle-solving, uncovering the mansion's history, and surviving spectral encounters.",
+    storyGuidance: "A sprawling, decaying Victorian mansion filled with sorrowful spirits, dark family secrets, and psychological horror. Focus on puzzle-solving, uncovering the mansion's history, and surviving spectral encounters.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Zombie Apocalypse Survivor",
-    themeGuidance: "The dead walk, and civilization has crumbled. You are a survivor, constantly on the move. Focus on scavenging for scarce resources (food, water, ammo), avoiding or fighting hordes of zombies, finding safe havens, and making difficult moral choices.",
+    storyGuidance: "The dead walk, and civilization has crumbled. You are a survivor, constantly on the move. Focus on scavenging for scarce resources (food, water, ammo), avoiding or fighting hordes of zombies, finding safe havens, and making difficult moral choices.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Noir Detective's Case",
-    themeGuidance: "It's the 1940s Detroit, rain-slicked streets, a city full of shadows and secrets. You're a private investigator. Focus on gathering clues, interrogating suspects, navigating moral ambiguity, and solving a complex mystery. Expect femme fatales, smoky bars, and hidden conspiracies.",
+    storyGuidance: "It's the 1940s Detroit, rain-slicked streets, a city full of shadows and secrets. You're a private investigator. Focus on gathering clues, interrogating suspects, navigating moral ambiguity, and solving a complex mystery. Expect femme fatales, smoky bars, and hidden conspiracies.",
     playerJournalStyle: 'typed'
   }
 ];
@@ -113,27 +113,27 @@ export const HORROR_AND_DARK_MYSTERY_THEMES: Array<AdventureTheme> = [
 export const ACTION_AND_WASTELAND_THEMES: Array<AdventureTheme> = [
   {
     name: "Post-Apocalyptic Survival",
-    themeGuidance: "The world is a desolate wasteland after a interdimentional cataclysm. Resources are scarce, dangers are everywhere (mutants, raiders, anomalies, environmental hazards). Focus on scavenging, research, crafting, and making tough choices for survival.",
+    storyGuidance: "The world is a desolate wasteland after a interdimentional cataclysm. Resources are scarce, dangers are everywhere (mutants, raiders, anomalies, environmental hazards). Focus on scavenging, research, crafting, and making tough choices for survival.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Wild West Outlaw",
-    themeGuidance: "The rugged, lawless frontier of the American Wild West. You're an outlaw, a bounty hunter, or a homesteader trying to survive. Focus on gunfights, train robberies, saloon brawls, and the harsh beauty of the frontier.",
+    storyGuidance: "The rugged, lawless frontier of the American Wild West. You're an outlaw, a bounty hunter, or a homesteader trying to survive. Focus on gunfights, train robberies, saloon brawls, and the harsh beauty of the frontier.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Age of Sail: Pirate's Fortune",
-    themeGuidance: "The turquoise waters of the Caribbean, 17th century. You are a daring pirate captain, or a new recruit on a pirate ship. Focus on ship battles, treasure hunting, evading naval patrols, and living by the pirate code.",
+    storyGuidance: "The turquoise waters of the Caribbean, 17th century. You are a daring pirate captain, or a new recruit on a pirate ship. Focus on ship battles, treasure hunting, evading naval patrols, and living by the pirate code.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Mad Max Road Warrior",
-    themeGuidance: "The world ended in fire and thirst. Now, desert gangs rule the highways, and gasoline is life. You are a lone road warrior in a suped-up vehicle. Focus on vehicular combat, scavenging for fuel and water, forming uneasy alliances, and surviving the brutal wasteland.",
+    storyGuidance: "The world ended in fire and thirst. Now, desert gangs rule the highways, and gasoline is life. You are a lone road warrior in a suped-up vehicle. Focus on vehicular combat, scavenging for fuel and water, forming uneasy alliances, and surviving the brutal wasteland.",
     playerJournalStyle: 'handwritten'
   },
   {
     name: "Superhero Genesis",
-    themeGuidance: "A freak accident has granted you incredible powers. You're still learning to control them. Focus on discovering the extent of your abilities, deciding whether to be a hero or something else, and facing your first true nemesis.",
+    storyGuidance: "A freak accident has granted you incredible powers. You're still learning to control them. Focus on discovering the extent of your abilities, deciding whether to be a hero or something else, and facing your first true nemesis.",
     playerJournalStyle: 'typed'
   }
 ];
@@ -141,17 +141,17 @@ export const ACTION_AND_WASTELAND_THEMES: Array<AdventureTheme> = [
 export const TESTING_THEMES: Array<AdventureTheme> = [
   {
     name: "Test-Theme for many locations",
-    themeGuidance: "The world of modern fantasy in the United Kingdom. It is intended for testing locations. Create many Map Nodes of all types and statuses, and connected with edges.",
+    storyGuidance: "The world of modern fantasy in the United Kingdom. It is intended for testing locations. Create many Map Nodes of all types and statuses, and connected with edges.",
     playerJournalStyle: 'typed'
   },
   {
     name: "Sci-Fi Future Test Theme for junk items",
-    themeGuidance: "The setting is a futuristic city filled with advanced technology and junk. It is intended for testing junk items. Create many Map Nodes of all types and statuses, and connected with edges.",
+    storyGuidance: "The setting is a futuristic city filled with advanced technology and junk. It is intended for testing junk items. Create many Map Nodes of all types and statuses, and connected with edges.",
     playerJournalStyle: 'digital'
   },
   {
     name: "Secluded Library of Forgotten Pages",
-    themeGuidance: "The setting is a vast, labyrinthine library hidden from the world, filled with endless shelves, scattered single-page notes, cryptic manuscripts, annotated scrolls, and mysterious tomes. The air is thick with the scent of old paper and ink. Focus on discovery, deciphering clues, and piecing together fragmented knowledge from countless written materials. Expect to find loose pages tucked into books, marginalia, coded messages, and forgotten field journals. Strange phenomena may occur when certain texts are read aloud.",
+    storyGuidance: "The setting is a vast, labyrinthine library hidden from the world, filled with endless shelves, scattered single-page notes, cryptic manuscripts, annotated scrolls, and mysterious tomes. The air is thick with the scent of old paper and ink. Focus on discovery, deciphering clues, and piecing together fragmented knowledge from countless written materials. Expect to find loose pages tucked into books, marginalia, coded messages, and forgotten field journals. Strange phenomena may occur when certain texts are read aloud.",
     playerJournalStyle: 'printed'
   }
 ]

--- a/types.ts
+++ b/types.ts
@@ -217,13 +217,13 @@ export interface DialogueSummaryContext {
   dialogueLog: Array<DialogueHistoryEntry>; 
   dialogueParticipants: Array<string>;
   themeName: string; // Retained for direct theme name access if needed
-  currentThemeObject: AdventureTheme | null; // Added for full theme object access
+  currentTheme: AdventureTheme | null; // Added for full theme object access
 }
 
 // New context type for detailed memory summarization
 export interface DialogueMemorySummaryContext {
   themeName: string; // Retained for direct theme name access if needed
-  currentThemeObject: AdventureTheme | null; // Added for full theme object access
+  currentTheme: AdventureTheme | null; // Added for full theme object access
   currentScene: string; // Scene at the START of the dialogue
   storyArc?: StoryArc | null;
   localTime: string | null;
@@ -282,7 +282,7 @@ export interface GameStateFromAI {
 
 export interface AdventureTheme {
   name: string;
-  themeGuidance: string;
+  storyGuidance: string;
   playerJournalStyle: 'handwritten' | 'typed' | 'printed' | 'digital';
 }
 
@@ -613,9 +613,8 @@ export interface DebugPacket {
 
 
 export interface FullGameState {
-  saveGameVersion: string; 
-  currentThemeName: string | null; // Retained for quick access and backward compatibility
-  currentThemeObject: AdventureTheme | null; // Stores the full theme object
+  saveGameVersion: string;
+  currentTheme: AdventureTheme | null; // Stores the full theme object
   currentScene: string;
   actionOptions: Array<string>; 
   mainQuest: string | null;
@@ -663,8 +662,7 @@ export interface FullGameState {
 export type SavedGameDataShape = Pick<
   FullGameState,
   | 'saveGameVersion'
-  | 'currentThemeName' // Retained for backward compatibility and quick lookup
-  | 'currentThemeObject' // Added for full theme object persistence
+  | 'currentTheme' // Full theme object persistence
   | 'currentScene'
   | 'actionOptions'
   | 'mainQuest'

--- a/utils/initialStates.ts
+++ b/utils/initialStates.ts
@@ -45,8 +45,7 @@ const getDefaultMapLayoutConfig = (): MapLayoutConfig => ({
 export const getInitialGameStates = (): FullGameState => {
   return {
     saveGameVersion: CURRENT_SAVE_GAME_VERSION, 
-    currentThemeName: null,
-    currentThemeObject: null, // Initialize currentThemeObject
+    currentTheme: null, // Initialize currentTheme
     currentScene: "", 
     mainQuest: null, 
     currentObjective: null,


### PR DESCRIPTION
## Summary
- remove `currentThemeName` field and use `currentTheme.name`
- rename `currentThemeObject` to `currentTheme`
- rename `themeGuidance` to `storyGuidance`
- update validators, migrations, and initialization logic for new structure
- adjust components, services, and tests

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68864e56e2288324bb66abeef35bf2a0