### PR TITLE
Fix librarianHint missing with written items

### DIFF
--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -347,8 +347,12 @@ const handleInventoryHints = async ({
       }
     }
 
-    const librarianHint =
+    let librarianHint =
       'librarianHint' in aiData ? aiData.librarianHint?.trim() : '';
+    if (!librarianHint && librarianNewItems.length > 0) {
+      const names = librarianNewItems.map(it => it.name).join(', ');
+      librarianHint = `Found ${names}.`;
+    }
     let libResult: Awaited<ReturnType<typeof applyLibrarianHints_Service>> | null = null;
     if (librarianHint) {
       libResult = await applyLibrarianHints_Service(


### PR DESCRIPTION
## Summary
- autofill `librarianHint` when storyteller forgets it but adds written items

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68866929d6a883249d2be5607f1caf4c