### PR TITLE
refactor: isolate cartographer utilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,7 +91,7 @@ This layer abstracts external interactions and complex data processing.
     *   `services/storyteller/responseParser.ts`: Parses the storyteller AI's JSON, validates, and attempts corrections.
     *   `services/dialogue/responseParser.ts`: Parses dialogue AI JSON for turns and summaries.
     *   `services/validationUtils.ts`: General data structure validation.
-    *   `services/cartographer/mapUpdateValidation.ts`: Specific validation for `AIMapUpdatePayload`.
+    *   `utils/mapUpdateValidation.ts`: Specific validation for `AIMapUpdatePayload`.
 *   **Persistence Service:**
    *   `services/saveLoad/`: Contains modules for validating, migrating and storing `FullGameState` data.
 *   **Utility Functions:**
@@ -106,12 +106,12 @@ This layer abstracts external interactions and complex data processing.
    *   `utils/loadingProgress.ts`: Tracks progress text for asynchronous operations.
    *   `constants.ts`: Map rendering constants like `NODE_RADIUS` and `DEFAULT_VIEWBOX`.
    *   `utils/mapGraphUtils.ts`: Helpers for navigating the map hierarchy.
-   *   `utils/mapHierarchyUpgradeUtils.ts`: Upgrades feature nodes with children into regions and inserts connector nodes.
+   *   `services/cartographer/mapHierarchyUpgrades.ts`: Upgrades feature nodes with children into regions and inserts connector nodes.
    *   `utils/mapLayoutUtils.ts`: Performs a nested circle layout for map visualization.
    *   `utils/mapNodeMatcher.ts`: Contains `selectBestMatchingMapNode` for fuzzy location lookups.
    *   `utils/mapPathfinding.ts`: Calculates travel paths between nodes.
-   *   `utils/mapUpdateHandlers.ts`: Applies AI map update payloads to `MapData`.
-   *   `services/cartographer/mapUpdateValidation.ts`: Validates `AIMapUpdatePayload` structures.
+   *   `services/cartographer/mapUpdateHandlers.ts`: Applies AI map update payloads to `MapData`.
+   *   `utils/mapUpdateValidation.ts`: Validates `AIMapUpdatePayload` structures.
    *   `utils/mapSynonyms.ts` and `utils/matcherData.ts`: Provide regex helpers and keyword lists used when parsing player text.
    *   `utils/svgUtils.ts`: Converts screen coordinates to the map's SVG space.
    *   `utils/markup.tsx`: Converts a small markup syntax (lists, *italic*, **bold**) into React nodes.

--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -34,7 +34,7 @@ import { getDefaultMapLayoutConfig } from './useMapUpdates';
 import { buildInitialGamePrompt } from './initPromptHelpers';
 import { DEFAULT_VIEWBOX } from '../constants';
 import { ProcessAiResponseFn } from './useProcessAiResponse';
-import { repairFeatureHierarchy } from '../utils/mapHierarchyUpgradeUtils';
+import { repairFeatureHierarchy } from '../services/cartographer/mapHierarchyUpgrades';
 import { clearAllImages } from '../services/imageDb';
 import {
   generateWorldFacts,

--- a/hooks/useMapUpdateProcessor.ts
+++ b/hooks/useMapUpdateProcessor.ts
@@ -11,7 +11,7 @@ import {
   LoadingReason,
   TurnChanges,
 } from '../types';
-import { handleMapUpdates } from '../utils/mapUpdateHandlers';
+import { handleMapUpdates } from '../services/cartographer/mapUpdateHandlers';
 
 export interface UseMapUpdateProcessorProps {
   loadingReasonRef: React.RefObject<LoadingReason | null>;

--- a/services/cartographer/api.ts
+++ b/services/cartographer/api.ts
@@ -34,12 +34,14 @@ export const updateMapFromAIData_Service = async (
   previousMapNodeId: string | null,
   inventoryItems: Array<Item>,
   knownNPCs: Array<NPC>,
-  storyArc: StoryArc | null,
+  _storyArc: StoryArc | null,
 ): Promise<MapUpdateServiceResult | null> => {
   if (!isApiConfigured()) {
     console.error('API Key not configured for Map Update Service.');
     return null;
   }
+
+  void _storyArc;
 
   const sceneDesc = 'sceneDescription' in aiData ? aiData.sceneDescription : '';
   const logMsg = aiData.logMessage ?? '';
@@ -119,7 +121,6 @@ export const updateMapFromAIData_Service = async (
     allKnownMainPlacesString,
     itemNames,
     npcNames,
-    storyArc,
   );
 
   const { payload, debugInfo } = await fetchMapUpdatePayload(

--- a/services/cartographer/hierarchyResolver.ts
+++ b/services/cartographer/hierarchyResolver.ts
@@ -4,7 +4,7 @@ import {
   suggestNodeTypeDowngrade,
   suggestNodeTypeUpgrade,
   mapHasHierarchyConflict,
-} from '../../utils/mapHierarchyUpgradeUtils';
+} from './mapHierarchyUpgrades';
 import { chooseHierarchyResolution_Service } from '../corrections/hierarchyUpgrade';
 import type { ApplyUpdatesContext } from './updateContext';
 

--- a/services/cartographer/index.ts
+++ b/services/cartographer/index.ts
@@ -6,7 +6,6 @@ export * from './api';
 export * from './promptBuilder';
 export * from './responseParser';
 export * from './systemPrompt';
-export * from './mapUpdateUtils';
 export * from './edgeUtils';
 export * from './connectorChains';
 export * from './request';

--- a/services/cartographer/mapHierarchyUpgrades.ts
+++ b/services/cartographer/mapHierarchyUpgrades.ts
@@ -1,5 +1,5 @@
 /**
- * @file mapHierarchyUpgradeUtils.ts
+ * @file mapHierarchyUpgrades.ts
  * @description Utilities for upgrading feature nodes to higher-level regions
  *              when they acquire child nodes. Introduces linking features and
  *              reroutes edges to conform to map layering rules.
@@ -11,11 +11,11 @@ import {
   MapEdge,
   AdventureTheme,
   MapNodeType,
-} from '../types';
-import { NODE_TYPE_LEVELS } from '../constants';
-import { structuredCloneGameState } from './cloneUtils';
-import { decideFeatureHierarchyUpgrade_Service } from '../services/corrections/hierarchyUpgrade';
-import { generateUniqueId } from './entityUtils';
+} from '../../types';
+import { NODE_TYPE_LEVELS } from '../../constants';
+import { structuredCloneGameState } from '../../utils/cloneUtils';
+import { decideFeatureHierarchyUpgrade_Service } from '../corrections/hierarchyUpgrade';
+import { generateUniqueId } from '../../utils/entityUtils';
 
 export const NODE_TYPE_DOWNGRADE_MAP: Record<MapNodeType, MapNodeType | undefined> = {
   region: 'location',

--- a/services/cartographer/mapUpdateHandlers.ts
+++ b/services/cartographer/mapUpdateHandlers.ts
@@ -12,22 +12,23 @@ import {
   LoadingReason,
   ValidNewNPCPayload,
   ValidNPCUpdatePayload
-} from '../types';
-import { updateMapFromAIData_Service, MapUpdateServiceResult } from '../services/cartographer';
-import { fetchFullPlaceDetailsForNewMapNode_Service, assignSpecificNamesToDuplicateNodes_Service } from '../services/corrections';
-import { selectBestMatchingMapNode, attemptMatchAndSetNode } from './mapNodeMatcher';
+} from '../../types';
+import { updateMapFromAIData_Service } from './api';
+import type { MapUpdateServiceResult } from './types';
+import { fetchFullPlaceDetailsForNewMapNode_Service, assignSpecificNamesToDuplicateNodes_Service } from '../corrections';
+import { selectBestMatchingMapNode, attemptMatchAndSetNode } from '../../utils/mapNodeMatcher';
 import {
   buildNPCChangeRecords,
   applyAllNPCChanges,
   updateEntityIdsInFacts,
-} from './gameLogicUtils';
+} from '../../utils/gameLogicUtils';
 import {
   existsNonRumoredPath,
   getAncestors,
   isDescendantOf,
   buildNonRumoredAdjacencyMap,
-} from './mapGraphUtils';
-import { buildNodeId } from './entityUtils';
+} from '../../utils/mapGraphUtils';
+import { buildNodeId } from '../../utils/entityUtils';
 
 /**
  * Handles all map-related updates from the AI response and returns the suggested node identifier.

--- a/services/cartographer/processNodeAdds.ts
+++ b/services/cartographer/processNodeAdds.ts
@@ -1,7 +1,7 @@
 import type { MapNode, MapNodeData, MapEdgeData } from '../../types';
 import { findMapNodeByIdentifier, buildNodeId } from '../../utils/entityUtils';
 import { findClosestAllowedParent } from '../../utils/mapGraphUtils';
-import { suggestNodeTypeDowngrade } from '../../utils/mapHierarchyUpgradeUtils';
+import { suggestNodeTypeDowngrade } from './mapHierarchyUpgrades';
 import { isEdgeConnectionAllowed, addEdgeWithTracking } from './edgeUtils';
 import { buildChainRequest } from './connectorChains';
 import { fetchLikelyParentNode_Service } from '../corrections/placeDetails';

--- a/services/cartographer/processNodeUpdates.ts
+++ b/services/cartographer/processNodeUpdates.ts
@@ -1,5 +1,5 @@
 import type { Item, MapEdge } from '../../types';
-import { suggestNodeTypeDowngrade } from '../../utils/mapHierarchyUpgradeUtils';
+import { suggestNodeTypeDowngrade } from './mapHierarchyUpgrades';
 import type { ApplyUpdatesContext } from './updateContext';
 
 export async function processNodeUpdates(ctx: ApplyUpdatesContext): Promise<void> {

--- a/services/cartographer/request.ts
+++ b/services/cartographer/request.ts
@@ -33,7 +33,7 @@ import {
   dedupeEdgeOps,
   normalizeStatusAndTypeSynonyms,
   fixDeleteIdMixups,
-} from './mapUpdateUtils';
+} from '../../utils/mapUpdateUtils';
 import type {
   AIMapUpdatePayload,
   MinimalModelCallRecord,

--- a/services/cartographer/responseParser.ts
+++ b/services/cartographer/responseParser.ts
@@ -4,8 +4,8 @@
  */
 import { AIMapUpdatePayload, AdventureTheme } from '../../types';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
-import { isValidAIMapUpdatePayload } from './mapUpdateValidation';
-import { normalizeStatusAndTypeSynonyms } from './mapUpdateUtils';
+import { isValidAIMapUpdatePayload } from '../../utils/mapUpdateValidation';
+import { normalizeStatusAndTypeSynonyms } from '../../utils/mapUpdateUtils';
 import { fetchCorrectedMapUpdatePayload_Service } from '../corrections';
 
 /**

--- a/services/corrections/mapUpdatePayload.ts
+++ b/services/corrections/mapUpdatePayload.ts
@@ -22,8 +22,8 @@ import { addProgressSymbol } from '../../utils/loadingProgress';
 import { extractJsonFromFence, safeParseJson } from '../../utils/jsonUtils';
 import { retryAiCall } from '../../utils/retry';
 import { isApiConfigured } from '../apiClient';
-import { isValidAIMapUpdatePayload } from '../cartographer/mapUpdateValidation';
-import { normalizeStatusAndTypeSynonyms } from '../cartographer/mapUpdateUtils';
+import { isValidAIMapUpdatePayload } from '../../utils/mapUpdateValidation';
+import { normalizeStatusAndTypeSynonyms } from '../../utils/mapUpdateUtils';
 
 export const fetchCorrectedMapUpdatePayload_Service = async (
   malformedJson: string,

--- a/tests/mapVisit.test.ts
+++ b/tests/mapVisit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { handleMapUpdates } from '../utils/mapUpdateHandlers.ts';
+import { handleMapUpdates } from '../services/cartographer/mapUpdateHandlers.ts';
 import { structuredCloneGameState } from '../utils/cloneUtils.ts';
 import type { AdventureTheme, FullGameState, GameStateFromAI, MapData, TurnChanges, MapLayoutConfig } from '../types';
 

--- a/utils/mapUpdateNormalizers.ts
+++ b/utils/mapUpdateNormalizers.ts
@@ -1,16 +1,16 @@
-import type { MapNodeData, MapEdgeData } from '../../types';
+import type { MapNodeData, MapEdgeData } from '../types';
 import {
   VALID_NODE_STATUS_VALUES,
   VALID_NODE_TYPE_VALUES,
   VALID_EDGE_TYPE_VALUES,
   VALID_EDGE_STATUS_VALUES,
-} from '../../constants';
+} from '../constants';
 import {
   NODE_STATUS_SYNONYMS,
   NODE_TYPE_SYNONYMS,
   EDGE_TYPE_SYNONYMS,
   EDGE_STATUS_SYNONYMS,
-} from '../../utils/mapSynonyms';
+} from './mapSynonyms';
 
 /**
  * Normalizes a MapNodeData object in place and records any invalid values.

--- a/utils/mapUpdateUtils.ts
+++ b/utils/mapUpdateUtils.ts
@@ -1,9 +1,9 @@
-import type { AIMapUpdatePayload, MapNodeData, MapEdgeData } from '../../types';
+import type { AIMapUpdatePayload, MapNodeData, MapEdgeData } from '../types';
 import {
   NODE_REMOVAL_SYNONYMS,
   EDGE_REMOVAL_SYNONYMS,
-} from '../../utils/mapSynonyms';
-import { applyNodeDataFix, applyEdgeDataFix } from './normalizers';
+} from './mapSynonyms';
+import { applyNodeDataFix, applyEdgeDataFix } from './mapUpdateNormalizers';
 
 // Synonym lists for interpreting node and edge removal operations
 export const NODE_REMOVAL_SYNONYM_SET = new Set<string>(NODE_REMOVAL_SYNONYMS);

--- a/utils/mapUpdateValidation.ts
+++ b/utils/mapUpdateValidation.ts
@@ -11,13 +11,13 @@ import {
   MapNodeData,
   MapEdgeType,
   MapEdgeStatus,
-} from '../../types';
+} from '../types';
 import {
   VALID_NODE_STATUS_VALUES,
   VALID_NODE_TYPE_VALUES,
   VALID_EDGE_STATUS_VALUES,
   VALID_EDGE_TYPE_VALUES,
-} from '../../constants';
+} from '../constants';
 
 function isValidAINodeAdd(op: unknown): op is AINodeAdd {
   if (typeof op !== 'object' || op === null) return false;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,12 @@ export default defineConfig(({ mode }: { mode: string }) => {
             if (id.includes('resources')) {
               return 'resources';
             }
+            if (id.includes('cartographer')) {
+              return 'cartographer';
+            }
+            if (id.includes('hooks')) {
+              return 'hooks';
+            }
             if (id.includes('corrections')) {
               return 'corrections';
             }


### PR DESCRIPTION
## Summary
- move map hierarchy upgrades and map update handler into cartographer service to avoid circular dependencies
- lazy-load name correction service to prevent static imports from hooks
- split Vite output into cartographer and hooks chunks
- extract map update validation and normalization utilities into shared utils to remove remaining cartographer–corrections cycle

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689341ce76ec83248282438ff1bfbe30