### PR TITLE
Validate story arc acts before prompting

### DIFF
--- a/hooks/initPromptHelpers.ts
+++ b/hooks/initPromptHelpers.ts
@@ -10,6 +10,7 @@ import {
   StoryArc,
 } from '../types';
 import { buildNewGameFirstTurnPrompt } from '../services/storyteller';
+import { isStoryArcValid } from '../utils/storyArcUtils';
 
 export interface BuildInitialGamePromptOptions {
   theme: AdventureTheme;
@@ -27,10 +28,13 @@ export const buildInitialGamePrompt = (
   options: BuildInitialGamePromptOptions,
 ): string => {
   const { theme, storyArc, worldFacts, heroSheet, heroBackstory } = options;
+  if (!storyArc || !isStoryArcValid(storyArc)) {
+    throw new Error('buildInitialGamePrompt: missing or invalid story arc');
+  }
 
   const prompt = buildNewGameFirstTurnPrompt(
     theme,
-    storyArc ?? { title: 'Untitled', overview: '', acts: [], currentAct: 1 },
+    storyArc,
     worldFacts ?? {
       geography: '',
       climate: '',

--- a/services/worldData/api.ts
+++ b/services/worldData/api.ts
@@ -19,6 +19,7 @@ import type {
   StoryArc,
   StoryAct,
 } from '../../types';
+import { isStoryArcValid } from '../../utils/storyArcUtils';
 
 interface StoryActData {
   title: string;
@@ -310,6 +311,9 @@ export const generateHeroData = async (
           currentAct: 1,
         };
         heroBackstory = rest;
+      }
+      if (storyArc && !isStoryArcValid(storyArc)) {
+        throw new Error('generateHeroData: invalid story arc');
       }
       return {
         result: {

--- a/tests/storyArcUtils.test.ts
+++ b/tests/storyArcUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { formatStoryArcContext } from '../utils/promptFormatters';
+import { isStoryArcValid } from '../utils/storyArcUtils';
+import type { StoryArc } from '../types';
+
+describe('story arc helpers', () => {
+  it('isStoryArcValid detects invalid current act', () => {
+    const arc: StoryArc = { title: 'Arc', overview: 'Overview', acts: [], currentAct: 1 };
+    expect(isStoryArcValid(arc)).toBe(false);
+  });
+
+  it('formatStoryArcContext returns empty string for invalid arc', () => {
+    const arc: StoryArc = { title: 'Arc', overview: 'Overview', acts: [], currentAct: 1 };
+    const result = formatStoryArcContext(arc);
+    expect(result).toBe('');
+  });
+
+  it('formatStoryArcContext formats a valid arc', () => {
+    const arc: StoryArc = {
+      title: 'Arc',
+      overview: 'Overview',
+      currentAct: 1,
+      acts: [
+        {
+          actNumber: 1,
+          title: 'Act 1',
+          description: 'Desc',
+          mainObjective: 'Main',
+          sideObjectives: ['Side'],
+          successCondition: 'Finish',
+          completed: false,
+        },
+      ],
+    };
+    const result = formatStoryArcContext(arc);
+    expect(result).toContain('Current Act 1: Act 1');
+  });
+});

--- a/utils/promptFormatters/main.ts
+++ b/utils/promptFormatters/main.ts
@@ -13,6 +13,7 @@ import {
   HeroBackstory,
   StoryArc,
 } from '../../types';
+import { isStoryArcValid } from '../storyArcUtils';
 import { formatKnownPlacesForPrompt } from './map';
 import { findTravelPath, buildTravelAdjacency } from '../mapPathfinding';
 
@@ -227,6 +228,7 @@ export const formatHeroBackstoryForPrompt = (
   ].join('\n');
 
 export const formatStoryArcContext = (arc: StoryArc): string => {
+  if (!isStoryArcValid(arc)) return '';
   const act = arc.acts[arc.currentAct - 1];
   const side = act.sideObjectives.join(', ');
   return [

--- a/utils/storyArcUtils.ts
+++ b/utils/storyArcUtils.ts
@@ -1,0 +1,17 @@
+import type { StoryArc } from '../types';
+
+/**
+ * Validates that a story arc contains a usable current act.
+ * Returns true if the arc has a current act within bounds and
+ * that act includes a side objectives array.
+ */
+export const isStoryArcValid = (arc: StoryArc | null | undefined): arc is StoryArc => {
+  if (!arc) return false;
+  if (!Array.isArray(arc.acts) || arc.acts.length === 0) return false;
+  const index = arc.currentAct - 1;
+  if (index < 0 || index >= arc.acts.length) return false;
+  const act = arc.acts.at(index);
+  if (!act) return false;
+  if (!Array.isArray(act.sideObjectives)) return false;
+  return true;
+};


### PR DESCRIPTION
## Summary
- ensure hero generation retries until a complete story arc with side objectives is returned
- require a validated story arc when building the initial storyteller prompt
- commit world facts and character data to game state as they arrive and check arc validity before starting

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_689470848e8c8324b7d8a5cc2b18033c