### PR TITLE
feat: cap startup AI responses

### DIFF
--- a/hooks/useGameInitialization.ts
+++ b/hooks/useGameInitialization.ts
@@ -333,7 +333,7 @@ export const useGameInitialization = (props: UseGameInitializationProps) => {
           systemInstructionUsed,
           jsonSchemaUsed,
           promptUsed,
-        } = await executeAIMainTurn(prompt);
+          } = await executeAIMainTurn(prompt, 6500);
         draftState.lastDebugPacket.rawResponseText = response.text ?? null;
         draftState.lastDebugPacket.storytellerThoughts = thoughts;
         draftState.lastDebugPacket.systemInstruction = systemInstructionUsed;

--- a/services/loremaster/api.ts
+++ b/services/loremaster/api.ts
@@ -219,22 +219,23 @@ export const extractInitialFacts_Service = async (
   } | null>(async () => {
     params.onSetLoadingReason?.('loremaster_extract');
     addProgressSymbol(LOADING_REASON_UI_MAP.loremaster_extract.icon);
-    const {
-      response,
-      systemInstructionUsed,
-      jsonSchemaUsed,
-      promptUsed,
-    } = await dispatchAIRequest({
-      modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
-      prompt: extractPrompt,
-      systemInstruction: EXTRACT_SYSTEM_INSTRUCTION,
-      thinkingBudget: 512,
-      includeThoughts: true,
-      responseMimeType: 'application/json',
-      jsonSchema: EXTRACT_FACTS_JSON_SCHEMA,
-      temperature: 0.7,
-      label: 'LoremasterExtractInitial',
-    });
+      const {
+        response,
+        systemInstructionUsed,
+        jsonSchemaUsed,
+        promptUsed,
+      } = await dispatchAIRequest({
+        modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt: extractPrompt,
+        systemInstruction: EXTRACT_SYSTEM_INSTRUCTION,
+        thinkingBudget: 512,
+        includeThoughts: true,
+        responseMimeType: 'application/json',
+        jsonSchema: EXTRACT_FACTS_JSON_SCHEMA,
+        temperature: 0.7,
+        label: 'LoremasterExtractInitial',
+        maxOutputTokens: 6500,
+      });
     const parts = (response.candidates?.[0]?.content?.parts ?? []) as Array<{
       text?: string;
       thought?: boolean;

--- a/services/modelDispatcher.ts
+++ b/services/modelDispatcher.ts
@@ -51,6 +51,7 @@ export interface ModelDispatchOptions {
   jsonSchema?: unknown;
   label?: string;
   debugLog?: Array<MinimalModelCallRecord>;
+  maxOutputTokens?: number;
 }
 
 /**
@@ -102,6 +103,7 @@ export const dispatchAIRequest = async (
     const cfg: Record<string, unknown> = {};
     if (options.temperature !== undefined) cfg.temperature = options.temperature;
     if (options.responseMimeType && supportsSchema) cfg.responseMimeType = options.responseMimeType;
+    if (options.maxOutputTokens !== undefined) cfg.maxOutputTokens = options.maxOutputTokens;
     if (supportsThinking && (options.thinkingBudget !== undefined || options.includeThoughts)) {
       const thinkingCfg: { thinkingBudget?: number; includeThoughts?: boolean } = {};
       if (options.thinkingBudget !== undefined) {

--- a/services/storyteller/api.ts
+++ b/services/storyteller/api.ts
@@ -390,6 +390,7 @@ export const STORYTELLER_JSON_SCHEMA = {
 // This function is now the primary way gameAIService interacts with Gemini for main game turns. It takes a fully constructed prompt.
 export const executeAIMainTurn = async (
   fullPrompt: string,
+  maxOutputTokens?: number,
 ): Promise<{
   response: GenerateContentResponse;
   thoughts: Array<string>;
@@ -429,6 +430,7 @@ export const executeAIMainTurn = async (
         responseMimeType: 'application/json',
         jsonSchema: STORYTELLER_JSON_SCHEMA,
         label: 'Storyteller',
+        maxOutputTokens,
       });
       const parts = (response.candidates?.[0]?.content?.parts ?? []) as Array<{
         text?: string;

--- a/services/worldData/api.ts
+++ b/services/worldData/api.ts
@@ -146,16 +146,17 @@ export const generateWorldFacts = async (
   const prompt =
     `Using the theme description "${theme.storyGuidance}", expand it into a world profile.`;
   const request = async () => {
-    const { response } = await dispatchAIRequest({
-      modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
-      prompt,
-      systemInstruction: 'Respond only with JSON matching the provided schema.',
-      thinkingBudget: 1024,
-      includeThoughts: false,
-      responseMimeType: 'application/json',
-      jsonSchema: worldFactsSchema,
-      label: 'WorldFacts',
-    });
+      const { response } = await dispatchAIRequest({
+        modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        systemInstruction: 'Respond only with JSON matching the provided schema.',
+        thinkingBudget: 1024,
+        includeThoughts: false,
+        responseMimeType: 'application/json',
+        jsonSchema: worldFactsSchema,
+        label: 'WorldFacts',
+        maxOutputTokens: 6500,
+      });
     return response.text ?? null;
   };
   return retryAiCall<WorldFacts>(async () => {
@@ -181,16 +182,17 @@ export const generateCharacterNames = async (
     The names shouls follow 'First Name Last Name' or 'First Name "Nickname" Last Name' or 'Prefix First Name Last Name' template.
     You MUST guarantee name variety! Every individual First Name, Last Name, and Nickname MUST appear only once throughout the whole list. They all should be unique.`;
   const request = async () => {
-    const { response } = await dispatchAIRequest({
-      modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
-      prompt,
-      systemInstruction: 'Respond with a JSON array of strings.',
-      thinkingBudget: 1024,
-      includeThoughts: false,
-      responseMimeType: 'application/json',
-      jsonSchema: { type: 'array', minItems: 50, items: { type: 'string' } },
-      label: 'HeroNames',
-    });
+      const { response } = await dispatchAIRequest({
+        modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        systemInstruction: 'Respond with a JSON array of strings.',
+        thinkingBudget: 1024,
+        includeThoughts: false,
+        responseMimeType: 'application/json',
+        jsonSchema: { type: 'array', minItems: 50, items: { type: 'string' } },
+        label: 'HeroNames',
+        maxOutputTokens: 6500,
+      });
     return response.text ?? null;
   };
   return retryAiCall<Array<string>>(async () => {
@@ -223,17 +225,18 @@ export const generateCharacterDescriptions = async (
       thinkingBudget: 1024,
       includeThoughts: false,
       responseMimeType: 'application/json',
-      jsonSchema: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: { name: { type: 'string' }, description: { type: 'string', minLength: 2000 } },
-          required: ['name', 'description'],
-          additionalProperties: false,
+        jsonSchema: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { name: { type: 'string' }, description: { type: 'string', minLength: 2000 } },
+            required: ['name', 'description'],
+            additionalProperties: false,
+          },
         },
-      },
-      label: 'HeroDescriptions',
-    });
+        label: 'HeroDescriptions',
+        maxOutputTokens: 6500,
+      });
     return response.text ?? null;
   };
   return retryAiCall<Array<CharacterOption>>(async () => {
@@ -261,19 +264,20 @@ export const generateHeroData = async (
     (heroName ? ` Their name is ${heroName}.` : '') +
     (heroDescription ? ` Here is a short description of the hero: ${heroDescription}.` : '') +
     ' Create a brief character sheet including occupation, notable traits, and starting items.';
-  const request = async (prompt: string, schema: unknown, label: string) => {
-    const { response } = await dispatchAIRequest({
-      modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
-      prompt,
-      systemInstruction: 'Respond only with JSON matching the provided schema.',
-      thinkingBudget: 1024,
-      includeThoughts: false,
-      responseMimeType: 'application/json',
-      jsonSchema: schema,
-      label,
-    });
-    return response.text ?? null;
-  };
+    const request = async (prompt: string, schema: unknown, label: string) => {
+      const { response } = await dispatchAIRequest({
+        modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        systemInstruction: 'Respond only with JSON matching the provided schema.',
+        thinkingBudget: 1024,
+        includeThoughts: false,
+        responseMimeType: 'application/json',
+        jsonSchema: schema,
+        label,
+        maxOutputTokens: 6500,
+      });
+      return response.text ?? null;
+    };
   return retryAiCall<{ heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null; storyArc: StoryArc | null }>(
     async () => {
       addProgressSymbol(LOADING_REASON_UI_MAP.initial_load.icon);
@@ -339,23 +343,24 @@ export const generateWorldData = async (
   const worldFactsPrompt =
     `Using the theme description "${theme.storyGuidance}", expand it into a detailed world profile.`;
 
-  const request = async (
-    prompt: string,
-    schema: unknown,
-    label: string,
-  ): Promise<string | null> => {
-    const { response } = await dispatchAIRequest({
-      modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
-      prompt,
-      systemInstruction: 'Respond only with JSON matching the provided schema.',
-      thinkingBudget: 1024,
-      includeThoughts: false,
-      responseMimeType: 'application/json',
-      jsonSchema: schema,
-      label,
-    });
-    return response.text ?? null;
-  };
+    const request = async (
+      prompt: string,
+      schema: unknown,
+      label: string,
+    ): Promise<string | null> => {
+      const { response } = await dispatchAIRequest({
+        modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        systemInstruction: 'Respond only with JSON matching the provided schema.',
+        thinkingBudget: 1024,
+        includeThoughts: false,
+        responseMimeType: 'application/json',
+        jsonSchema: schema,
+        label,
+        maxOutputTokens: 6500,
+      });
+      return response.text ?? null;
+    };
 
   return retryAiCall<WorldDataResult>(async () => {
     addProgressSymbol(LOADING_REASON_UI_MAP.initial_load.icon);
@@ -419,19 +424,20 @@ export const generateNextStoryAct = async (
     `Recent Log:\n${logLines}\n\n` +
     `Generate full details for Act ${String(nextActNumber)} (${nature}).`;
 
-  const request = async () => {
-    const { response } = await dispatchAIRequest({
-      modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
-      prompt,
-      systemInstruction: 'Respond only with JSON matching the provided schema.',
-      thinkingBudget: 1024,
-      includeThoughts: false,
-      responseMimeType: 'application/json',
-      jsonSchema: storyActSchema,
-      label: 'NextAct',
-    });
-    return response.text ?? null;
-  };
+    const request = async () => {
+      const { response } = await dispatchAIRequest({
+        modelNames: [GEMINI_LITE_MODEL_NAME, GEMINI_MODEL_NAME],
+        prompt,
+        systemInstruction: 'Respond only with JSON matching the provided schema.',
+        thinkingBudget: 1024,
+        includeThoughts: false,
+        responseMimeType: 'application/json',
+        jsonSchema: storyActSchema,
+        label: 'NextAct',
+        maxOutputTokens: 6500,
+      });
+      return response.text ?? null;
+    };
 
   return retryAiCall<StoryAct>(async () => {
     addProgressSymbol(LOADING_REASON_UI_MAP.storyteller.icon);

--- a/utils/initialStates.ts
+++ b/utils/initialStates.ts
@@ -54,7 +54,7 @@ export const getInitialGameStates = (): FullGameState => {
     lastJournalWriteTurn: 0,
     lastJournalInspectTurn: 0,
     lastLoreDistillTurn: 0,
-    gameLog: ["Welcome to Whispers in the Dark!"],
+    gameLog: [],
     lastActionLog: null,
     themeFacts: [],
     worldFacts: null,


### PR DESCRIPTION
## Summary
- remove initial "Welcome to Whispers in the Dark!" log entry
- allow API dispatcher to cap Gemini output tokens
- restrict game-start AI calls to 6500 tokens for faster error recovery

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6894820d37708324b3e3ecfa64351fd2