### PR TITLE
Avoid duplicate item creations from hints

### DIFF
--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -33,6 +33,7 @@ import {
   findMapNodeByIdentifier,
   findNPCByIdentifier,
 } from '../utils/entityUtils';
+import { filterDuplicateCreates } from '../utils/itemChangeUtils';
 
 interface CorrectItemChangesParams {
   aiItemChanges: Array<ItemChange>;
@@ -340,12 +341,6 @@ const handleInventoryHints = async ({
       );
     }
     setLoadingReason(original);
-    if (invResult) {
-      combinedItemChanges = combinedItemChanges.concat(invResult.itemChanges);
-      if (draftState.lastDebugPacket) {
-        draftState.lastDebugPacket.inventoryDebugInfo = invResult.debugInfo;
-      }
-    }
 
     let librarianHint =
       'librarianHint' in aiData ? aiData.librarianHint?.trim() : '';
@@ -367,6 +362,21 @@ const handleInventoryHints = async ({
         limitedMapContextWritten,
       );
     }
+
+    if (invResult && libResult) {
+      invResult.itemChanges = filterDuplicateCreates(
+        invResult.itemChanges,
+        libResult.itemChanges,
+      );
+    }
+
+    if (invResult) {
+      combinedItemChanges = combinedItemChanges.concat(invResult.itemChanges);
+      if (draftState.lastDebugPacket) {
+        draftState.lastDebugPacket.inventoryDebugInfo = invResult.debugInfo;
+      }
+    }
+
     if (libResult) {
       combinedItemChanges = combinedItemChanges.concat(libResult.itemChanges);
       if (draftState.lastDebugPacket) {

--- a/tests/itemChangeUtils.test.ts
+++ b/tests/itemChangeUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { filterDuplicateCreates } from '../utils/itemChangeUtils';
+import type { ItemChange } from '../types';
+
+describe('filterDuplicateCreates', () => {
+  it('removes inventory creates when librarian creates same item', () => {
+    const inventory: Array<ItemChange> = [
+      {
+        action: 'create',
+        item: {
+          id: 'book1',
+          name: 'Ancient Tome',
+          type: 'book',
+          description: 'old',
+          holderId: 'player',
+        },
+      },
+      {
+        action: 'create',
+        item: {
+          id: 'lantern1',
+          name: 'Lantern',
+          type: 'single-use',
+          description: 'light',
+          holderId: 'player',
+        },
+      },
+    ];
+    const librarian: Array<ItemChange> = [
+      {
+        action: 'create',
+        item: {
+          id: 'book2',
+          name: 'Ancient Tome',
+          type: 'book',
+          description: 'old',
+          holderId: 'player',
+        },
+      },
+    ];
+    const result = filterDuplicateCreates(inventory, librarian);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.item.name).toBe('Lantern');
+  });
+});

--- a/utils/itemChangeUtils.ts
+++ b/utils/itemChangeUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * @file itemChangeUtils.ts
+ * @description Helpers for working with arrays of ItemChange objects.
+ */
+
+import { ItemChange } from '../types';
+
+/**
+ * Filters out inventory create actions when the librarian already creates
+ * an item with the same name. Case-insensitive name comparison is used.
+ */
+export const filterDuplicateCreates = (
+  inventoryChanges: Array<ItemChange>,
+  librarianChanges: Array<ItemChange>,
+): Array<ItemChange> => {
+  const librarianNames = new Set<string>();
+  for (const change of librarianChanges) {
+    if (change.action === 'create' && typeof change.item.name === 'string') {
+      librarianNames.add(change.item.name.toLowerCase());
+    }
+  }
+  return inventoryChanges.filter(
+    change =>
+      !(
+        change.action === 'create' &&
+        typeof change.item.name === 'string' &&
+        librarianNames.has(change.item.name.toLowerCase())
+      ),
+  );
+};
+
+export default filterDuplicateCreates;


### PR DESCRIPTION
## Summary
- skip inventory creates when librarian already creates the same item
- add item change deduplication utility and unit test

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6894becd955483248e3e1f46edde6e57