### PR TITLE
Fix tag loss when item type is omitted and restore inspect after undo

### DIFF
--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -32,6 +32,7 @@ import {
 } from '../constants';
 
 import { structuredCloneGameState } from '../utils/cloneUtils';
+import { resetInspectCooldowns } from '../utils/undoUtils';
 import { generateNextStoryAct } from '../services/worldData';
 import { useProcessAiResponse } from './useProcessAiResponse';
 import { useInventoryActions } from './useInventoryActions';
@@ -487,11 +488,12 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
    * Restores the previous turn's game state if available.
    */
   const handleUndoTurn = useCallback(() => {
-    setGameStateStack((prevStack) => {
+    setGameStateStack(prevStack => {
       const [current, previous] = prevStack;
       if (previous && current.globalTurnNumber > 0) {
         clearObjectiveAnimationTimer();
-        return [previous, current];
+        const cleanedPrev = resetInspectCooldowns(previous);
+        return [cleanedPrev, current];
       }
       return prevStack;
     });

--- a/services/parsers/validation.ts
+++ b/services/parsers/validation.ts
@@ -129,11 +129,15 @@ export function isValidItem(item: unknown, context?: 'create' | 'change'): item 
     const normalized = normalizeTags(obj.tags);
     if (normalized) obj.tags = normalized;
     else obj.tags = obj.tags.filter(t => (VALID_TAGS as ReadonlyArray<string>).includes(t));
-
-    const allowed = WRITTEN_TYPE_SET.has(obj.type ?? '')
-      ? [...COMMON_TAGS, ...WRITTEN_TAGS]
-      : COMMON_TAGS;
-    obj.tags = obj.tags.filter(t => (allowed as ReadonlyArray<string>).includes(t));
+    const allowed =
+      obj.type === undefined
+        ? VALID_TAGS
+        : WRITTEN_TYPE_SET.has(obj.type)
+          ? [...COMMON_TAGS, ...WRITTEN_TAGS]
+          : COMMON_TAGS;
+    obj.tags = obj.tags.filter(t =>
+      (allowed as ReadonlyArray<string>).includes(t),
+    );
   }
   if (WRITTEN_TYPE_SET.has(obj.type ?? '')) {
     obj.tags = obj.tags ?? [];

--- a/tests/itemChangeParsing.test.ts
+++ b/tests/itemChangeParsing.test.ts
@@ -71,14 +71,14 @@ describe('parseInventoryResponse', () => {
       itemChanges: [
           {
             action: 'create',
-          item: {
-            name: 'Mysterious Note',
-            type: 'page',
-            description: 'An old piece of parchment',
-            holderId: PLAYER,
-          },
+        item: {
+          name: 'Mysterious Note',
+          type: 'page',
+          description: 'An old piece of parchment',
+          holderId: PLAYER,
         },
-      ],
+      },
+    ],
     };
 
     const text = '```json\n' + JSON.stringify(payload) + '\n```';
@@ -88,6 +88,24 @@ describe('parseInventoryResponse', () => {
 
     const item = res.itemChanges[0].item as { tags?: Array<string> };
     expect(item.tags).toEqual(['printed']);
+  });
+
+  it('retains tags when type is omitted in change action', () => {
+    const payload = {
+      change: [
+        {
+          id: 'i1',
+          name: 'Faded Music Sheet',
+          tags: ['handwritten', 'recovered'],
+        },
+      ],
+    };
+    const text = '```json\n' + JSON.stringify(payload) + '\n```';
+    const maybeRes = parseInventoryResponse(text);
+    if (!maybeRes) throw new Error('Failed to parse inventory response');
+    const res = maybeRes;
+    const item = res.itemChanges[0].item as { tags?: Array<string> };
+    expect(item.tags).toEqual(['handwritten', 'recovered']);
   });
 
   it('preserves malformed addDetails with invalidPayload', () => {

--- a/tests/resetInspectCooldowns.test.ts
+++ b/tests/resetInspectCooldowns.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { resetInspectCooldowns } from '../utils/undoUtils';
+import { getInitialGameStates } from '../utils/initialStates';
+import { PLAYER_HOLDER_ID } from '../constants';
+
+describe('resetInspectCooldowns', () => {
+  it('clears future inspect timestamps', () => {
+    const state = getInitialGameStates();
+    state.globalTurnNumber = 4;
+    state.inventory = [{
+      id: 'p1',
+      name: 'Page',
+      type: 'page',
+      description: 'note',
+      holderId: PLAYER_HOLDER_ID,
+      lastInspectTurn: 6,
+    }];
+    state.lastJournalInspectTurn = 7;
+    const cleaned = resetInspectCooldowns(state);
+    expect(cleaned.inventory[0].lastInspectTurn).toBeUndefined();
+    expect(cleaned.lastJournalInspectTurn).toBe(0);
+  });
+
+  it('clears inspect timestamps equal to current turn', () => {
+    const state = getInitialGameStates();
+    state.globalTurnNumber = 4;
+    state.inventory = [{
+      id: 'p1',
+      name: 'Page',
+      type: 'page',
+      description: 'note',
+      holderId: PLAYER_HOLDER_ID,
+      lastInspectTurn: 4,
+    }];
+    state.lastJournalInspectTurn = 4;
+    const cleaned = resetInspectCooldowns(state);
+    expect(cleaned.inventory[0].lastInspectTurn).toBeUndefined();
+    expect(cleaned.lastJournalInspectTurn).toBe(0);
+  });
+
+  it('preserves valid inspect timestamps', () => {
+    const state = getInitialGameStates();
+    state.globalTurnNumber = 4;
+    state.inventory = [{
+      id: 'p1',
+      name: 'Page',
+      type: 'page',
+      description: 'note',
+      holderId: PLAYER_HOLDER_ID,
+      lastInspectTurn: 3,
+    }];
+    state.lastJournalInspectTurn = 2;
+    const cleaned = resetInspectCooldowns(state);
+    expect(cleaned.inventory[0].lastInspectTurn).toBe(3);
+    expect(cleaned.lastJournalInspectTurn).toBe(2);
+  });
+});

--- a/utils/undoUtils.ts
+++ b/utils/undoUtils.ts
@@ -1,0 +1,21 @@
+import { structuredCloneGameState } from './cloneUtils';
+import { FullGameState } from '../types';
+
+/**
+ * Resets inspect-related cooldown timestamps that point to future turns.
+ *
+ * @param state - Game state to sanitize.
+ * @returns Deep-cloned state with invalid inspect timestamps cleared.
+ */
+export function resetInspectCooldowns(state: FullGameState): FullGameState {
+  const cleaned = structuredCloneGameState(state);
+  cleaned.inventory = cleaned.inventory.map(item => (
+    item.lastInspectTurn !== undefined && item.lastInspectTurn >= cleaned.globalTurnNumber
+      ? { ...item, lastInspectTurn: undefined }
+      : item
+  ));
+  if (cleaned.lastJournalInspectTurn >= cleaned.globalTurnNumber) {
+    cleaned.lastJournalInspectTurn = 0;
+  }
+  return cleaned;
+}


### PR DESCRIPTION
## Summary
- keep tag arrays intact when parsing item changes with no type
- add regression test for tag preservation on change action
- reset inspect cooldowns when undoing a turn so Inspect is re-enabled
- clear inspect timestamps from current turns and add unit coverage

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6894d150fd588324b5fc05b4f8b6c9f2