### PR TITLE
Use item IDs for inventory actions

### DIFF
--- a/components/app/GameSidebar.tsx
+++ b/components/app/GameSidebar.tsx
@@ -23,8 +23,8 @@ interface GameSidebarProps {
   readonly storyArc: StoryArc | null;
   readonly mapNodes: Array<MapNode>;
   readonly objectiveAnimationType: 'success' | 'neutral' | null;
-  readonly onDropItem: (itemName: string) => void;
-  readonly onStashToggle: (itemName: string) => void;
+  readonly onDropItem: (itemId: string) => void;
+  readonly onStashToggle: (itemId: string) => void;
   readonly onItemInteract: (
     item: Item,
     interactionType: 'generic' | 'specific' | 'inspect',
@@ -32,7 +32,7 @@ interface GameSidebarProps {
   ) => void;
   readonly onReadPage: (item: Item) => void;
   readonly onReadPlayerJournal: () => void;
-  readonly onTakeItem: (itemName: string) => void;
+  readonly onTakeItem: (itemId: string) => void;
   readonly globalTurnNumber: number;
   readonly disabled: boolean;
 }

--- a/components/elements/Button.tsx
+++ b/components/elements/Button.tsx
@@ -56,10 +56,11 @@ export interface ButtonProps {
   readonly title?: string;
   readonly type?: 'button' | 'submit' | 'reset';
   readonly 'data-action-name'?: string;
+  readonly 'data-item-id'?: string;
   readonly 'data-item-name'?: string;
+  readonly 'data-node-id'?: string;
   readonly 'data-option'?: string;
   readonly 'data-prompt-effect'?: string;
-  readonly 'data-node-id'?: string;
   readonly variant?: ButtonVariant;
   readonly preset?: ButtonPreset;
 }
@@ -79,10 +80,11 @@ function Button({
   variant = 'standard',
   preset,
   'data-action-name': dataActionName,
+  'data-item-id': dataItemId,
   'data-item-name': dataItemName,
+  'data-node-id': dataNodeId,
   'data-option': dataOption,
   'data-prompt-effect': dataPromptEffect,
-  'data-node-id': dataNodeId,
 }: ButtonProps) {
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
@@ -164,6 +166,7 @@ function Button({
       aria-pressed={variant === 'toggle' ? pressed : undefined}
       className={`rounded-md shadow transition-colors duration-150 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 ${appliedSize} ${variantClasses[variant]} ${preset ? presetClasses[preset] : ''} ${pressedClasses}`}
       data-action-name={dataActionName}
+      data-item-id={dataItemId}
       data-item-name={dataItemName}
       data-node-id={dataNodeId}
       data-option={dataOption}
@@ -190,6 +193,7 @@ function Button({
 
 Button.defaultProps = {
   'data-action-name': undefined,
+  'data-item-id': undefined,
   'data-item-name': undefined,
   'data-node-id': undefined,
   'data-option': undefined,

--- a/components/inventory/InventoryDisplay.tsx
+++ b/components/inventory/InventoryDisplay.tsx
@@ -17,8 +17,8 @@ interface InventoryDisplayProps {
     interactionType: 'generic' | 'specific' | 'inspect',
     knownUse?: KnownUse
   ) => void;
-  readonly onDropItem: (itemName: string) => void;
-  readonly onStashToggle: (itemName: string) => void;
+  readonly onDropItem: (itemId: string) => void;
+  readonly onStashToggle: (itemId: string) => void;
   readonly onReadPage: (item: Item) => void;
   readonly currentTurn: number;
   readonly disabled: boolean;
@@ -27,9 +27,9 @@ interface InventoryDisplayProps {
 function InventoryDisplay({ items, onItemInteract, onDropItem, onStashToggle, onReadPage, currentTurn, disabled }: InventoryDisplayProps) {
   const {
     displayedItems,
-    newlyAddedItemNames,
-    stashingItemNames,
-    confirmingDiscardItemName,
+    newlyAddedItemIds,
+    stashingItemIds,
+    confirmingDiscardItemId,
     sortOrder,
     handleSortByName,
     handleSortByType,
@@ -60,21 +60,21 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, onStashToggle, on
 
   const registerItemRef = useCallback((el: HTMLLIElement | null) => {
     if (!el) return;
-    const name = el.dataset.itemName;
-    if (name) {
-      itemElementMap.current.set(name, el);
+    const id = el.dataset.itemId;
+    if (id) {
+      itemElementMap.current.set(id, el);
     }
   }, []);
 
   useLayoutEffect(() => {
     const newRects = new Map<string, DOMRect>();
-    itemElementMap.current.forEach((el, name) => {
+    itemElementMap.current.forEach((el, id) => {
       if (!el.isConnected) {
-        itemElementMap.current.delete(name);
-        prevRectsRef.current.delete(name);
+        itemElementMap.current.delete(id);
+        prevRectsRef.current.delete(id);
         return;
       }
-      newRects.set(name, el.getBoundingClientRect());
+      newRects.set(id, el.getBoundingClientRect());
     });
 
     if (prevDisabledRef.current !== disabled) {
@@ -84,9 +84,9 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, onStashToggle, on
     }
 
     if (!disabled) {
-      prevRectsRef.current.forEach((prevRect, name) => {
-        const newRect = newRects.get(name);
-        const el = itemElementMap.current.get(name);
+      prevRectsRef.current.forEach((prevRect, id) => {
+        const newRect = newRects.get(id);
+        const el = itemElementMap.current.get(id);
         if (!newRect || !el) return;
         const dx = Math.round(prevRect.left - newRect.left);
         const dy = Math.round(prevRect.top - newRect.top);
@@ -144,9 +144,9 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, onStashToggle, on
         <ul className="flex flex-wrap justify-center gap-4 list-none p-0">
           {displayedItems.map(item => {
             const applicableUses = getApplicableKnownUses(item);
-            const isNew = newlyAddedItemNames.has(item.name);
-            const isStashing = stashingItemNames.has(item.name);
-            const isConfirmingDiscard = confirmingDiscardItemName === item.name;
+            const isNew = newlyAddedItemIds.has(item.id);
+            const isStashing = stashingItemIds.has(item.id);
+            const isConfirmingDiscard = confirmingDiscardItemId === item.id;
             return (
               <InventoryItem
                 applicableUses={applicableUses}
@@ -157,7 +157,7 @@ function InventoryDisplay({ items, onItemInteract, onDropItem, onStashToggle, on
                 isNew={isNew}
                 isStashing={isStashing}
                 item={item}
-                key={item.name}
+                key={item.id}
                 onCancelDiscard={handleCancelDiscard}
                 onConfirmDrop={handleConfirmDrop}
                 onGenericUse={handleGenericUse}

--- a/components/inventory/InventoryItem.tsx
+++ b/components/inventory/InventoryItem.tsx
@@ -73,10 +73,10 @@ function InventoryItem({
       <Button
         ariaLabel={`${knownUse.actionName}${knownUse.description ? ': ' + knownUse.description : ''}`}
         data-action-name={knownUse.actionName}
-        data-item-name={item.name}
+        data-item-id={item.id}
         data-prompt-effect={knownUse.promptEffect}
         disabled={disabled || isConfirmingDiscard}
-        key={`${item.name}-knownuse-${knownUse.actionName}`}
+        key={`${item.id}-knownuse-${knownUse.actionName}`}
         label={knownUse.actionName}
         onClick={onSpecificUse}
         preset="teal"
@@ -102,9 +102,9 @@ function InventoryItem({
   actionButtons.push(
     <Button
       ariaLabel={`Inspect ${item.name}`}
-      data-item-name={item.name}
+      data-item-id={item.id}
       disabled={inspectDisabled}
-      key={`${item.name}-inspect`}
+        key={`${item.id}-inspect`}
       label="Inspect"
       onClick={onInspect}
       preset="indigo"
@@ -116,13 +116,13 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={`Read ${item.name}`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={
           disabled ||
           isConfirmingDiscard ||
           (item.id === PLAYER_JOURNAL_ID && (item.chapters?.length ?? 0) === 0)
         }
-        key={`${item.name}-read`}
+        key={`${item.id}-read`}
         label="Read"
         onClick={onRead}
         preset="teal"
@@ -136,9 +136,9 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={`Attempt to use ${item.name} (generic action)`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled || isConfirmingDiscard}
-        key={`${item.name}-generic-use`}
+        key={`${item.id}-generic-use`}
         label="Attempt to Use (Generic)"
         onClick={onGenericUse}
         preset="sky"
@@ -151,9 +151,9 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled || isConfirmingDiscard}
-        key={`${item.name}-vehicle-action`}
+        key={`${item.id}-vehicle-action`}
         label={item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`}
         onClick={onVehicleToggle}
         preset="sky"
@@ -166,7 +166,7 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={`Discard ${item.name}`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled}
         icon={<Icon
           color="white"
@@ -175,7 +175,7 @@ function InventoryItem({
           name="trash"
           size={16}
         />}
-        key={`${item.name}-discard`}
+        key={`${item.id}-discard`}
         label="Discard"
         onClick={onStartConfirmDiscard}
         preset="orange"
@@ -194,9 +194,9 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={filterMode === 'stashed' ? `Retrieve ${item.name}` : `Stash ${item.name}`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled}
-        key={`${item.name}-stash`}
+        key={`${item.id}-stash`}
         label={filterMode === 'stashed' ? 'Retrieve' : 'Stash'}
         onClick={onStashToggle}
         preset="sky"
@@ -209,9 +209,9 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={`Drop ${item.name}`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled}
-        key={`${item.name}-drop`}
+        key={`${item.id}-drop`}
         label="Drop"
         onClick={onStartConfirmDiscard}
         preset="sky"
@@ -224,9 +224,9 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={`Drop ${item.name}`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled}
-        key={`${item.name}-drop`}
+        key={`${item.id}-drop`}
         label="Drop"
         onClick={onStartConfirmDiscard}
         preset="sky"
@@ -239,9 +239,9 @@ function InventoryItem({
     actionButtons.push(
       <Button
         ariaLabel={`Park ${item.name} here`}
-        data-item-name={item.name}
+        data-item-id={item.id}
         disabled={disabled}
-        key={`${item.name}-drop`}
+        key={`${item.id}-drop`}
         label="Park Here"
         onClick={onStartConfirmDiscard}
         preset="sky"
@@ -254,13 +254,13 @@ function InventoryItem({
     actionButtons.push(
       <div
         className="grid grid-cols-2 gap-2 mt-2"
-        key={`${item.name}-confirm-group`}
+        key={`${item.id}-confirm-group`}
       >
         <Button
           ariaLabel={`Confirm drop of ${item.name}`}
-          data-item-name={item.name}
+          data-item-id={item.id}
           disabled={disabled}
-          key={`${item.name}-confirm-drop`}
+          key={`${item.id}-confirm-drop`}
           label={
             item.type === 'vehicle' && !item.isActive
               ? 'Confirm Park'
@@ -276,7 +276,7 @@ function InventoryItem({
         <Button
           ariaLabel="Cancel discard"
           disabled={disabled}
-          key={`${item.name}-cancel-discard`}
+          key={`${item.id}-cancel-discard`}
           label="Cancel"
           onClick={onCancelDiscard}
           preset="slate"
@@ -289,8 +289,8 @@ function InventoryItem({
   return (
     <li
       className={`w-[270px] text-slate-300 bg-slate-700/60 p-4 rounded-md shadow border border-slate-600 ${isNew ? 'animate-new-item-pulse' : ''} ${isStashing ? 'animate-archive-fade-out' : ''} flex flex-col`}
-      data-item-name={item.name}
-      key={item.name}
+      data-item-id={item.id}
+      key={item.id}
       ref={registerRef}
     >
       <div className="flex justify-between items-center mb-1 text-xs">

--- a/components/inventory/LocationItemsDisplay.tsx
+++ b/components/inventory/LocationItemsDisplay.tsx
@@ -7,7 +7,7 @@ import Button from '../elements/Button';
 
 interface LocationItemsDisplayProps {
   readonly items: Array<Item>;
-  readonly onTakeItem: (itemName: string) => void;
+  readonly onTakeItem: (itemId: string) => void;
   readonly onItemInteract: (
     item: Item,
     type: 'generic' | 'specific' | 'inspect',
@@ -21,9 +21,9 @@ interface LocationItemsDisplayProps {
 function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, currentNodeId, mapNodes }: LocationItemsDisplayProps) {
   const handleTakeItem = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const itemName = event.currentTarget.dataset.itemName;
-      if (itemName) {
-        onTakeItem(itemName);
+      const itemId = event.currentTarget.dataset.itemId;
+      if (itemId) {
+        onTakeItem(itemId);
         event.currentTarget.blur();
       }
     },
@@ -32,9 +32,9 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
 
   const handleInspect = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (!name) return;
-      const item = items.find(i => i.name === name);
+      const id = event.currentTarget.dataset.itemId;
+      if (!id) return;
+      const item = items.find(i => i.id === id);
       if (!item) return;
       onItemInteract(item, 'inspect');
       event.currentTarget.blur();
@@ -44,9 +44,9 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
 
   const handleGenericUse = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (!name) return;
-      const item = items.find(i => i.name === name);
+      const id = event.currentTarget.dataset.itemId;
+      if (!id) return;
+      const item = items.find(i => i.id === id);
       if (!item) return;
       onItemInteract(item, 'generic');
       event.currentTarget.blur();
@@ -56,9 +56,9 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
 
   const handleSpecificUse = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const { itemName, actionName, promptEffect } = event.currentTarget.dataset;
-      if (!itemName || !actionName || !promptEffect) return;
-      const item = items.find(i => i.name === itemName);
+      const { itemId, actionName, promptEffect } = event.currentTarget.dataset;
+      if (!itemId || !actionName || !promptEffect) return;
+      const item = items.find(i => i.id === itemId);
       if (!item) return;
       const ku: KnownUse = { actionName, promptEffect, description: actionName };
       onItemInteract(item, 'specific', ku);
@@ -113,7 +113,7 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
           return (
             <li
               className="w-[270px] text-slate-300 bg-slate-700/60 p-4 rounded-md shadow border border-slate-600 flex flex-col"
-              key={item.name}
+              key={item.id}
             >
               <div className="flex justify-between items-center mb-1 text-xs">
                 <ItemTypeDisplay type={item.type} />
@@ -146,10 +146,10 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
                       <Button
                         ariaLabel={`${ku.actionName}${ku.description ? ': ' + ku.description : ''}`}
                         data-action-name={ku.actionName}
-                        data-item-name={item.name}
+                        data-item-id={item.id}
                         data-prompt-effect={ku.promptEffect}
                         disabled={disabled}
-                        key={`${item.name}-ku-${ku.actionName}`}
+                        key={`${item.id}-ku-${ku.actionName}`}
                         label={ku.actionName}
                         onClick={handleSpecificUse}
                         preset="teal"
@@ -160,7 +160,7 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
 
                     <Button
                       ariaLabel={`Inspect ${item.name}`}
-                      data-item-name={item.name}
+                      data-item-id={item.id}
                       disabled={disabled}
                       label="Inspect"
                       onClick={handleInspect}
@@ -170,7 +170,7 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
 
                     <Button
                       ariaLabel={`Attempt to use ${item.name}`}
-                      data-item-name={item.name}
+                      data-item-id={item.id}
                       disabled={disabled}
                       label="Attempt to Use (Generic)"
                       onClick={handleGenericUse}
@@ -182,7 +182,7 @@ function LocationItemsDisplay({ items, onTakeItem, onItemInteract, disabled, cur
                   <button
                     aria-label={item.type === 'vehicle' ? `Enter ${item.name}` : `Take ${item.name}`}
                     className="w-full text-sm bg-green-700 hover:bg-green-600 text-white font-medium py-1.5 px-3 rounded shadow disabled:bg-slate-600 disabled:text-slate-300 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-                    data-item-name={item.name}
+                    data-item-id={item.id}
                     disabled={disabled}
                     onClick={handleTakeItem}
                     type="button"

--- a/hooks/useInventoryActions.ts
+++ b/hooks/useInventoryActions.ts
@@ -30,19 +30,19 @@ export const useInventoryActions = ({
     getStateRef.current = getCurrentGameState;
   }, [getCurrentGameState]);
   const handleDropItem = useCallback(
-    (itemName: string, logMessageOverride?: string) => {
+    (itemId: string, logMessageOverride?: string) => {
       const currentFullState = getCurrentGameState();
       if (isLoading || currentFullState.dialogueState) return;
 
       const itemToDiscard = currentFullState.inventory.find(
-        (item) => item.name === itemName && item.holderId === PLAYER_HOLDER_ID,
+        item => item.id === itemId && item.holderId === PLAYER_HOLDER_ID,
       );
       if (!itemToDiscard) return;
 
       const draftState = structuredCloneGameState(currentFullState);
       const currentLocationId = currentFullState.currentMapNodeId ?? 'unknown';
       draftState.inventory = draftState.inventory.map(item => {
-        if (item.name !== itemName || item.holderId !== PLAYER_HOLDER_ID) {
+        if (item.id !== itemId || item.holderId !== PLAYER_HOLDER_ID) {
           return item;
         }
 
@@ -82,9 +82,9 @@ export const useInventoryActions = ({
           currentFullState.localPlace ??
           'Unknown Place';
         if (itemToDiscard.type === 'vehicle' && !itemToDiscard.isActive) {
-          logMessage = `You left your ${itemName} parked at ${placeName}.`;
+          logMessage = `You left your ${itemToDiscard.name} parked at ${placeName}.`;
         } else {
-          logMessage = `You left your ${itemName} at ${placeName}.`;
+          logMessage = `You left your ${itemToDiscard.name} at ${placeName}.`;
         }
       }
 
@@ -98,7 +98,7 @@ export const useInventoryActions = ({
   );
 
   const handleTakeLocationItem = useCallback(
-    (itemName: string) => {
+    (itemId: string) => {
       const currentFullState = getCurrentGameState();
       if (isLoading || currentFullState.dialogueState) return;
 
@@ -106,8 +106,8 @@ export const useInventoryActions = ({
       if (!currentLocationId) return;
 
       const adjacentIds = getAdjacentNodeIds(currentFullState.mapData, currentLocationId);
-      const itemToTake = currentFullState.inventory.find((item) => {
-        if (item.name !== itemName) return false;
+      const itemToTake = currentFullState.inventory.find(item => {
+        if (item.id !== itemId) return false;
         if (item.holderId === currentLocationId) return true;
         return adjacentIds.includes(item.holderId);
       });
@@ -115,7 +115,7 @@ export const useInventoryActions = ({
 
       const draftState = structuredCloneGameState(currentFullState);
       draftState.inventory = draftState.inventory.map((item) =>
-        item.name === itemName && item.holderId === itemToTake.holderId
+        item.id === itemId && item.holderId === itemToTake.holderId
           ? { ...item, holderId: PLAYER_HOLDER_ID }
           : item,
       );
@@ -140,8 +140,8 @@ export const useInventoryActions = ({
       };
       draftState.lastTurnChanges = turnChangesForTake;
 
-      draftState.gameLog = removeDroppedItemLog(draftState.gameLog, itemName);
-      if (draftState.lastActionLog?.startsWith(`You left your ${itemName}`)) {
+      draftState.gameLog = removeDroppedItemLog(draftState.gameLog, itemToTake.name);
+      if (draftState.lastActionLog?.startsWith(`You left your ${itemToTake.name}`)) {
         draftState.lastActionLog = null;
       }
       commitGameState(draftState);
@@ -273,13 +273,13 @@ export const useInventoryActions = ({
 
 
   const handleStashToggle = useCallback(
-    (name: string) => {
+    (id: string) => {
       const currentFullState = getCurrentGameState();
       if (isLoading || currentFullState.dialogueState) return;
 
       const draftState = structuredCloneGameState(currentFullState);
       draftState.inventory = draftState.inventory.map(item =>
-        item.name === name && item.holderId === PLAYER_HOLDER_ID
+        item.id === id && item.holderId === PLAYER_HOLDER_ID
           ? { ...item, stashed: !item.stashed }
           : item,
       );

--- a/hooks/useInventoryDisplay.ts
+++ b/hooks/useInventoryDisplay.ts
@@ -14,8 +14,8 @@ interface UseInventoryDisplayProps {
     type: 'generic' | 'specific' | 'inspect',
     knownUse?: KnownUse
   ) => void;
-  readonly onDropItem: (itemName: string) => void;
-  readonly onStashToggle: (itemName: string) => void;
+  readonly onDropItem: (itemId: string) => void;
+  readonly onStashToggle: (itemId: string) => void;
   readonly onReadPage: (item: Item) => void;
 }
 
@@ -27,12 +27,12 @@ export const useInventoryDisplay = ({
   onStashToggle,
   onReadPage,
 }: UseInventoryDisplayProps) => {
-  const [newlyAddedItemNames, setNewlyAddedItemNames] = useState<Set<string>>(new Set());
+  const [newlyAddedItemIds, setNewlyAddedItemIds] = useState<Set<string>>(new Set());
   const prevItemsRef = useRef<Array<Item>>(items);
-  const [confirmingDiscardItemName, setConfirmingDiscardItemName] = useState<string | null>(null);
+  const [confirmingDiscardItemId, setConfirmingDiscardItemId] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<SortOrder>('default');
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
-  const [stashingItemNames, setStashingItemNames] = useState<Set<string>>(new Set());
+  const [stashingItemIds, setStashingItemIds] = useState<Set<string>>(new Set());
 
   const handleSortByName = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     setSortOrder(prev => (prev === 'name' ? 'default' : 'name'));
@@ -55,22 +55,22 @@ export const useInventoryDisplay = ({
   }, []);
 
   const handleStartConfirmDiscard = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    const name = event.currentTarget.dataset.itemName;
-    if (name) {
-      setConfirmingDiscardItemName(name);
+    const id = event.currentTarget.dataset.itemId;
+    if (id) {
+      setConfirmingDiscardItemId(id);
       event.currentTarget.blur();
     }
   }, []);
 
   const handleConfirmDrop = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (!name) return;
-      const item = items.find(i => i.name === name);
+      const id = event.currentTarget.dataset.itemId;
+      if (!id) return;
+      const item = items.find(i => i.id === id);
       if (!item) return;
-      onDropItem(name);
+      onDropItem(id);
 
-      setConfirmingDiscardItemName(null);
+      setConfirmingDiscardItemId(null);
       event.currentTarget.blur();
     },
     [items, onDropItem]
@@ -79,36 +79,36 @@ export const useInventoryDisplay = ({
 
   const handleStashToggleInternal = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (name) {
-        const item = items.find(i => i.name === name);
-        onStashToggle(name);
+      const id = event.currentTarget.dataset.itemId;
+      if (id) {
+        const item = items.find(i => i.id === id);
+        onStashToggle(id);
         if (item?.stashed) {
           if (filterMode === 'stashed') {
-            setStashingItemNames(current => new Set(current).add(name));
+            setStashingItemIds(current => new Set(current).add(id));
             setTimeout(() => {
-              setStashingItemNames(current => {
+              setStashingItemIds(current => {
                 const updated = new Set(current);
-                updated.delete(name);
+                updated.delete(id);
                 return updated;
               });
             }, 1000);
           } else {
-            setNewlyAddedItemNames(current => new Set(current).add(name));
+            setNewlyAddedItemIds(current => new Set(current).add(id));
             setTimeout(() => {
-              setNewlyAddedItemNames(current => {
+              setNewlyAddedItemIds(current => {
                 const updated = new Set(current);
-                updated.delete(name);
+                updated.delete(id);
                 return updated;
               });
             }, 1500);
           }
         } else {
-          setStashingItemNames(current => new Set(current).add(name));
+          setStashingItemIds(current => new Set(current).add(id));
           setTimeout(() => {
-            setStashingItemNames(current => {
+            setStashingItemIds(current => {
               const updated = new Set(current);
-              updated.delete(name);
+              updated.delete(id);
               return updated;
             });
           }, 1000);
@@ -120,15 +120,15 @@ export const useInventoryDisplay = ({
   );
 
   const handleCancelDiscard = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    setConfirmingDiscardItemName(null);
+    setConfirmingDiscardItemId(null);
     event.currentTarget.blur();
   }, []);
 
   const handleSpecificUse = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const { itemName, actionName, promptEffect } = event.currentTarget.dataset;
-      if (!itemName || !actionName || !promptEffect) return;
-      const item = items.find(i => i.name === itemName);
+      const { itemId, actionName, promptEffect } = event.currentTarget.dataset;
+      if (!itemId || !actionName || !promptEffect) return;
+      const item = items.find(i => i.id === itemId);
       if (!item) return;
       const knownUse: KnownUse = {
         actionName,
@@ -143,9 +143,9 @@ export const useInventoryDisplay = ({
 
   const handleInspect = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (!name) return;
-      const item = items.find(i => i.name === name);
+      const id = event.currentTarget.dataset.itemId;
+      if (!id) return;
+      const item = items.find(i => i.id === id);
       if (!item) return;
       onItemInteract(item, 'inspect');
       event.currentTarget.blur();
@@ -155,9 +155,9 @@ export const useInventoryDisplay = ({
 
   const handleGenericUse = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (!name) return;
-      const item = items.find(i => i.name === name);
+      const id = event.currentTarget.dataset.itemId;
+      if (!id) return;
+      const item = items.find(i => i.id === id);
       if (!item) return;
       onItemInteract(item, 'generic');
       event.currentTarget.blur();
@@ -167,9 +167,9 @@ export const useInventoryDisplay = ({
 
   const handleVehicleToggle = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const name = event.currentTarget.dataset.itemName;
-      if (!name) return;
-      const item = items.find(i => i.name === name);
+      const id = event.currentTarget.dataset.itemId;
+      if (!id) return;
+      const item = items.find(i => i.id === id);
       if (!item) return;
       const actionName = item.isActive ? `Exit ${item.name}` : `Enter ${item.name}`;
       const dynamicKnownUse: KnownUse = {
@@ -184,9 +184,9 @@ export const useInventoryDisplay = ({
   );
 
   const handleRead = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    const name = event.currentTarget.dataset.itemName;
-    if (!name) return;
-    const item = items.find(i => i.name === name);
+    const id = event.currentTarget.dataset.itemId;
+    if (!id) return;
+    const item = items.find(i => i.id === id);
     if (!item) return;
     onReadPage(item);
     event.currentTarget.blur();
@@ -194,28 +194,28 @@ export const useInventoryDisplay = ({
 
 
   useEffect(() => {
-    const currentItemNames = new Set(items.map(item => item.name));
-    const prevItemNames = new Set(prevItemsRef.current.map(item => item.name));
+    const currentItemIds = new Set(items.map(item => item.id));
+    const prevItemIds = new Set(prevItemsRef.current.map(item => item.id));
     const added: Array<string> = [];
 
-    currentItemNames.forEach(name => {
-      if (!prevItemNames.has(name)) {
-        added.push(name);
+    currentItemIds.forEach(id => {
+      if (!prevItemIds.has(id)) {
+        added.push(id);
       }
     });
 
     if (added.length > 0) {
-      setNewlyAddedItemNames(currentAnimatingItems => {
+      setNewlyAddedItemIds(currentAnimatingItems => {
         const newSet = new Set(currentAnimatingItems);
-        added.forEach(name => newSet.add(name));
+        added.forEach(id => newSet.add(id));
         return newSet;
       });
 
-      added.forEach(name => {
+      added.forEach(id => {
         setTimeout(() => {
-          setNewlyAddedItemNames(currentAnimatingItems => {
+          setNewlyAddedItemIds(currentAnimatingItems => {
             const updatedSet = new Set(currentAnimatingItems);
-            updatedSet.delete(name);
+            updatedSet.delete(id);
             return updatedSet;
           });
         }, 1500);
@@ -226,7 +226,7 @@ export const useInventoryDisplay = ({
 
   const displayedItems = useMemo(() => {
     const itemsToDisplay = items.filter(item => {
-      if (stashingItemNames.has(item.name)) return true;
+      if (stashingItemIds.has(item.id)) return true;
       const isWritten = ['page', 'book', 'picture', 'map'].includes(item.type);
       if (filterMode === 'stashed') return item.stashed && isWritten;
       const isStashedWritten = item.stashed && isWritten;
@@ -249,7 +249,7 @@ export const useInventoryDisplay = ({
       sortedItems.reverse();
     }
     return sortedItems;
-  }, [items, sortOrder, filterMode, stashingItemNames]);
+  }, [items, sortOrder, filterMode, stashingItemIds]);
 
   const getApplicableKnownUses = useCallback((item: Item): Array<KnownUse> => {
     if (!item.knownUses) return [];
@@ -275,9 +275,9 @@ export const useInventoryDisplay = ({
 
   return {
     displayedItems,
-    newlyAddedItemNames,
-    stashingItemNames,
-    confirmingDiscardItemName,
+    newlyAddedItemIds,
+    stashingItemIds,
+    confirmingDiscardItemId,
     sortOrder,
     filterMode,
     handleSortByName,


### PR DESCRIPTION
## Summary
- Use item IDs instead of names for inventory handlers and keys
- Support item IDs in button components
- Drop, stash, and take item actions now work with IDs

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a9d8ab54dc8324a19e7b4efeab2985