### PR TITLE
feat: show act intro modal and enhance victory screen

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -26,6 +26,7 @@ import DebugLoreModal from '../modals/DebugLoreModal';
 import GeminiKeyModal from '../modals/GeminiKeyModal';
 import CharacterSelectModal from '../modals/CharacterSelectModal';
 import GenderSelectModal from '../modals/GenderSelectModal';
+import ActIntroModal from '../modals/ActIntroModal';
 import VictoryScreen from '../modals/VictoryScreen';
 import Footer from './Footer';
 import AppModals from './AppModals';
@@ -61,6 +62,7 @@ import {
   CharacterOption,
   HeroSheet,
   HeroBackstory,
+  StoryAct,
   StoryArc,
   ThinkingEffort,
 } from '../../types';
@@ -263,9 +265,26 @@ function App() {
       simulateVictory,
       queueItemAction,
       queuedItemActions,
-      clearQueuedItemActions,
-      remainingActionPoints,
-    } = gameLogic;
+    clearQueuedItemActions,
+    remainingActionPoints,
+  } = gameLogic;
+
+  const [pendingAct, setPendingAct] = useState<StoryAct | null>(null);
+  const [lastShownAct, setLastShownAct] = useState(0);
+
+  useEffect(() => {
+    if (storyArc && storyArc.currentAct !== lastShownAct) {
+      const index = storyArc.currentAct - 1;
+      if (storyArc.acts.length > index) {
+        setPendingAct(storyArc.acts[index]);
+        setLastShownAct(storyArc.currentAct);
+      }
+    }
+  }, [storyArc?.currentAct, storyArc, lastShownAct]);
+
+  const handleActContinue = useCallback(() => {
+    setPendingAct(null);
+  }, []);
 
 
   const handleApplyGameState = useCallback(
@@ -332,7 +351,8 @@ function App() {
     effectiveIsTitleMenuOpen ||
     newGameFromMenuConfirmOpen ||
     loadGameFromMenuConfirmOpen ||
-    isCustomGameSetupVisible;
+    isCustomGameSetupVisible ||
+    pendingAct !== null;
 
 
   useEffect(() => {
@@ -932,6 +952,13 @@ function App() {
         isVisible={isGenderSelectVisible}
         onSubmit={submitGenderSelectModal}
       />
+
+      {pendingAct ? (
+        <ActIntroModal
+          act={pendingAct}
+          onContinue={handleActContinue}
+        />
+      ) : null}
 
       {isVictory && heroSheet && storyArc ? (
         <VictoryScreen

--- a/components/modals/ActIntroModal.tsx
+++ b/components/modals/ActIntroModal.tsx
@@ -1,0 +1,40 @@
+import Button from '../elements/Button';
+import type { StoryAct } from '../../types';
+
+interface ActIntroModalProps {
+  readonly act: StoryAct;
+  readonly onContinue: () => void;
+}
+
+function ActIntroModal({ act, onContinue }: ActIntroModalProps) {
+  return (
+    <div
+      aria-labelledby="act-intro-heading"
+      aria-modal="true"
+      className="animated-frame open"
+      role="dialog"
+    >
+      <div className="animated-frame-content flex flex-col items-center p-4 text-center">
+        <h2 id="act-intro-heading" className="text-2xl font-bold">
+          {`Act ${String(act.actNumber)}: ${act.title}`}
+        </h2>
+
+        <p className="mt-4">
+          {act.description}
+        </p>
+
+        <div className="mt-6">
+          <Button
+            ariaLabel="Continue"
+            label="Continue"
+            onClick={onContinue}
+            preset="blue"
+            size="lg"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ActIntroModal;

--- a/components/modals/VictoryScreen.tsx
+++ b/components/modals/VictoryScreen.tsx
@@ -24,10 +24,20 @@ function VictoryScreen({ heroSheet, storyArc, onClose }: VictoryScreenProps) {
           {`You guided ${heroSheet.name}, ${heroSheet.occupation}, through ${storyArc.title}.`}
         </p>
 
-        <ul className="mt-4 list-inside list-disc text-left">
+        <ul className="mt-4 space-y-4 text-left">
           {storyArc.acts.map(act => (
             <li key={act.actNumber}>
-              {`Act ${String(act.actNumber)}: ${act.title} - ${act.mainObjective}`}
+              <p className="font-semibold">
+                {`Act ${String(act.actNumber)}: ${act.title}`}
+              </p>
+
+              <p className="italic">
+                {act.mainObjective}
+              </p>
+
+              <p className="mt-1">
+                {act.description}
+              </p>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- display an act intro modal with title and description at the start of each act
- show act titles, objectives, and descriptions on the victory screen

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa1b9a39a083248ceb08edd4ad5e25