### PR TITLE
feat: award score when advancing acts

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -55,6 +55,8 @@ export const MAIN_TURN_OPTIONS_COUNT = 6; // Number of action choices shown each
 export const FREE_FORM_ACTION_MAX_LENGTH = 70;
 export const FREE_FORM_ACTION_COST = 2;
 
+export const ACT_COMPLETION_SCORE = 5; // Score points awarded for completing an act
+
 export const ACTION_POINTS_PER_TURN = 3; // Points available each turn for item actions
 export const KNOWN_USE_ACTION_COST = 3;
 export const GENERIC_USE_ACTION_COST = 2;

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -29,6 +29,7 @@ import {
   PLAYER_HOLDER_ID,
   DISTILL_LORE_INTERVAL,
   RECENT_LOG_COUNT_FOR_DISTILL,
+  ACT_COMPLETION_SCORE,
 } from '../constants';
 
 import { structuredCloneGameState } from '../utils/cloneUtils';
@@ -548,6 +549,9 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     if (draftState.storyArc) {
       const arc = draftState.storyArc;
       arc.acts[arc.currentAct - 1].completed = true;
+
+      draftState.score += ACT_COMPLETION_SCORE;
+      turnChanges.scoreChangedBy += ACT_COMPLETION_SCORE;
 
       if (newAct) {
         arc.acts.push(newAct);


### PR DESCRIPTION
## Summary
- award players 5 score points when an act is completed
- add `ACT_COMPLETION_SCORE` constant for act completion reward

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68aa228ef6988324910c8221becec9a4