### PR TITLE
Pre-generate first turn during character overview

### DIFF
--- a/components/ActionOptions.tsx
+++ b/components/ActionOptions.tsx
@@ -14,7 +14,7 @@ import Button from './elements/Button';
 
 interface ActionOptionsProps {
   readonly options: Array<string>;
-  readonly onActionSelect: (action: string) => void;
+  readonly onActionSelect: (action: string) => void | Promise<void>;
   readonly disabled: boolean;
   readonly inventory: Array<Item>;
   readonly mapData: Array<MapNode>;
@@ -58,7 +58,7 @@ function ActionOptions({
   const executeQueuedOnly = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       queuedActions.forEach(a => a.effect?.());
-      onActionSelect(queuedPromptText);
+      void onActionSelect(queuedPromptText);
       onClearQueuedActions();
       event.currentTarget.blur();
     },
@@ -71,7 +71,7 @@ function ActionOptions({
         ? `${queuedPromptText}\n  - ${action}`
         : `  - ${action}`;
       queuedActions.forEach(a => a.effect?.());
-      onActionSelect(combined);
+      void onActionSelect(combined);
       onClearQueuedActions();
       event.currentTarget.blur();
     },

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -7,15 +7,24 @@ import { LOADING_REASON_UI_MAP } from '../constants';
 import { useLoadingProgress } from '../hooks/useLoadingProgress';
 import { useLoadingReason } from '../hooks/useLoadingReason';
 
+interface LoadingSpinnerProps {
+  readonly className?: string;
+  readonly showText?: boolean;
+  readonly size?: 'lg' | 'sm';
+}
+
 /**
- * Displays a spinner with a reason message while the game is busy.
+ * Displays a spinner with an optional reason message while the game is busy.
  */
-function LoadingSpinner() {
+function LoadingSpinner({ className = '', showText = true, size = 'lg' }: LoadingSpinnerProps) {
   const loadingReason = useLoadingReason();
   const { progress, retryCount } = useLoadingProgress();
-  const spinnerBaseClass = "rounded-full h-16 w-16 border-t-4 border-b-4";
+  const spinnerBaseClass =
+    size === 'sm'
+      ? 'rounded-full h-6 w-6 border-t-2 border-b-2'
+      : 'rounded-full h-16 w-16 border-t-4 border-b-4';
   const spinnerClass = `${spinnerBaseClass} animate-spin border-sky-600`;
-  const textColor = "text-sky-400";
+  const textColor = 'text-sky-400';
 
   const entry = loadingReason ? LOADING_REASON_UI_MAP[loadingReason] : undefined;
   const textMessage = entry?.text ?? 'Loading...';
@@ -26,10 +35,12 @@ function LoadingSpinner() {
 
   const retryDisplay = retryCount > 0 ? `Retry ${String(retryCount)}` : '';
 
+  const containerClass = showText ? 'flex flex-col items-center my-8' : '';
+
   return (
     <div
       aria-live="polite"
-      className="flex flex-col items-center my-8"
+      className={`${containerClass} ${className}`}
       role="status"
     >
       <div
@@ -37,23 +48,33 @@ function LoadingSpinner() {
         className={spinnerClass}
       />
 
-      <p className={`mt-2 text-xl ${textColor} text-shadow-md`}>
-        {textMessage}
-      </p>
+      {showText ? (
+        <>
+          <p className={`mt-2 text-xl ${textColor} text-shadow-md`}>
+            {textMessage}
+          </p>
 
-      {retryDisplay ? (
-        <p className={`text-sm ${textColor} text-shadow-md mt-1`}>
-          {retryDisplay}
-        </p>
-      ) : null}
+          {retryDisplay ? (
+            <p className={`mt-1 text-sm ${textColor} text-shadow-md`}>
+              {retryDisplay}
+            </p>
+          ) : null}
 
-      {progressDisplay ? (
-        <div className="mt-2 text-2xl text-sky-300 font-mono text-shadow-md">
-          {progressDisplay}
-        </div>
+          {progressDisplay ? (
+            <div className="mt-2 text-2xl text-sky-300 font-mono text-shadow-md">
+              {progressDisplay}
+            </div>
+          ) : null}
+        </>
       ) : null}
     </div>
   );
 }
 
 export default LoadingSpinner;
+
+LoadingSpinner.defaultProps = {
+  className: '',
+  showText: true,
+  size: 'lg',
+} as const;

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -300,6 +300,12 @@ function App() {
     }
   }, [isVictory]);
 
+  useEffect(() => {
+    if (lastTurnChanges?.mainQuestAchieved) {
+      void triggerMainQuestAchieved();
+    }
+  }, [lastTurnChanges?.mainQuestAchieved, triggerMainQuestAchieved]);
+
   const handleActContinue = useCallback(() => {
     setPendingAct(null);
   }, []);

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -275,6 +275,7 @@ function App() {
 
   const [pendingAct, setPendingAct] = useState<StoryAct | null>(null);
   const [lastShownAct, setLastShownAct] = useState(0);
+  const [isActTurnGenerating, setIsActTurnGenerating] = useState(false);
 
   const currentAct = storyArc?.currentAct ?? 0;
   const actsLength = storyArc?.acts.length ?? 0;
@@ -291,6 +292,15 @@ function App() {
       setLastShownAct(0);
     }
   }, [storyArc]);
+
+  useEffect(() => {
+    if (pendingAct && pendingAct.actNumber > 1) {
+      setIsActTurnGenerating(true);
+      void handleActionSelect('Look around.').finally(() => {
+        setIsActTurnGenerating(false);
+      });
+    }
+  }, [pendingAct, handleActionSelect]);
 
   const handleActContinue = useCallback(() => {
     setPendingAct(null);
@@ -966,6 +976,7 @@ function App() {
       {pendingAct ? (
         <ActIntroModal
           act={pendingAct}
+          isTurnGenerating={isActTurnGenerating}
           onContinue={handleActContinue}
         />
       ) : null}

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -275,10 +275,10 @@ function App() {
 
   const [pendingAct, setPendingAct] = useState<StoryAct | null>(null);
   const [lastShownAct, setLastShownAct] = useState(0);
-  const [isActTurnGenerating, setIsActTurnGenerating] = useState(false);
-
   const currentAct = storyArc?.currentAct ?? 0;
   const actsLength = storyArc?.acts.length ?? 0;
+
+  const isActTurnGenerating = pendingAct !== null && isLoading;
 
   useEffect(() => {
     if (storyArc && currentAct !== lastShownAct && actsLength > currentAct - 1) {
@@ -294,13 +294,16 @@ function App() {
   }, [storyArc]);
 
   useEffect(() => {
-    if (pendingAct && pendingAct.actNumber > 1) {
-      setIsActTurnGenerating(true);
-      void handleActionSelect('Look around.').finally(() => {
-        setIsActTurnGenerating(false);
-      });
+    if (pendingAct && pendingAct.actNumber > 1 && !isVictory) {
+      void handleActionSelect('Look around.');
     }
-  }, [pendingAct, handleActionSelect]);
+  }, [pendingAct, handleActionSelect, isVictory]);
+
+  useEffect(() => {
+    if (isVictory) {
+      setPendingAct(null);
+    }
+  }, [isVictory]);
 
   const handleActContinue = useCallback(() => {
     setPendingAct(null);

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -153,6 +153,7 @@ function App() {
     isCharacterSelectVisible,
     characterSelectData,
     submitCharacterSelectModal,
+    submitCharacterSelectHeroData,
     genderSelectDefault,
     submitDebugLoreModal,
     closeDebugLoreModal,
@@ -170,19 +171,22 @@ function App() {
   const closeGeminiKeyModal = useCallback(() => { setGeminiKeyVisible(false); }, []);
 
   const openCharacterSelect = useCallback(
-    (data: {
-      theme: AdventureTheme;
-      heroGender: string;
-      worldFacts: WorldFacts;
-      options: Array<CharacterOption>;
-    }) =>
-      new Promise<{
+    (
+      data: {
+        theme: AdventureTheme;
+        heroGender: string;
+        worldFacts: WorldFacts;
+        options: Array<CharacterOption>;
+      },
+      onHeroData: (result: {
         name: string;
         heroSheet: HeroSheet | null;
         heroBackstory: HeroBackstory | null;
         storyArc: StoryArc | null;
-      }>(resolve => {
-        openCharacterSelectModal(data, resolve);
+      }) => Promise<void>,
+    ) =>
+      new Promise<void>(resolve => {
+        openCharacterSelectModal(data, onHeroData, resolve);
       }),
     [openCharacterSelectModal],
   );
@@ -979,6 +983,7 @@ function App() {
           heroGender={characterSelectData.heroGender}
           isVisible={isCharacterSelectVisible}
           onComplete={submitCharacterSelectModal}
+          onHeroData={submitCharacterSelectHeroData}
           options={characterSelectData.options}
           theme={characterSelectData.theme}
           worldFacts={characterSelectData.worldFacts}

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -280,6 +280,12 @@ function App() {
 
   const isActTurnGenerating = pendingAct !== null && isLoading;
 
+  const handleActionSelectRef = useRef(handleActionSelect);
+
+  useEffect(() => {
+    handleActionSelectRef.current = handleActionSelect;
+  }, [handleActionSelect]);
+
   useEffect(() => {
     if (storyArc && currentAct !== lastShownAct && actsLength > currentAct - 1) {
       setPendingAct(storyArc.acts[currentAct - 1]);
@@ -295,9 +301,9 @@ function App() {
 
   useEffect(() => {
     if (pendingAct && pendingAct.actNumber > 1 && !isVictory) {
-      void handleActionSelect('Look around.');
+      void handleActionSelectRef.current('Look around.');
     }
-  }, [pendingAct, handleActionSelect, isVictory]);
+  }, [pendingAct, isVictory]);
 
   useEffect(() => {
     if (isVictory) {

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -4,7 +4,7 @@
  * @description Main application component wiring together UI and game logic.
  */
 
-import { useRef, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import * as React from 'react';
 import { useGameLogic } from '../../hooks/useGameLogic';
@@ -280,12 +280,6 @@ function App() {
 
   const isActTurnGenerating = pendingAct !== null && isLoading;
 
-  const handleActionSelectRef = useRef(handleActionSelect);
-
-  useEffect(() => {
-    handleActionSelectRef.current = handleActionSelect;
-  }, [handleActionSelect]);
-
   useEffect(() => {
     if (storyArc && currentAct !== lastShownAct && actsLength > currentAct - 1) {
       setPendingAct(storyArc.acts[currentAct - 1]);
@@ -299,11 +293,6 @@ function App() {
     }
   }, [storyArc]);
 
-  useEffect(() => {
-    if (pendingAct && pendingAct.actNumber > 1 && !isVictory) {
-      void handleActionSelectRef.current('Look around.');
-    }
-  }, [pendingAct, isVictory]);
 
   useEffect(() => {
     if (isVictory) {

--- a/components/modals/ActIntroModal.tsx
+++ b/components/modals/ActIntroModal.tsx
@@ -35,7 +35,6 @@ function ActIntroModal({ act, isTurnGenerating, onContinue }: ActIntroModalProps
         <div className="mt-8 flex items-center space-x-4 self-center">
           <Button
             ariaLabel="Continue"
-            disabled={isTurnGenerating}
             label="Continue"
             onClick={onContinue}
             preset="blue"

--- a/components/modals/ActIntroModal.tsx
+++ b/components/modals/ActIntroModal.tsx
@@ -1,12 +1,14 @@
 import Button from '../elements/Button';
+import LoadingSpinner from '../LoadingSpinner';
 import type { StoryAct } from '../../types';
 
 interface ActIntroModalProps {
   readonly act: StoryAct;
+  readonly isTurnGenerating: boolean;
   readonly onContinue: () => void;
 }
 
-function ActIntroModal({ act, onContinue }: ActIntroModalProps) {
+function ActIntroModal({ act, isTurnGenerating, onContinue }: ActIntroModalProps) {
   return (
     <div
       aria-labelledby="act-intro-heading"
@@ -30,14 +32,22 @@ function ActIntroModal({ act, onContinue }: ActIntroModalProps) {
           </section>
         </div>
 
-        <div className="mt-8 self-center">
+        <div className="mt-8 flex items-center space-x-4 self-center">
           <Button
             ariaLabel="Continue"
+            disabled={isTurnGenerating}
             label="Continue"
             onClick={onContinue}
             preset="blue"
             size="lg"
           />
+
+          {isTurnGenerating ? (
+            <LoadingSpinner
+              showText={false}
+              size="sm"
+            />
+          ) : null}
         </div>
       </div>
     </div>

--- a/hooks/useAppModals.ts
+++ b/hooks/useAppModals.ts
@@ -38,12 +38,15 @@ export const useAppModals = () => {
     options: Array<CharacterOption>;
   } | null>(null);
   const characterSelectResolveRef = useRef<(
+    () => void
+  ) | null>(null);
+  const characterSelectHeroDataRef = useRef<(
     (result: {
       name: string;
       heroSheet: HeroSheet | null;
       heroBackstory: HeroBackstory | null;
       storyArc: StoryArc | null;
-    }) => void
+    }) => Promise<void>
   ) | null>(null);
 
   const openVisualizer = useCallback(() => { setIsVisualizerVisible(true); }, []);
@@ -114,23 +117,37 @@ export const useAppModals = () => {
         worldFacts: WorldFacts;
         options: Array<CharacterOption>;
       },
-      resolve: (result: { name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null; storyArc: StoryArc | null }) => void,
+      onHeroData: (result: {
+        name: string;
+        heroSheet: HeroSheet | null;
+        heroBackstory: HeroBackstory | null;
+        storyArc: StoryArc | null;
+      }) => Promise<void>,
+      resolve: () => void,
     ) => {
       setCharacterSelectData(data);
+      characterSelectHeroDataRef.current = onHeroData;
       characterSelectResolveRef.current = resolve;
       setIsCharacterSelectVisible(true);
     },
     []
   );
 
-  const submitCharacterSelectModal = useCallback(
-    (result: { name: string; heroSheet: HeroSheet | null; heroBackstory: HeroBackstory | null; storyArc: StoryArc | null }) => {
-      characterSelectResolveRef.current?.(result);
-      setIsCharacterSelectVisible(false);
-      setCharacterSelectData(null);
-    },
-    []
+  const submitCharacterSelectHeroData = useCallback(
+    (result: {
+      name: string;
+      heroSheet: HeroSheet | null;
+      heroBackstory: HeroBackstory | null;
+      storyArc: StoryArc | null;
+    }) => characterSelectHeroDataRef.current?.(result) ?? Promise.resolve(),
+    [],
   );
+
+  const submitCharacterSelectModal = useCallback(() => {
+    characterSelectResolveRef.current?.();
+    setIsCharacterSelectVisible(false);
+    setCharacterSelectData(null);
+  }, []);
 
   return {
     // state
@@ -193,6 +210,7 @@ export const useAppModals = () => {
     submitGenderSelectModal,
     openCharacterSelectModal,
     submitCharacterSelectModal,
+    submitCharacterSelectHeroData,
   } as const;
 };
 

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -58,12 +58,13 @@ export interface UseGameLogicProps {
       worldFacts: WorldFacts;
       options: Array<CharacterOption>;
     },
-  ) => Promise<{
-    name: string;
-    heroSheet: HeroSheet | null;
-    heroBackstory: HeroBackstory | null;
-    storyArc: StoryArc | null;
-  }>;
+    onHeroData: (result: {
+      name: string;
+      heroSheet: HeroSheet | null;
+      heroBackstory: HeroBackstory | null;
+      storyArc: StoryArc | null;
+    }) => Promise<void>,
+  ) => Promise<void>;
   openGenderSelectModal: (defaultGender: string) => Promise<string>;
 }
 

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -389,7 +389,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
    * @param action - The action string chosen by the player.
    */
   const handleActionSelect = useCallback(
-    (action: string) => {
+    (action: string): Promise<void> => {
       const currentFullState = getCurrentGameState();
       let finalAction = action;
 
@@ -428,7 +428,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         }
       }
 
-      void executePlayerAction(finalAction);
+      return executePlayerAction(finalAction);
     }, [getCurrentGameState, executePlayerAction]);
 
   /**

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -559,6 +559,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         turnChanges.mainQuestAchieved = false;
       } else {
         draftState.isVictory = true;
+        turnChanges.mainQuestAchieved = false;
       }
     }
 

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -565,8 +565,13 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     draftState.globalTurnNumber += 1;
     draftState.lastTurnChanges = turnChanges;
     commitGameState(draftState);
+
+    if (!stateOverride && newAct) {
+      void handleActionSelect('Look around.');
+    }
+
     return draftState;
-  }, [getCurrentGameState, commitGameState]);
+  }, [getCurrentGameState, commitGameState, handleActionSelect]);
 
   /**
    * Sequentially completes all remaining acts to reach victory.

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -389,8 +389,8 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
    * @param action - The action string chosen by the player.
    */
   const handleActionSelect = useCallback(
-    (action: string): Promise<void> => {
-      const currentFullState = getCurrentGameState();
+    (action: string, stateOverride?: FullGameState): Promise<void> => {
+      const currentFullState = stateOverride ?? getCurrentGameState();
       let finalAction = action;
 
       const highlightMatcher = buildHighlightRegex(
@@ -428,7 +428,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
         }
       }
 
-      return executePlayerAction(finalAction);
+      return executePlayerAction(finalAction, false, currentFullState);
     }, [getCurrentGameState, executePlayerAction]);
 
   /**
@@ -567,7 +567,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
     commitGameState(draftState);
 
     if (!stateOverride && newAct) {
-      void handleActionSelect('Look around.');
+      void handleActionSelect('Look around.', draftState);
     }
 
     return draftState;

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -27,7 +27,6 @@ import { refineLore_Service } from '../services/loremaster';
 import { generatePageText } from '../services/page';
 import { formatKnownPlacesForPrompt, npcsToString } from '../utils/promptFormatters';
 import { rot13, toRunic, tornVisibleText } from '../utils/textTransforms';
-import { generateNextStoryAct } from '../services/worldData';
 import {
   findItemByIdentifier,
   findMapNodeByIdentifier,
@@ -767,30 +766,6 @@ export const useProcessAiResponse = ({
       }
 
       updateDialogueState(draftState, aiData, isFromDialogueSummary);
-
-      if (
-        turnChanges.mainQuestAchieved &&
-        draftState.storyArc &&
-        draftState.currentTheme &&
-        draftState.worldFacts &&
-        draftState.heroSheet
-      ) {
-        const newAct = await generateNextStoryAct(
-          draftState.currentTheme,
-          draftState.worldFacts,
-          draftState.heroSheet,
-          draftState.storyArc,
-          draftState.gameLog,
-          draftState.currentScene,
-        );
-        if (newAct) {
-          const arc = draftState.storyArc;
-          arc.acts[arc.currentAct - 1].completed = true;
-          arc.acts.push(newAct);
-          arc.currentAct = newAct.actNumber;
-          turnChanges.mainQuestAchieved = false;
-        }
-      }
 
       draftState.lastTurnChanges = turnChanges;
     },


### PR DESCRIPTION
## Summary
- Start generating the game's first turn while the player reviews their chosen character
- Character selection modal now emits hero data without closing to enable background work
- Show a small spinner beside the start button while the first turn finishes generating

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab2165279083248bd89716dcebdd83