### PR TITLE
Show turn during lore processing

### DIFF
--- a/components/MainToolbar.tsx
+++ b/components/MainToolbar.tsx
@@ -3,12 +3,14 @@
  * @file MainToolbar.tsx
  * @description Top-level toolbar with action buttons.
  */
-import { Icon } from './elements/icons';
 import Button from './elements/Button';
+import { Icon } from './elements/icons';
+import LoadingSpinner from './LoadingSpinner';
 
 interface MainToolbarProps {
   readonly score: number;
   readonly isLoading: boolean;
+  readonly isTurnProcessing: boolean;
   readonly currentThemeName: string | null;
   readonly currentSceneExists: boolean;
   readonly onOpenVisualizer: () => void;
@@ -23,6 +25,7 @@ interface MainToolbarProps {
 function MainToolbar({
   score,
   isLoading,
+  isTurnProcessing,
   currentThemeName,
   currentSceneExists,
   onOpenVisualizer,
@@ -52,6 +55,13 @@ function MainToolbar({
           </span>
         </div>
 
+        {isTurnProcessing ? (
+          <LoadingSpinner
+            showText={false}
+            size="sm"
+          />
+        ) : null}
+
         {/* Turns counter removed */}
       </div>
 
@@ -60,7 +70,7 @@ function MainToolbar({
       <div className="flex space-x-2">
         <Button
           ariaLabel="Visualize Scene"
-          disabled={isLoading || !currentThemeName || !currentSceneExists}
+          disabled={isLoading || isTurnProcessing || !currentThemeName || !currentSceneExists}
           icon={<Icon
             inline
             name="visualize"
@@ -75,7 +85,7 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open Knowledge Base"
-          disabled={isLoading || !currentThemeName}
+          disabled={isLoading || isTurnProcessing || !currentThemeName}
           icon={<Icon
             inline
             name="bookOpen"
@@ -91,7 +101,7 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open Map"
-          disabled={isLoading || !currentThemeName}
+          disabled={isLoading || isTurnProcessing || !currentThemeName}
           icon={<Icon
             inline
             name="map"
@@ -106,7 +116,7 @@ function MainToolbar({
 
         <Button
           ariaLabel="Open Title Menu"
-          disabled={isLoading}
+          disabled={isLoading || isTurnProcessing}
           icon={<Icon
             inline
             name="menu"

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -224,7 +224,15 @@ function App() {
   const {
     currentTheme,
     currentScene, mainQuest, currentObjective, actionOptions, storyArc, heroSheet,
-    inventory, itemsHere, itemPresenceByNode, gameLog, isLoading, error, lastActionLog, mapData,
+    inventory,
+    itemsHere,
+    itemPresenceByNode,
+    gameLog,
+    isLoading,
+    isTurnProcessing,
+    error,
+    lastActionLog,
+    mapData,
     currentMapNodeId, mapLayoutConfig,
     allNPCs,
     score, freeFormActionText, setFreeFormActionText,
@@ -278,7 +286,7 @@ function App() {
   const currentAct = storyArc?.currentAct ?? 0;
   const actsLength = storyArc?.acts.length ?? 0;
 
-  const isActTurnGenerating = pendingAct !== null && isLoading;
+  const isActTurnGenerating = pendingAct !== null && (isLoading || isTurnProcessing);
 
   useEffect(() => {
     if (storyArc && currentAct !== lastShownAct && actsLength > currentAct - 1) {
@@ -411,26 +419,47 @@ function App() {
   }, [currentScene, setVisualizerImageUrl, setVisualizerImageScene]);
 
   useAutosave({
-    gatherGameStateStack,
-    gatherDebugPacketStack,
-    isLoading,
-    hasGameBeenInitialized,
     appReady,
-    dialogueState,
-    setError: (msg) => { getGameLogic().setError(msg); },
     dependencies: [
-      currentTheme, currentScene, actionOptions, mainQuest, currentObjective,
-      inventory, gameLog, lastActionLog, mapData, currentMapNodeId,
-      mapLayoutConfig, allNPCs, score, localTime, localEnvironment, localPlace,
+      currentTheme,
+      currentScene,
+      actionOptions,
+      mainQuest,
+      currentObjective,
+      inventory,
+      gameLog,
+      lastActionLog,
+      mapData,
+      currentMapNodeId,
+      mapLayoutConfig,
+      allNPCs,
+      score,
+      localTime,
+      localEnvironment,
+      localPlace,
       enabledThemePacks,
-      debugLore, debugGoodFacts, debugBadFacts,
+      debugLore,
+      debugGoodFacts,
+      debugBadFacts,
     ],
+    dialogueState,
+    gatherDebugPacketStack,
+    gatherGameStateStack,
+    hasGameBeenInitialized,
+    isLoading,
+    isTurnProcessing,
+    setError: (msg) => { getGameLogic().setError(msg); },
   });
 
 
 
 
-  const canPerformFreeAction = score >= FREE_FORM_ACTION_COST && !isLoading && hasGameBeenInitialized && !dialogueState;
+  const canPerformFreeAction =
+    score >= FREE_FORM_ACTION_COST &&
+    !isLoading &&
+    !isTurnProcessing &&
+    hasGameBeenInitialized &&
+    !dialogueState;
 
 
   const enableMobileTap =
@@ -790,7 +819,8 @@ function App() {
             <MainToolbar
               currentSceneExists={!!currentScene}
               currentThemeName={currentTheme ? currentTheme.name : null}
-              isLoading={isLoading || !!dialogueState}
+              isLoading={isLoading || !!dialogueState || isTurnProcessing}
+              isTurnProcessing={isTurnProcessing}
               onOpenKnowledgeBase={openKnowledgeBase}
               onOpenMap={openMap}
               onOpenTitleMenu={openTitleMenu}
@@ -827,7 +857,7 @@ function App() {
 
                   <ActionOptions
                     allNPCs={allNPCs}
-                    disabled={isLoading || !!dialogueState}
+                    disabled={isLoading || isTurnProcessing || !!dialogueState}
                     inventory={inventory}
                     mapData={mapData.nodes}
                     onActionSelect={handleActionSelect}
@@ -853,7 +883,7 @@ function App() {
                 allNPCs={allNPCs}
                 currentMapNodeId={currentMapNodeId}
                 currentObjective={currentObjective}
-                disabled={isLoading || isAnyModalOrDialogueActive}
+                disabled={isLoading || isTurnProcessing || isAnyModalOrDialogueActive}
                 enableMobileTap={enableMobileTap}
                 globalTurnNumber={globalTurnNumber}
                 inventory={inventory}
@@ -873,7 +903,7 @@ function App() {
         </main>
 
         <ItemChangeAnimator
-          isGameBusy={isAnyModalOrDialogueActive || isLoading}
+          isGameBusy={isAnyModalOrDialogueActive || isLoading || isTurnProcessing}
           lastTurnChanges={lastTurnChanges}
         />
 

--- a/hooks/useAutosave.ts
+++ b/hooks/useAutosave.ts
@@ -13,24 +13,26 @@ import {
 export const AUTOSAVE_DEBOUNCE_TIME = 1500;
 
 export interface UseAutosaveOptions {
-  readonly gatherGameStateStack: () => GameStateStack;
-  readonly gatherDebugPacketStack: () => DebugPacketStack;
-  readonly isLoading: boolean;
-  readonly hasGameBeenInitialized: boolean;
   readonly appReady: boolean;
-  readonly dialogueState: unknown;
   readonly dependencies: Array<unknown>;
+  readonly dialogueState: unknown;
+  readonly gatherDebugPacketStack: () => DebugPacketStack;
+  readonly gatherGameStateStack: () => GameStateStack;
+  readonly hasGameBeenInitialized: boolean;
+  readonly isLoading: boolean;
+  readonly isTurnProcessing: boolean;
   readonly setError?: (msg: string | null) => void;
 }
 
 export function useAutosave({
-  gatherGameStateStack,
-  gatherDebugPacketStack,
-  isLoading,
-  hasGameBeenInitialized,
   appReady,
-  dialogueState,
   dependencies,
+  dialogueState,
+  gatherDebugPacketStack,
+  gatherGameStateStack,
+  hasGameBeenInitialized,
+  isLoading,
+  isTurnProcessing,
   setError,
 }: UseAutosaveOptions) {
   const autosaveTimeoutRef = useRef<number | null>(null);
@@ -38,7 +40,7 @@ export function useAutosave({
   const dependenciesKey = JSON.stringify(dependencies);
 
   useEffect(() => {
-    if (isLoading || !hasGameBeenInitialized || !appReady || !!dialogueState) {
+    if (isLoading || isTurnProcessing || !hasGameBeenInitialized || !appReady || !!dialogueState) {
       return;
     }
     if (autosaveTimeoutRef.current) {
@@ -72,6 +74,7 @@ export function useAutosave({
     appReady,
     dialogueState,
     dependenciesKey,
+    isTurnProcessing,
     setError,
   ]);
 }

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -86,6 +86,7 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     () => initialDebugStackFromApp ?? [null, null],
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isTurnProcessing, setIsTurnProcessing] = useState<boolean>(false);
   const loadingReason = useLoadingReason();
   const loadingReasonRef = useRef<LoadingReason | null>(loadingReason);
   const setLoadingReasonRef = useCallback((reason: LoadingReason | null) => {
@@ -190,12 +191,14 @@ export const useGameLogic = (props: UseGameLogicProps) => {
     commitGameState,
     setGameStateStack,
     setIsLoading,
+    setIsTurnProcessing,
     setLoadingReason: setLoadingReasonRef,
     setError,
     setParseErrorCounter,
     freeFormActionText,
     setFreeFormActionText,
     isLoading,
+    isTurnProcessing,
     hasGameBeenInitialized,
     loadingReasonRef,
     debugLore: currentSnapshot.debugLore,
@@ -559,6 +562,7 @@ const { isDialogueExiting, handleDialogueOptionSelect, handleForceExitDialogue }
     gameLog: currentFullState.gameLog,
     lastActionLog: currentFullState.lastActionLog,
     isLoading: isLoading || (currentFullState.dialogueState !== null && isDialogueExiting),
+    isTurnProcessing,
     loadingReason,
     error,
     allNPCs: currentFullState.allNPCs,

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -287,9 +287,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       );
 
       let draftState = structuredCloneGameState(currentFullState);
-      const willRunDistill =
-        (currentFullState.globalTurnNumber + 1) % DISTILL_LORE_INTERVAL === 0 &&
-        currentFullState.lastLoreDistillTurn !== currentFullState.globalTurnNumber + 1;
       const debugPacket = {
         prompt,
         systemInstruction: SYSTEM_INSTRUCTION,
@@ -355,7 +352,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           scoreChangeFromAction,
           setIsLoading,
           setIsTurnProcessing,
-          shouldRunDistill: willRunDistill,
         });
       } catch (e: unknown) {
         encounteredError = true;
@@ -382,9 +378,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       } finally {
         if (!encounteredError) {
           draftState.globalTurnNumber += 1;
-          if (willRunDistill) {
-            await runDistillIfNeeded(draftState);
-          }
+          await runDistillIfNeeded(draftState);
         }
         commitGameState(draftState);
         setIsTurnProcessing(false);

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -287,6 +287,9 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       );
 
       let draftState = structuredCloneGameState(currentFullState);
+      const willRunDistill =
+        (currentFullState.globalTurnNumber + 1) % DISTILL_LORE_INTERVAL === 0 &&
+        currentFullState.lastLoreDistillTurn !== currentFullState.globalTurnNumber + 1;
       const debugPacket = {
         prompt,
         systemInstruction: SYSTEM_INSTRUCTION,
@@ -352,6 +355,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           scoreChangeFromAction,
           setIsLoading,
           setIsTurnProcessing,
+          shouldRunDistill: willRunDistill,
         });
       } catch (e: unknown) {
         encounteredError = true;
@@ -378,7 +382,9 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
       } finally {
         if (!encounteredError) {
           draftState.globalTurnNumber += 1;
-          await runDistillIfNeeded(draftState);
+          if (willRunDistill) {
+            await runDistillIfNeeded(draftState);
+          }
         }
         commitGameState(draftState);
         setIsTurnProcessing(false);

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -355,7 +355,6 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           scoreChangeFromAction,
           setIsLoading,
           setIsTurnProcessing,
-          shouldRunDistill: willRunDistill,
         });
       } catch (e: unknown) {
         encounteredError = true;

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -355,6 +355,7 @@ export const usePlayerActions = (props: UsePlayerActionsProps) => {
           scoreChangeFromAction,
           setIsLoading,
           setIsTurnProcessing,
+          shouldRunDistill: willRunDistill,
         });
       } catch (e: unknown) {
         encounteredError = true;

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -415,6 +415,7 @@ export interface ProcessAiResponseOptions {
   scoreChangeFromAction?: number;
   setIsLoading?: (val: boolean) => void;
   setIsTurnProcessing?: (val: boolean) => void;
+  shouldRunDistill?: boolean;
 }
 
 export type ProcessAiResponseFn = (
@@ -771,6 +772,10 @@ export const useProcessAiResponse = ({
           );
         }
         setLoadingReason(original);
+      }
+
+      if (options.shouldRunDistill === false) {
+        options.setIsTurnProcessing?.(false);
       }
 
       updateDialogueState(draftState, aiData, isFromDialogueSummary);

--- a/hooks/useProcessAiResponse.ts
+++ b/hooks/useProcessAiResponse.ts
@@ -415,7 +415,6 @@ export interface ProcessAiResponseOptions {
   scoreChangeFromAction?: number;
   setIsLoading?: (val: boolean) => void;
   setIsTurnProcessing?: (val: boolean) => void;
-  shouldRunDistill?: boolean;
 }
 
 export type ProcessAiResponseFn = (
@@ -772,10 +771,6 @@ export const useProcessAiResponse = ({
           );
         }
         setLoadingReason(original);
-      }
-
-      if (options.shouldRunDistill === false) {
-        options.setIsTurnProcessing?.(false);
       }
 
       updateDialogueState(draftState, aiData, isFromDialogueSummary);


### PR DESCRIPTION
## Summary
- display new turn immediately while Loremaster finishes lore extraction and refinement
- add background processing flag to disable actions and show small spinner in toolbar
- pause autosave during lore processing

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3c9b01788324beee6d49ecfe17d1