### PR TITLE
fix: show act intro only on new act

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -296,10 +296,10 @@ function App() {
   }, [storyArc, currentAct, actsLength, lastShownAct]);
 
   useEffect(() => {
-    if (storyArc?.currentAct === 1) {
+    if (storyArc?.currentAct === 1 && lastShownAct !== 0) {
       setLastShownAct(0);
     }
-  }, [storyArc]);
+  }, [storyArc?.currentAct, lastShownAct]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid resetting last shown act on every story update so ActIntroModal only appears when act changes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6c230b088324b94805e51fbac9ba