### PR TITLE
fix: correct book, map, and trash icons

### DIFF
--- a/components/elements/icons/BookOpen.tsx
+++ b/components/elements/icons/BookOpen.tsx
@@ -1,19 +1,24 @@
-import type { SVGProps } from "react";
+import type { SVGProps } from 'react';
+
 function SvgBookOpen({ height = '1em', width = '1em' }: SVGProps<SVGSVGElement>) {
-  return (<svg
-    fill="none"
-    height={height}
-    stroke="currentColor"
-    strokeWidth={1.5}
-    viewBox="0 0 24 24"
-    width={width}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M12 6.042A8.97 8.97 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A9 9 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.97 8.97 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A9 9 0 0 0 18 18a8.97 8.97 0 0 0-6-2.292m0 0V3.75m0 16.5V18"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>)
+  return (
+    <svg
+      fill="none"
+      height={height}
+      stroke="currentColor"
+      strokeWidth={1.5}
+      viewBox="0 0 24 24"
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
 }
+
 export default SvgBookOpen;
+

--- a/components/elements/icons/Map.tsx
+++ b/components/elements/icons/Map.tsx
@@ -1,29 +1,24 @@
-import type { SVGProps } from "react";
+import type { SVGProps } from 'react';
+
 function SvgMap({ height = '1em', width = '1em' }: SVGProps<SVGSVGElement>) {
-  return (<svg
-    fill="none"
-    height={height}
-    viewBox="0 0 24 24"
-    width={width}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M3 20V5l6-2v15zM9 18V3l6 2v15zM15 20V5l6 2v15z"
+  return (
+    <svg
+      fill="none"
+      height={height}
       stroke="currentColor"
-      strokeWidth={1.2}
-    />
-
-    <path
-      d="M9 3v15M15 5v15"
-      stroke="#b6c2d1"
-      strokeWidth={0.8}
-    />
-
-    <path
-      d="M3 20V5l6-2 6 2 6 2v15l-6-2-6-2-6 2"
-      stroke="currentColor"
-      strokeWidth={1.2}
-    />
-  </svg>)
+      strokeWidth={1.5}
+      viewBox="0 0 24 24"
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
 }
+
 export default SvgMap;
+

--- a/components/elements/icons/Trash.tsx
+++ b/components/elements/icons/Trash.tsx
@@ -1,19 +1,24 @@
-import type { SVGProps } from "react";
+import type { SVGProps } from 'react';
+
 function SvgTrash({ height = '1em', width = '1em' }: SVGProps<SVGSVGElement>) {
-  return (<svg
-    fill="none"
-    height={height}
-    stroke="currentColor"
-    strokeWidth={1.5}
-    viewBox="0 0 24 24"
-    width={width}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21q.512.078 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48 48 0 0 0-3.478-.397m-12.56 0c1.153 0 2.243.032 3.223.094M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>)
+  return (
+    <svg
+      fill="none"
+      height={height}
+      stroke="currentColor"
+      strokeWidth={1.5}
+      viewBox="0 0 24 24"
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
 }
+
 export default SvgTrash;
+


### PR DESCRIPTION
## Summary
- fix bookOpen icon path
- replace map icon with simplified version
- correct trash icon path

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c56541e40c8324b855ccb0d1e622c9